### PR TITLE
refactor(graphics/ui): use FontManager for accurate text dimensions

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -727,6 +727,10 @@ Specific layout implementations that organize elements in a row or column. Both 
     Sets the visible area dimensions for scrolling calculations.
 - **`float getScrollOffset() const`**
     Returns the current scroll position in pixels.
+- **`void setNavigationButtons(uint8_t upButton, uint8_t downButton)`**
+    Sets the button indices used for layout navigation (e.g., UP/DOWN for vertical, LEFT/RIGHT for horizontal).
+- **`void setButtonStyle(Color selectedTextCol, Color selectedBgCol, Color unselectedTextCol, Color unselectedBgCol)`**
+    Sets the colors used for child buttons when they are selected or unselected.
 
 ---
 
@@ -1298,10 +1302,10 @@ A simple text label UI element.
     - **sz**: Text size multiplier.
 
 - **`void setText(const std::string& t)`**
-    Updates the label's text. Recalculates dimensions automatically.
+    Updates the label's text. Recalculates dimensions immediately using the current font metrics.
 
 - **`void centerX(int screenWidth)`**
-    Centers the label horizontally.
+    Centers the label horizontally within the specified width. Recalculates dimensions before positioning to ensure precision.
 
 ---
 

--- a/include/graphics/ui/UILabel.h
+++ b/include/graphics/ui/UILabel.h
@@ -53,14 +53,10 @@ private:
     std::string text;
     Color color;
     uint8_t size;
-    bool dirty = false;
 
     /**
         * @brief Recalculates width and height based on current text and font size.
         */
-    inline void recalcSize() {
-        this->width  = (float)(text.length() * (6 * size));
-        this->height = (float)(8 * size);
-    }
+    void recalcSize();
 };
 }

--- a/src/graphics/ui/UIButton.cpp
+++ b/src/graphics/ui/UIButton.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License
  */
 #include "graphics/ui/UIButton.h"
+#include "graphics/FontManager.h"
 
 namespace pixelroot32::graphics::ui {
 
@@ -93,8 +94,8 @@ namespace pixelroot32::graphics::ui {
         Color currentTextCol = (isSelected && !hasBackground) ? Color::Yellow : textColor;
 
         if (textAlign == TextAlignment::CENTER) {
-            // Calculate text width manually (assuming default font 5x7 + 1 spacing = 6px per char)
-            int textWidth = static_cast<int>(label.length()) * (6 * fontSize);
+            // Calculate text width using FontManager
+            int textWidth = FontManager::textWidth(nullptr, label.c_str(), fontSize);
             int textX = static_cast<int>(x) + (static_cast<int>(width) - textWidth) / 2;
             renderer.drawText(label.c_str(), textX, textY, currentTextCol, fontSize);
         } else if (textAlign == TextAlignment::RIGHT) {

--- a/src/graphics/ui/UILabel.cpp
+++ b/src/graphics/ui/UILabel.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License
  */
 #include "graphics/ui/UILabel.h"
+#include "graphics/FontManager.h"
 
 namespace pixelroot32::graphics::ui {
 
@@ -19,24 +20,32 @@ namespace pixelroot32::graphics::ui {
     void UILabel::setText(const std::string& newText) {
         if (text == newText) return;
         text = newText;
-        dirty = true;
+        recalcSize();
     }
 
     void UILabel::centerX(int screenWidth) {
+        recalcSize();
         this->x = (screenWidth - width) * 0.5f;
     }
 
     void UILabel::update(unsigned long deltaTime) {
         (void)deltaTime;
-
-        if (dirty) {
-            recalcSize();
-            dirty = false;
-        }
     }
 
     void UILabel::draw(Renderer& renderer) {
         if (!isVisible) return;
         renderer.drawText(text.c_str(), x, y, color, size);
     }
-}
+
+    void UILabel::recalcSize() {
+        const Font* font = FontManager::getDefaultFont();
+        if (font) {
+            this->width = (float)FontManager::textWidth(font, text.c_str(), size);
+            this->height = (float)(font->glyphHeight * size);
+        } else {
+            // Fallback if no font is set (6x8 default)
+            this->width = (float)(text.length() * (6 * size));
+            this->height = (float)(8 * size);
+        }
+    }
+} // namespace pixelroot32::graphics::ui


### PR DESCRIPTION
- Replace manual width calculation in UILabel and UIButton with FontManager::textWidth
- Remove dirty flag and immediate recalc in UILabel::setText and centerX
- Update API documentation to reflect new behavior
- Add fallback to default calculation when no font is available