### PR TITLE
docs: update version references to v1.0.0 and improve formatting

### DIFF
--- a/docs/MEMORY_MANAGEMENT_GUIDE.md
+++ b/docs/MEMORY_MANAGEMENT_GUIDE.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0  
 **Last Updated:** February 2026  
-**Engine Version:** v0.9.0-dev  
+**Engine Version:** v1.0.0
 
 ## Overview
 
@@ -58,6 +58,7 @@ Understanding the engine's memory limits is crucial for developing stable games 
 ### Configuration Examples
 
 **For maximum performance (128x128, low entity count):**
+
 ```cpp
 // platformio.ini build_flags
 -D LOGICAL_WIDTH=128
@@ -67,6 +68,7 @@ Understanding the engine's memory limits is crucial for developing stable games 
 ```
 
 **For richer scenes (with PSRAM):**
+
 ```cpp
 // platformio.ini build_flags
 -D LOGICAL_WIDTH=240
@@ -99,11 +101,13 @@ void debugMemory() {
 ### Heap Fragmentation Warning
 
 Long-running games may experience heap fragmentation. Symptoms:
+
 - Gradual decrease in free heap despite stable entity count
 - Sudden crashes when allocating new objects
 - Performance degradation over time
 
 **Mitigation strategies:**
+
 1. Use **Object Pooling** for bullets/particles
 2. Pre-allocate in `Scene::init()`, not during gameplay
 3. Use **SceneArena** for temporary allocations
@@ -367,6 +371,7 @@ public:
 When working with high-performance drivers (TFT, I2S), memory must be allocated with specific capabilities.
 
 ### DMA-Capable Memory
+
 For SPI or I2S transfers to work without CPU intervention, the buffers must be in a specific region of SRAM.
 
 ```cpp
@@ -385,8 +390,10 @@ if (dmaBuffer == nullptr) {
 heap_caps_free(dmaBuffer);
 ```
 
-### Memory-Performance Trade-offs (v0.9.1)
-In v0.9.1, the `TFT_eSPI_Drawer` uses double-buffering for DMA. Increasing `LINES_PER_BLOCK` improves throughput but increases memory usage linearly:
+### Memory-Performance Trade-offs (v1.0.0)
+
+In v1.0.0, the `TFT_eSPI_Drawer` uses double-buffering for DMA. Increasing `LINES_PER_BLOCK` improves throughput but increases memory usage linearly:
+
 - **Baseline**: 20 lines = ~10KB (at 240 width)
 - **Optimized**: 60 lines = ~30KB
 - **Max**: 120 lines = ~60KB (Half frame)

--- a/docs/MUSIC_PLAYER_GUIDE.md
+++ b/docs/MUSIC_PLAYER_GUIDE.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0  
 **Last Updated:** February 2026  
-**Engine Version:** v0.9.0-dev  
+**Engine Version:** v1.0.0
 
 ## Overview
 

--- a/docs/PLATFORM_COMPATIBILITY.md
+++ b/docs/PLATFORM_COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0  
 **Last Updated:** February 2026  
-**Engine Version:** v0.9.0-dev  
+**Engine Version:** v1.0.0
 
 ## Overview
 
@@ -380,16 +380,19 @@ if (u8g2_instance) {
 }
 ```
 
-#### Integer Scaling Fast-Path (v0.9.1+)
+#### Integer Scaling Fast-Path (v1.0.0)
+
 The engine includes a "Fast-Path" for 2x scaling that bypasses the generic bit-by-bit loop. This LUT-based expansion doubles the horizontal processing speed.
 
 ### TFT Displays (SPI/DMA)
 
 #### SPI DMA Pipelining
+
 For TFT displays using `TFT_eSPI`, the engine uses double-buffering and DMA. To minimize interrupt overhead, the engine processes data in large blocks (default: 60 lines).
 
 **Recommendation:**
-- Keep your `SPI_FREQUENCY` at the maximum stable value for your panel (typically 40MHz or 80MHz). 
+
+- Keep your `SPI_FREQUENCY` at the maximum stable value for your panel (typically 40MHz or 80MHz).
 - Use exact 2x scaling (e.g., 120x120 -> 240x240) to trigger the hardware-optimized blit path.
 
 > [!TIP]

--- a/docs/RESOLUTION_SCALING.md
+++ b/docs/RESOLUTION_SCALING.md
@@ -61,10 +61,10 @@ To avoid the massive RAM overhead of a full-size physical framebuffer (which wou
 ### 3. Optimization Techniques (ESP32)
 
 - **8-bit to 16-bit Conversion:** Optimized color conversion from the engine's 8-bit palette to the hardware's RGB565.
-- **Fast-Path Switching (v0.9.1+):**
-    - **1:1 Native:** Directly volcates the buffer if logical and physical match, supporting offsets for centering.
-    - **2x Integer Scaling:** Uses a Bit-Expansion LUT (OLED) or 32-bit register writes (TFT) to duplicate pixels without recalculating indices.
-    - **Generic NN:** Fallback for fractional scales (e.g., 1.5x) using optimized LUTs.
+- **Fast-Path Switching (v1.0.0):**
+  - **1:1 Native:** Directly volcates the buffer if logical and physical match, supporting offsets for centering.
+  - **2x Integer Scaling:** Uses a Bit-Expansion LUT (OLED) or 32-bit register writes (TFT) to duplicate pixels without recalculating indices.
+  - **Generic NN:** Fallback for fractional scales (e.g., 1.5x) using optimized LUTs.
 
 ---
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.1  
 **Last Updated:** February 2026  
-**Engine Version:** v0.9.0-dev  
+**Engine Version:** v1.0.0
 
 ## Overview
 
@@ -467,6 +467,7 @@ void test_performance_60fps(void) {
 ### Common Issues
 
 1. **Memory Leaks**
+
    ```cpp
    void test_no_memory_leak(void) {
        size_t heapBefore = ESP.getFreeHeap();
@@ -480,6 +481,7 @@ void test_performance_60fps(void) {
    ```
 
 2. **Timing Issues**
+
    ```cpp
    void test_timing_sensitive(void) {
        // Use consistent timing
@@ -491,6 +493,7 @@ void test_performance_60fps(void) {
    ```
 
 3. **Platform Differences**
+
    ```cpp
    void test_platform_consistency(void) {
        #ifdef ESP32
@@ -527,26 +530,31 @@ void test_with_debug_output(void) {
 ## Testing Best Practices
 
 ### 1. Test Naming
+
 - Be descriptive: `test_physics_gravity_acceleration()`
 - Include edge cases: `test_collision_circle_perfect_overlap()`
 - Group related tests in same file
 
 ### 2. Test Independence
+
 - Each test should be independent
 - Use `setUp()` and `tearDown()` for consistent state
 - Avoid relying on test execution order
 
 ### 3. Test Coverage
+
 - Test happy path and error cases
 - Include boundary conditions
 - Test platform-specific behavior when relevant
 
 ### 4. Performance
+
 - Keep individual tests fast (<100ms)
 - Use mocks for slow external dependencies
 - Consider test suite execution time
 
 ### 5. Maintainability
+
 - Write clear, readable test code
 - Document complex test scenarios
 - Update tests when code changes
@@ -556,17 +564,20 @@ void test_with_debug_output(void) {
 ## Resources
 
 ### Documentation
+
 - [Unity Test Framework](https://github.com/ThrowTheSwitch/Unity)
 - [PlatformIO Unit Testing](https://docs.platformio.org/en/latest/advanced/unit-testing/index.html)
 - [Google Test Primer](https://github.com/google/googletest/blob/main/docs/primer.md) (concepts apply)
 
 ### Tools
+
 - **gcov**: Code coverage analysis
 - **Valgrind**: Memory debugging (native)
 - **ESP32 Exception Decoder**: Crash analysis
 - **PlatformIO Test Explorer**: VS Code extension
 
 ### Examples
+
 - See `test/unit/` for all unit test suites (e.g. `test_physics_actor/`, `test_ui/`, `test_math/`).
 - See `test/test_engine_integration/` and `test/test_game_loop/` for integration and game-loop tests.
 - See `test/test_config.h` for shared macros and helpers (`TEST_ASSERT_FLOAT_EQUAL`, `test_data`, `test_setup`/`test_teardown`).

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "PixelRoot32-Game-Engine",
-  "description": "PixelRoot32-Game-Engine is an entity-based game engine with scene management, designed for embedded systems. The engine ships with a reference driver based on TFT_eSPI.",
+  "description": "PixelRoot32-Game-Engine is a lightweight, modular 2D game engine written in C++17, designed primarily for ESP32 microcontrollers, with a native simulation layer for PC (SDL2) to enable rapid development without hardware.",
   "keywords": [
     "esp32",
     "game-engine",


### PR DESCRIPTION
Update engine version references from v0.9.0-dev to v1.0.0 across all documentation files. Improve markdown formatting for better readability by adding consistent line breaks before lists and code blocks. Also update the library description to better reflect the engine's current capabilities.