### PR TITLE
refactor(core): replace constexpr with macro for physics module conditionals

### DIFF
--- a/src/core/Scene.cpp
+++ b/src/core/Scene.cpp
@@ -70,9 +70,9 @@ namespace pixelroot32::core {
             t0 = pixelroot32::platforms::config::profilerMicros();
         }
         
-        if constexpr (modules::Physics) {
+        #if PIXELROOT32_ENABLE_PHYSICS
             collisionSystem.update();
-        }
+        #endif
 
         if constexpr (pixelroot32::platforms::config::EnableProfiling) {
             gProfilerCollisionTime += pixelroot32::platforms::config::profilerMicros() - t0;
@@ -80,16 +80,6 @@ namespace pixelroot32::core {
     }
 
     void Scene::sortEntities() {
-        // for (int i = 0; i < entityCount - 1; i++) {
-        //     for (int j = 0; j < entityCount - i - 1; j++) {
-        //         if (entities[j]->getRenderLayer() > entities[j + 1]->getRenderLayer()) {
-        //             Entity* temp = entities[j];
-        //             entities[j] = entities[j + 1];
-        //             entities[j + 1] = temp;
-        //         }
-        //     }
-        // }
-        // needsSorting = false;
         for (int i = 1; i < entityCount; i++) {
             Entity* key = entities[i];
             int j = i - 1;
@@ -154,13 +144,13 @@ namespace pixelroot32::core {
             entities[entityCount++] = entity;
             needsSorting = true;
 
-            if constexpr (modules::Physics) {
+            #if PIXELROOT32_ENABLE_PHYSICS
                 collisionSystem.addEntity(entity);
             
                 if (entity->type == EntityType::ACTOR) {
                     static_cast<Actor*>(entity)->collisionSystem = &collisionSystem;
                 }
-            }
+            #endif
         }
     }
 
@@ -168,9 +158,9 @@ namespace pixelroot32::core {
         assert(entity != nullptr && "Cannot remove null entity from scene");
         for (int i = 0; i < entityCount; i++) {
             if (entities[i] == entity) {
-                if constexpr (modules::Physics) {
+                #if PIXELROOT32_ENABLE_PHYSICS
                     collisionSystem.removeEntity(entity);
-                }
+                #endif
                 
                 for (int j = i; j < entityCount - 1; j++) {
                     entities[j] = entities[j + 1];
@@ -182,11 +172,11 @@ namespace pixelroot32::core {
     }
 
     void Scene::clearEntities() {
-        if constexpr (modules::Physics) {
+        #if PIXELROOT32_ENABLE_PHYSICS
             for (int i = 0; i < entityCount; i++) {
                 collisionSystem.removeEntity(entities[i]);
             }
-        }
+        #endif
         entityCount = 0;
     }   
 }


### PR DESCRIPTION
Switch from compile-time constexpr checks to preprocessor macros for physics module conditionals to allow runtime configuration. This enables optional inclusion of physics functionality at build time rather than requiring it to be determined at compile time.