### PR TITLE
build(test): downgrade to C++11 and enhance test runner

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ build_flags =
 	-DUNIT_TEST
 	-Iinclude
 	-Isrc/platforms/mock
-	-std=c++17
+	-std=c++11
 	-DSDL_MAIN_HANDLED
 	-lSDL2
 	--coverage


### PR DESCRIPTION
- Change C++ standard from C++17 to C++11 in platformio.ini and run_tests.py
- Add automatic Unity test framework installation and verification
- Include necessary source files for test compilation dependencies
- Translate script comments and messages from Spanish to English