### PR TITLE
docs: update API reference and formatting for consistency

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1306,14 +1306,25 @@ void EnemyActor::draw(Renderer& renderer) {
 
 **Inherits:** None
 
-Configuration settings for initializing displays.
+Configuration settings for initializing displays. Supports both physical (hardware) and logical (rendering) resolutions.
 
 #### Properties
 
-- **`rotation`**: Display rotation (0-3).
-- **`width`**: Display width in pixels.
-- **`height`**: Display height in pixels.
-- **`xOffset, yOffset`**: Offsets for display rendering.
+- **`type`**: The display type (`ST7789`, `ST7735`, `NONE`, `CUSTOM`).
+- **`rotation`**: Display rotation (0-3 or degrees).
+- **`physicalWidth, physicalHeight`**: Actual hardware resolution.
+- **`logicalWidth, logicalHeight`**: Rendering resolution (game logic).
+- **`xOffset, yOffset`**: Alignment offsets.
+
+#### Custom Displays
+
+To use a custom display driver, use the `PIXELROOT32_CUSTOM_DISPLAY` macro:
+
+```cpp
+auto config = PIXELROOT32_CUSTOM_DISPLAY(new MyDriver(), 240, 240);
+```
+
+For more details, see the [Extensibility Guide](EXTENDING_PIXELROOT32.md).
 
 ---
 

--- a/docs/AUDIO_NES_SUBSYSTEM_REFERENCE.md
+++ b/docs/AUDIO_NES_SUBSYSTEM_REFERENCE.md
@@ -310,10 +310,10 @@ The engine provides two distinct backends for ESP32, allowing developers to choo
 - **Use case**: Retro audio using the ESP32's **internal 8-bit DAC** (GPIO 25 or 26), either
   driving a small speaker directly or feeding a simple amplifier like **PAM8302A**.
 - **Key points**:
- - Uses the ESP32 DAC driver (`dac_output_voltage`) for 0–255 output values.
- - **No I2S** involved; samples are pushed from a dedicated FreeRTOS task at the configured sample rate.
- - Lower resolution (8-bit) but perfect for "chiptune" and Game Boy–style sounds.
- - Works well with small on-board speakers and low-cost mono amps.
+- Uses the ESP32 DAC driver (`dac_output_voltage`) for 0–255 output values.
+- **No I2S** involved; samples are pushed from a dedicated FreeRTOS task at the configured sample rate.
+- Lower resolution (8-bit) but perfect for "chiptune" and Game Boy–style sounds.
+- Works well with small on-board speakers and low-cost mono amps.
 
 ### 4.3 Backend Configuration (in `main.cpp`)
 

--- a/docs/MULTI_CORE_AUDIO_ARCHITECTURE.md
+++ b/docs/MULTI_CORE_AUDIO_ARCHITECTURE.md
@@ -113,6 +113,7 @@ Problems:
 ````
 
 SDL2 mirrors this architecture using either:
+
 - A dedicated audio thread, or
 - The existing callback-based model (fallback).
 
@@ -164,9 +165,9 @@ struct AudioCommand {
 
 ### Notes
 
-* AudioEngine::playEvent() becomes a thin wrapper around enqueue().
-* No audio behavior changes in this phase.
-* Existing games remain unchanged.
+- AudioEngine::playEvent() becomes a thin wrapper around enqueue().
+- No audio behavior changes in this phase.
+- Existing games remain unchanged.
 
 ---
 
@@ -174,23 +175,23 @@ struct AudioCommand {
 
 ### Goals
 
-* Centralize all audio state and timing.
-* Make audio execution independent of frame rate.
-* Prepare for multi-core execution without enforcing it.
+- Centralize all audio state and timing.
+- Make audio execution independent of frame rate.
+- Prepare for multi-core execution without enforcing it.
 
 ### AudioScheduler Responsibilities
 
-* Own AudioChannel array.
-* Process AudioCommandQueue.
-* Generate PCM samples.
-* Maintain audio-time in samples.
-* Output to AudioBackend.
+- Own AudioChannel array.
+- Process AudioCommandQueue.
+- Generate PCM samples.
+- Maintain audio-time in samples.
+- Output to AudioBackend.
 
 ### Audio Time Model
 
-* Internal time unit: samples.
-* No milliseconds inside the audio thread.
-* Conversion from seconds/ms happens only at command ingestion.
+- Internal time unit: samples.
+- No milliseconds inside the audio thread.
+- Conversion from seconds/ms happens only at command ingestion.
 
 ```cpp
 uint64_t audioTimeSamples;
@@ -215,35 +216,35 @@ public:
 
 ### Goals
 
-* Remove frame-driven music sequencing.
-* Make music sample-accurate and audio-owned.
-* Preserve MusicPlayer API.
+- Remove frame-driven music sequencing.
+- Make music sample-accurate and audio-owned.
+- Preserve MusicPlayer API.
 
 ### Revised Responsibilities
 
 #### MusicPlayer (Game Thread)
 
-* Thin client.
-* Enqueues:
+- Thin client.
+- Enqueues:
 
-  * play / stop / pause / resume
-  * tempo changes
-* Does NOT advance notes.
+  - play / stop / pause / resume
+  - tempo changes
+- Does NOT advance notes.
 
 #### MusicSequencer (Audio Thread)
 
-* Owns:
+- Owns:
 
-  * current track
-  * note index
-  * remainingSamples
-* Triggers AudioEvents internally.
-* Uses only sample-based timing.
+  - current track
+  - note index
+  - remainingSamples
+- Triggers AudioEvents internally.
+- Uses only sample-based timing.
 
 ### Important Change
 
-* durationMs and remainingMs are removed from runtime audio state.
-* All durations are converted to sample counts at scheduling time.
+- durationMs and remainingMs are removed from runtime audio state.
+- All durations are converted to sample counts at scheduling time.
 
 ---
 
@@ -251,14 +252,14 @@ public:
 
 ### Goals
 
-* Completely separate game-time and audio-time.
-* Ensure render stalls never affect audio pitch or tempo.
+- Completely separate game-time and audio-time.
+- Ensure render stalls never affect audio pitch or tempo.
 
 ### Rules
 
-* Game loop uses deltaTime (ms).
-* Audio uses sample counts only.
-* No cross-domain timing math outside well-defined boundaries.
+- Game loop uses deltaTime (ms).
+- Audio uses sample counts only.
+- No cross-domain timing math outside well-defined boundaries.
 
 ---
 
@@ -266,15 +267,15 @@ public:
 
 ### Goals
 
-* Run audio on Core 0 when available.
-* Keep Core 1 dedicated to game logic and rendering.
-* Allow coexistence with WiFi/Bluetooth.
+- Run audio on Core 0 when available.
+- Keep Core 1 dedicated to game logic and rendering.
+- Allow coexistence with WiFi/Bluetooth.
 
 ### FreeRTOS Strategy
 
-* AudioScheduler runs as a pinned task.
-* Priority configurable at runtime.
-* Optional yielding between buffers.
+- AudioScheduler runs as a pinned task.
+- Priority configurable at runtime.
+- Optional yielding between buffers.
 
 ```cpp
 audioTaskCore = 0;
@@ -283,7 +284,7 @@ audioTaskPriority = configMAX_PRIORITIES - 1;
 
 Fallback:
 
-* If Core 0 unavailable, audio runs on Core 1 at lower priority.
+- If Core 0 unavailable, audio runs on Core 1 at lower priority.
 
 ---
 
@@ -296,18 +297,18 @@ Fallback:
 
 Both modes share:
 
-* Command queue
-* Scheduler logic
-* Sample-based timing
+- Command queue
+- Scheduler logic
+- Sample-based timing
 
 ---
 
 ## Phase 7: Backward Compatibility Guarantees
 
-* AudioEngine::playEvent() remains valid.
-* MusicPlayer public API unchanged.
-* Existing examples compile and behave identically.
-* No required changes in game code.
+- AudioEngine::playEvent() remains valid.
+- MusicPlayer public API unchanged.
+- Existing examples compile and behave identically.
+- No required changes in game code.
 
 ---
 
@@ -315,27 +316,27 @@ Both modes share:
 
 After full migration:
 
-* Input
-* Scene update
-* Rendering
-* MusicPlayer command submission
+- Input
+- Scene update
+- Rendering
+- MusicPlayer command submission
 
 Removed:
 
-* AudioEngine.update()
-* Music sequencing logic
-* Audio timing logic
+- AudioEngine.update()
+- Music sequencing logic
+- Audio timing logic
 
 ---
 
 ## Key Improvements Over Version 1.0
 
-* Stronger ownership guarantees for audio state.
-* Sample-based timing enforced earlier.
-* Clearer separation of MusicPlayer vs MusicSequencer roles.
-* Reduced ambiguity around timing responsibilities.
-* Safer overflow policy for command queue.
-* Lower long-term debugging and maintenance cost.
+- Stronger ownership guarantees for audio state.
+- Sample-based timing enforced earlier.
+- Clearer separation of MusicPlayer vs MusicSequencer roles.
+- Reduced ambiguity around timing responsibilities.
+- Safer overflow policy for command queue.
+- Lower long-term debugging and maintenance cost.
 
 ---
 
@@ -343,11 +344,11 @@ Removed:
 
 This architecture:
 
-* Matches real console audio pipelines.
-* Preserves PixelRoot32’s simplicity.
-* Scales cleanly to WiFi/Bluetooth usage.
-* Maintains SDL2 development ergonomics.
-* Eliminates race conditions by design.
+- Matches real console audio pipelines.
+- Preserves PixelRoot32’s simplicity.
+- Scales cleanly to WiFi/Bluetooth usage.
+- Maintains SDL2 development ergonomics.
+- Eliminates race conditions by design.
 
 Multi-core support becomes an implementation detail, not a structural dependency.
 


### PR DESCRIPTION
- Enhance DisplayConfig documentation with physical/logical resolution details
- Add custom display driver usage example
- Fix markdown list formatting inconsistencies across audio documentation
- Standardize bullet point formatting for better readability
- Update cross-references to other documentation files