### PR TITLE
Release v0.4.1 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Watch PixelRoot32 running on ESP32 with example games:
 - **Basic Gravity and Kinematics**: Suitable for arcade and simple platformer games
 
 ### 🖥️ User Interface
-- **Lightweight UI System**: UI controls (Label, Button) with automatic layout management
+- **Lightweight UI System**: UI controls (Label, CheckBox, Button) with automatic layout management
 - **Automatic Layouts**: `UIVerticalLayout`, `UIHorizontalLayout`, `UIGridLayout`, `UIPaddingContainer`, `UIPanel`, and `UIAnchorLayout` for organizing elements without manual calculations
 - **Native Bitmap Font**: Text renderer based on 1bpp sprites with an integrated 5x7 font, ensuring pixel-perfect consistency across PC and ESP32
 
@@ -383,6 +383,19 @@ See the [official documentation](https://pixelroot32-game-engine.github.io/tools
 
 ## Changelog
 
+### v0.4.0-dev
+
+- **UI CheckBox Support**: Introduced the `UICheckBox` element for toggleable states.
+  - Added new `UICheckBox` class with checked state management and callback support (`onCheckChanged`).
+  - Extended `UIElementType` enum to include the `CHECKBOX` type.
+  - Updated all layout containers (`UIGridLayout`, `UIVerticalLayout`, `UIHorizontalLayout`) to support checkbox elements.
+- **Improved UI Text Precision**: Refactored `UILabel` and `UIButton` to use `FontManager` for pixel-perfect text dimensions.
+  - Replaced manual width calculations with `FontManager::textWidth`.
+  - Optimized `UILabel` by removing the dirty flag and implementing immediate dimension recalculation in `setText` and `centerX`.
+  - Added a safety fallback to default calculations when no custom font is loaded.
+- **Input & Stability**: Fixed button `stateChanged` reset logic in `InputManager` to prevent stale input states from affecting UI interactions.
+- **Documentation**: Updated API reference and user manuals to include `UICheckBox` usage and reflect the latest UI behavior.
+
 ### v0.3.0-dev
 
 - **Renderer Fix**: Fixed 2bpp/4bpp sprite clipping when camera offset is applied. Clipping now uses finalX/finalY with xOffset/yOffset, preventing the player from disappearing past the viewport width.
@@ -404,7 +417,7 @@ See the [official documentation](https://pixelroot32-game-engine.github.io/tools
 - **Architecture**: Moved `DrawSurface` implementation handling to the engine core. This removes the need for manual developer implementation and facilitates the integration of future display drivers.
 - **Driver Support**: Clarified driver support status (TFT_eSPI & SDL2) and roadmap.
 
-### v0.1.0-dev (Release)
+### v0.1.0-dev
 
 - **Initial Public Preview.**
 - **Core Architecture**: Scene, Entity, Actor, and PhysicsActor system.

--- a/include/graphics/PaletteDefs.h
+++ b/include/graphics/PaletteDefs.h
@@ -8,98 +8,98 @@
 namespace pixelroot32::graphics {
 
 static constexpr uint16_t PALETTE_NES[] = {
-    0x0000, // #000000
-    0x216A, // #1D2B53
-    0x792A, // #7E2553
-    0xAA87, // #AB5236
-    0x62AA, // #5F574F
-    0xC618, // #C2C3C7
-    0xFF9C, // #FFF1E8
-    0xF809, // #FF004D
-    0xFD00, // #FFA300
-    0xFF45, // #FFEC27
-    0x0707, // #00E436
-    0x2D7F, // #29ADFF
-    0x83B3, // #83769C
-    0xFBB4, // #FF77A8
-    0xFE55, // #FFCCAA
-    0x042A, // #008751
+    0x0000, // #000000 (Black)
+    0xFF9C, // #FFF1E8 (White)
+    0x216A, // #1D2B53 (Navy)
+    0x2D7F, // #29ADFF (Blue)
+    0xFE55, // #FFCCAA (Cyan/Skin)
+    0x042A, // #008751 (DarkGreen)
+    0x0707, // #00E436 (Green)
+    0xFF45, // #FFEC27 (LightGreen/Yellowish)
+    0xFD00, // #FFA300 (Yellow)
+    0xAA87, // #AB5236 (Orange)
+    0xFBB4, // #FF77A8 (LightRed/Pink)
+    0xF809, // #FF004D (Red)
+    0x792A, // #7E2553 (DarkRed/Maroon)
+    0x83B3, // #83769C (Purple)
+    0x62AA, // #5F574F (Magenta/DarkGray)
+    0xC618, // #C2C3C7 (Gray)
 };
 
 static constexpr uint16_t PALETTE_GB[] = {
-    0x11C2, // #0F380F
-    0x1A63, // #1B4D1B
-    0x3306, // #306230
-    0x53E8, // #4F7F3F
-    0x6C69, // #6B8F4E
-    0x8D42, // #8BAC0F
-    0x9DC2, // #9BBC0F
-    0xB64D, // #B6C96A
-    0xCF34, // #CFE5A5
-    0xDF78, // #DDEFC7
-    0xE7BB, // #E8F7DC
-    0xF7FD, // #F4FFEB
-    0x42E5, // #3E5F2A
-    0x5BE7, // #5C7F3A
-    0x7D6B, // #7FAE5C
-    0xAE71, // #AFCF8F
+    0x11C2, // #0F380F (Black)
+    0xF7FD, // #F4FFEB (White)
+    0x42E5, // #3E5F2A (Navy/DarkerGreen)
+    0x5BE7, // #5C7F3A (Blue/DarkerGreen)
+    0xAE71, // #AFCF8F (Cyan/LightGreen)
+    0x1A63, // #1B4D1B (DarkGreen)
+    0x3306, // #306230 (Green)
+    0x53E8, // #4F7F3F (LightGreen)
+    0x9DC2, // #9BBC0F (Yellow/Green)
+    0xB64D, // #B6C96A (Orange/LightGreen)
+    0xDF78, // #DDEFC7 (LightRed/VeryLightGreen)
+    0x8D42, // #8BAC0F (Red/Green)
+    0x6C69, // #6B8F4E (DarkRed/Green)
+    0x7D6B, // #7FAE5C (Purple/Green)
+    0xE7BB, // #E8F7DC (Magenta/AlmostWhite)
+    0xCF34, // #CFE5A5 (Gray/LightGreen)
 };
 
 static constexpr uint16_t PALETTE_GBC[] = {
-    0x08C4, // #081820
-    0xF7BE, // #F8F8F8
-    0x334A, // #346856
-    0x8DEE, // #88C070
-    0xDFB9, // #E0F8D0
-    0x21DD, // #2038EC
-    0x5D5E, // #58A8F8
-    0x18CF, // #181878
-    0x7B5D, // #7B68EE
-    0xA986, // #B03030
-    0xE28A, // #E85050
-    0xF5B6, // #F8B8B8
-    0xD480, // #D89000
-    0xF6E6, // #F8E030
-    0x9D13, // #A0A0A0
-    0x0000, // #000000
+    0x0000, // #000000 (Black)
+    0xF7BE, // #F8F8F8 (White)
+    0x18CF, // #181878 (Navy)
+    0x21DD, // #2038EC (Blue)
+    0x5D5E, // #58A8F8 (Cyan)
+    0x08C4, // #081820 (DarkGreen/VeryDark)
+    0x334A, // #346856 (Green)
+    0x8DEE, // #88C070 (LightGreen)
+    0xF6E6, // #F8E030 (Yellow)
+    0xD480, // #D89000 (Orange)
+    0xF5B6, // #F8B8B8 (LightRed)
+    0xA986, // #B03030 (Red)
+    0xE28A, // #E85050 (DarkRed/LightRed)
+    0x7B5D, // #7B68EE (Purple)
+    0xDFB9, // #E0F8D0 (Magenta/LightGreen)
+    0x9D13, // #A0A0A0 (Gray)
 };
 
 static constexpr uint16_t PALETTE_PICO8[] = {
-    0x0000, // #000000
-    0x216A, // #1D2B53
-    0x792A, // #7E2553
-    0x042A, // #008751
-    0xAA87, // #AB5236
-    0x62AA, // #5F574F
-    0xC618, // #C2C3C7
-    0xFF9C, // #FFF1E8
-    0xF809, // #FF004D
-    0xFD00, // #FFA300
-    0xFF45, // #FFEC27
-    0x0707, // #00E436
-    0x2D7F, // #29ADFF
-    0x83B3, // #83769C
-    0xFBB4, // #FF77A8
-    0xFE55, // #FFCCAA
+    0x0000, // #000000 (Black)
+    0xFF9C, // #FFF1E8 (White)
+    0x216A, // #1D2B53 (Navy)
+    0x2D7F, // #29ADFF (Blue)
+    0xFE55, // #FFCCAA (Cyan/Skin)
+    0x042A, // #008751 (DarkGreen)
+    0x0707, // #00E436 (Green)
+    0xFF45, // #FFEC27 (LightGreen/Yellowish)
+    0xFD00, // #FFA300 (Yellow)
+    0xAA87, // #AB5236 (Orange)
+    0xFBB4, // #FF77A8 (LightRed/Pink)
+    0xF809, // #FF004D (Red)
+    0x792A, // #7E2553 (DarkRed/Maroon)
+    0x83B3, // #83769C (Purple)
+    0x62AA, // #5F574F (Magenta/DarkGray)
+    0xC618, // #C2C3C7 (Gray)
 };
 
 static constexpr uint16_t PALETTE_PR32[] = {
-    0x0000, // #000000
-    0xFFFF, // #FFFFFF
-    0x1907, // #1B1F3B
-    0x025F, // #0047FF
-    0x061F, // #00C2FF
-    0x13C2, // #0E7A0D
-    0x3648, // #2ECC40
-    0xA7F3, // #A8FF9E
-    0xFEA0, // #FFD500
-    0xFCE3, // #FF9F1C
-    0xB884, // #C1121F
-    0x6822, // #6A040F
-    0x7977, // #7B2CBF
-    0xC3FF, // #C77DFF
-    0x8C71, // #8D8D8D
-    0xCE79, // #CECECE
+    0x0000, // #000000 (Black)
+    0xFFFF, // #FFFFFF (White)
+    0x1907, // #1B1F3B (Navy)
+    0x025F, // #0047FF (Blue)
+    0x061F, // #00C2FF (Cyan)
+    0x13C2, // #0E7A0D (DarkGreen)
+    0x3648, // #2ECC40 (Green)
+    0xA7F3, // #A8FF9E (LightGreen)
+    0xFEA0, // #FFD500 (Yellow)
+    0xFCE3, // #FF9F1C (Orange)
+    0xC3FF, // #C77DFF (LightRed/LightPurple)
+    0xB884, // #C1121F (Red)
+    0x6822, // #6A040F (DarkRed)
+    0x7977, // #7B2CBF (Purple)
+    0xCE79, // #CECECE (Magenta/LightGray)
+    0x8C71, // #8D8D8D (Gray)
 };
 
 }

--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
     "engine",
     "tft_espi"
   ],
-  "version": "0.3.0-dev",
+  "version": "0.4.0-dev",
   "build": {
     "srcDir": "src",
     "includeDir": "include"


### PR DESCRIPTION
Add descriptive color names (e.g., "Black", "White", "Navy") as comments next to each hex value in all palette arrays (NES, GB, GBC, PICO8, PR32). This improves code readability and helps developers quickly identify colors when working with these predefined palettes.