### PR TITLE
feat(graphics): enhance color handling and palette management

### DIFF
--- a/include/graphics/Color.h
+++ b/include/graphics/Color.h
@@ -15,6 +15,8 @@ enum class PaletteType {
     PR32
 };
 
+static constexpr uint8_t PALETTE_SIZE = 16;
+
 // Default palette is PR32.
 // The Color enum is mapped to the PR32 palette indices (0-15).
 // Some legacy colors are aliased to the nearest available color in the 16-color palette.
@@ -53,13 +55,27 @@ enum class Color : uint8_t {
     Silver = Gray,
 
     // Special
-    Transparent = 0, // Treated as Black or handled by renderer logic
+
+    // Color::Transparent is not a real color.
+    // It must be handled by the renderer/blitter and must never be resolved.
+    // Using it in drawing primitives results in a no-op.
+    Transparent = 255,
     DebugRed = Red,
     DebugGreen = Green,
-    DebugBlue = Blue,
-
-    COUNT = 16
+    DebugBlue = Blue
 };
+
+
+// -----------------------------------------------------------------------------
+// Palette system
+// -----------------------------------------------------------------------------
+//
+// Only one palette can be active at a time.
+// All Color values are resolved against the currently active palette.
+//
+// Switching the active palette affects all subsequent draw calls.
+// Custom palettes are not copied; the provided palette pointer must remain valid.
+//
 
 /**
  * @brief Selects the active color palette.
@@ -74,9 +90,10 @@ void setPalette(PaletteType palette);
  */
 void setCustomPalette(const uint16_t* palette);
 
-// Removed static constexpr ENGINE_PALETTE to support dynamic switching.
-
-
+/**
+ * @brief Resolves a Color enum to its corresponding 16-bit color value.
+ * @note Color::Transparent is not a real color and must not be resolved.
+ */
 uint16_t resolveColor(Color color);
 
 }

--- a/src/graphics/Color.cpp
+++ b/src/graphics/Color.cpp
@@ -7,20 +7,46 @@
 
 namespace pixelroot32::graphics {
 
+struct PaletteEntry {
+    PaletteType type;
+    const uint16_t* colors;
+};
+
+static constexpr PaletteEntry kPalettes[] = {
+    { PaletteType::NES,   PALETTE_NES   },
+    { PaletteType::GB,    PALETTE_GB    },
+    { PaletteType::GBC,   PALETTE_GBC   },
+    { PaletteType::PICO8, PALETTE_PICO8 },
+    { PaletteType::PR32,  PALETTE_PR32  },
+};
+
+
 // Current active palette pointer. Defaults to PR32.
 static const uint16_t* currentPalette = PALETTE_PR32;
 
+/** 
+ * @brief Set palette.
+ * @param palette type of palette.
+ * 
+*/
 void setPalette(PaletteType palette) {
-    switch (palette) {
-        case PaletteType::NES: currentPalette = PALETTE_NES; break;
-        case PaletteType::GB: currentPalette = PALETTE_GB; break;
-        case PaletteType::GBC: currentPalette = PALETTE_GBC; break;
-        case PaletteType::PICO8: currentPalette = PALETTE_PICO8; break;
-        case PaletteType::PR32: currentPalette = PALETTE_PR32; break;
-        default: currentPalette = PALETTE_PR32; break;
+    for (const auto& entry : kPalettes) {
+        if (entry.type == palette) {
+            currentPalette = entry.colors;
+            return;
+        }
     }
+    currentPalette = PALETTE_PR32; // fallback
 }
 
+/** 
+ * @brief Set custom palette.
+ * @param palette array colors.
+ * 
+ * Note:
+ * The engine does NOT copy the palette.
+ * The palette pointer must remain valid for the entire usage period.
+*/
 void setCustomPalette(const uint16_t* palette) {
     if (palette != nullptr) {
         currentPalette = palette;
@@ -34,9 +60,12 @@ void setCustomPalette(const uint16_t* palette) {
  */
 uint16_t resolveColor(Color color) {
     uint8_t idx = static_cast<uint8_t>(color);
-    if (idx >= static_cast<uint8_t>(Color::COUNT)) {
-        return 0xFFFF; // fallback white
+
+    // Color::Transparent must be handled by the renderer, not here
+    if (idx >= PALETTE_SIZE) {
+        return 0; // value is irrelevant, should never be drawn
     }
+
     return currentPalette[idx];
 }
 

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -22,6 +22,10 @@
 
 namespace pixelroot32::graphics {
 
+    inline bool isDrawable(Color c) {
+        return c != Color::Transparent;
+    }
+
     Renderer::Renderer(const DisplayConfig& config) : config(config) {        
         drawer = config.drawSurface;
         xOffset = config.xOffset;
@@ -44,26 +48,32 @@ namespace pixelroot32::graphics {
     }
 
     void Renderer::drawText(const char* text, int16_t x, int16_t y, Color color, uint8_t size) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawText(text, x, y, resolveColor(color), size);
     }
 
     void Renderer::drawTextCentered(const char* text, int16_t y, Color color, uint8_t size) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawTextCentered(text, y, resolveColor(color), size);
     }
 
     void Renderer::drawFilledCircle(int x, int y, int radius, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawFilledCircle(xOffset + x, yOffset + y, radius, resolveColor(color));
     }
 
     void Renderer::drawCircle(int x, int y, int radius, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawCircle(xOffset + x, yOffset + y, radius, resolveColor(color));
     }
 
     void Renderer::drawRectangle(int x, int y, int width, int height, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawRectangle(xOffset + x, yOffset + y, width, height, resolveColor(color));
     }
 
     void Renderer::drawFilledRectangle(int x, int y, int width, int height, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawFilledRectangle(xOffset + x, yOffset + y, width, height, resolveColor(color));
     }
 
@@ -72,6 +82,7 @@ namespace pixelroot32::graphics {
     }
 
     void Renderer::drawLine(int x1, int y1, int x2, int y2, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawLine(xOffset + x1, yOffset + y1, xOffset + x2, yOffset + y2, resolveColor(color));
     }
 
@@ -82,10 +93,12 @@ namespace pixelroot32::graphics {
 
     //draw an image to the screen in an bitmap format
     void Renderer::drawBitmap(int x, int y, int width, int height, const uint8_t *bitmap, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawBitmap(xOffset + x, yOffset + y, width, height, bitmap, resolveColor(color));
     }
 
     void Renderer::drawPixel(int x, int y, Color color) {
+        if (!isDrawable(color)) return;
         getDrawSurface().drawPixel(x, y, resolveColor(color));
     }
 


### PR DESCRIPTION
- Introduced a static constexpr PALETTE_SIZE for better palette size management.
- Updated Color enum to redefine Transparent as 255, ensuring it is handled correctly by the renderer.
- Implemented a PaletteEntry struct for cleaner palette management and streamlined the setPalette function to utilize an array of palette entries.
- Added isDrawable function to check if a color can be drawn, preventing unnecessary draw calls for Transparent colors.
- Enhanced documentation for color resolution and palette management functions.