### PR TITLE
chore: update gitignore and vscode launch config for portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ coverage_filtered.info
 *.log
 test_output.log
 platformio_test.log
+
+.opencode/
+openspec/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,8 @@
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug",
-            "executable": "c:/Users/gperez88/Documents/Proyects/Games/pixelroot32 workspace/PixelRoot32-Game-Samples/lib/PixelRoot32-Game-Engine/.pio/build/native_test/program.exe",
+            "executable": "${workspaceFolder}/.pio/build/native_test/program.exe",
             "projectEnvName": "native_test",
-            "toolchainBinDir": "C:/msys64/mingw64/bin",
             "internalConsoleOptions": "openOnSessionStart",
             "preLaunchTask": {
                 "type": "PlatformIO",
@@ -25,18 +24,16 @@
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug (skip Pre-Debug)",
-            "executable": "c:/Users/gperez88/Documents/Proyects/Games/pixelroot32 workspace/PixelRoot32-Game-Samples/lib/PixelRoot32-Game-Engine/.pio/build/native_test/program.exe",
+            "executable": "${workspaceFolder}/.pio/build/native_test/program.exe",
             "projectEnvName": "native_test",
-            "toolchainBinDir": "C:/msys64/mingw64/bin",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug (without uploading)",
-            "executable": "c:/Users/gperez88/Documents/Proyects/Games/pixelroot32 workspace/PixelRoot32-Game-Samples/lib/PixelRoot32-Game-Engine/.pio/build/native_test/program.exe",
+            "executable": "${workspaceFolder}/.pio/build/native_test/program.exe",
             "projectEnvName": "native_test",
-            "toolchainBinDir": "C:/msys64/mingw64/bin",
             "internalConsoleOptions": "openOnSessionStart",
             "loadMode": "manual"
         }


### PR DESCRIPTION
- Add .opencode/ and openspec/ to .gitignore to exclude IDE-specific directories
- Replace hardcoded executable paths with ${workspaceFolder} variable in launch.json
- Remove toolchainBinDir setting to rely on default platformio configuration