### PR TITLE
feat(graphics): add support for custom color palettes

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -507,6 +507,11 @@ Enumeration of available color palettes.
     Sets the active color palette for the engine.
     *Note: This should typically be called once during game initialization (e.g., in the first Scene's `init()` method). Only one palette can be active at a time.*
 
+- **`static void setCustomPalette(const uint16_t* palette)`**
+    Sets a custom color palette defined by the user.
+  - **palette**: Pointer to an array of 16 `uint16_t` values (RGB565).
+  - **Warning**: The array must remain valid for the duration of its use (e.g., use `static const` or global arrays). The engine does not copy the data.
+
 - **`static uint16_t resolveColor(Color color)`**
     Converts a `Color` enum value to its corresponding RGB565 `uint16_t` representation based on the currently active palette.
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,45 @@ void MyScene::init() {
 
 > **Note:** Only one palette can be active globally. When switching scenes, it is good practice to explicitly set the desired palette in `init()`.
 
+### Custom Color Palette
+
+You can also define your own custom palette. This is useful for giving your game a unique look while respecting the 16-color limit.
+
+**How to define and use a custom palette:**
+
+1. Define a `static const` array of 16 `uint16_t` values (RGB565 format).
+2. Pass it to `pr32::graphics::setCustomPalette(...)`.
+
+```cpp
+#include <graphics/Color.h>
+
+// Define your custom 16-color palette (RGB565)
+// Values must be ordered to match the Color enum indices (Black=0, White=1, etc.)
+// if you want to keep compatibility with standard Color names.
+static const uint16_t MY_SEPIA_PALETTE[16] = {
+    0x0000, // 0: Black
+    0xE79C, // 1: White (Sepia tone)
+    0x3186, // 2: Navy
+    0x52AA, // 3: Blue
+    // ... define all 16 colors ...
+    0xCE79  // 15: Gray
+};
+
+void MyScene::init() {
+    // Apply the custom palette
+    pr32::graphics::setCustomPalette(MY_SEPIA_PALETTE);
+}
+```
+
+> **Warning:** The array passed to `setCustomPalette` **must remain valid** while it is active. Always use `static const` arrays or global variables. Do not pass a local stack array.
+
 ### Technical Implementation
 
 The palette system is designed for **zero-overhead switching**, critical for the limited resources of the ESP32:
 
-1.  **Flash Storage**: All palettes are stored as `static constexpr` arrays in flash memory (RODATA), consuming no dynamic RAM.
-2.  **Pointer-Based Switching**: The engine maintains a single global pointer `currentPalette` that points to the active array. Calling `setPalette()` merely updates this pointer, making the operation instantaneous (**O(1)**).
-3.  **Dynamic Resolution**: The `resolveColor(Color c)` function uses the enum value as a direct index into the array referenced by `currentPalette`. This ensures that all rendering calls automatically use the new colors without needing to redraw or reload assets.
+1. **Flash Storage**: All palettes are stored as `static constexpr` arrays in flash memory (RODATA), consuming no dynamic RAM.
+2. **Pointer-Based Switching**: The engine maintains a single global pointer `currentPalette` that points to the active array. Calling `setPalette()` merely updates this pointer, making the operation instantaneous (**O(1)**).
+3. **Dynamic Resolution**: The `resolveColor(Color c)` function uses the enum value as a direct index into the array referenced by `currentPalette`. This ensures that all rendering calls automatically use the new colors without needing to redraw or reload assets.
 
 Sprites are defined as compact 1bpp bitmaps by default:
 

--- a/include/graphics/Color.h
+++ b/include/graphics/Color.h
@@ -67,6 +67,13 @@ enum class Color : uint8_t {
  */
 void setPalette(PaletteType palette);
 
+/**
+ * @brief Sets a custom color palette.
+ * @param palette Pointer to an array of 16 uint16_t RGB565 color values.
+ *                The array must remain valid (e.g., static or global) as the engine does not copy it.
+ */
+void setCustomPalette(const uint16_t* palette);
+
 // Removed static constexpr ENGINE_PALETTE to support dynamic switching.
 
 

--- a/src/graphics/Color.cpp
+++ b/src/graphics/Color.cpp
@@ -21,6 +21,12 @@ void setPalette(PaletteType palette) {
     }
 }
 
+void setCustomPalette(const uint16_t* palette) {
+    if (palette != nullptr) {
+        currentPalette = palette;
+    }
+}
+
 /**
  * @brief Resolves a Color enum to its corresponding 16-bit color value.
  * @param color The Color enum value.


### PR DESCRIPTION
Add setCustomPalette function to allow users to define their own 16-color palettes in RGB565 format. The palette array must remain valid as the engine references it directly for performance. Documentation includes usage examples and warnings.