### PR TITLE
feat(graphics): add ILI9341 display support and fix tile animation config

### DIFF
--- a/include/graphics/DisplayConfig.h
+++ b/include/graphics/DisplayConfig.h
@@ -30,8 +30,10 @@
 namespace pixelroot32::graphics {
 
 enum DisplayType {
-    ST7789, // 240x240 TFT
-    ST7735, // 128x128 TFT
+    ST7789, // TFT
+    ST7735, // TFT
+    ILI9341, // TFT 
+    ILI9341_2, // TFT Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
     OLED_SSD1306, // 128x64 OLED (U8G2)
     OLED_SH1106,  // 128x64 OLED (U8G2)
     NONE,   // for SDL2 native no driver.

--- a/include/platforms/EngineConfig.h
+++ b/include/platforms/EngineConfig.h
@@ -115,10 +115,6 @@
     #define MAX_TILESET_SIZE 256
 #endif
 
-#ifndef PIXELROOT32_ENABLE_TILE_ANIMATIONS
-    #define PIXELROOT32_ENABLE_TILE_ANIMATIONS 1
-#endif
-
 // =============================================================================
 // Palette Limits
 // =============================================================================
@@ -211,7 +207,6 @@ namespace pixelroot32::platforms::config {
 
     // Tile Animation
     inline constexpr uint16_t MaxTilesetSize = MAX_TILESET_SIZE;
-    inline constexpr bool EnableTileAnimations = PIXELROOT32_ENABLE_TILE_ANIMATIONS;
 
     // Scene Limits
     inline constexpr int MaxScenes = MAX_SCENES;
@@ -271,6 +266,12 @@ namespace pixelroot32::platforms::config {
     inline constexpr bool EnableSceneArena = true;
     #else
     inline constexpr bool EnableSceneArena = false;
+    #endif
+
+    #ifndef PIXELROOT32_ENABLE_TILE_ANIMATIONS
+    inline constexpr bool EnableTileAnimations = false;
+    #else
+    inline constexpr bool EnableTileAnimations = true;
     #endif
 
     inline unsigned long profilerMicros() {

--- a/src/graphics/DisplayConfig.cpp
+++ b/src/graphics/DisplayConfig.cpp
@@ -52,6 +52,8 @@ namespace pixelroot32::graphics {
                 {
                 case DisplayType::ST7789:
                 case DisplayType::ST7735:
+                case DisplayType::ILI9341:
+                case DisplayType::ILI9341_2:
                 default:
                     rawSurface = new pixelroot32::drivers::esp32::TFT_eSPI_Drawer();
                     break;

--- a/src/platforms/mock/MockSDL2Events.cpp
+++ b/src/platforms/mock/MockSDL2Events.cpp
@@ -5,6 +5,8 @@
  * Mock SDL2 events implementation
  */
 
+#ifdef PLATFORM_NATIVE
+
 #include "platforms/mock/MockSDL2Events.h"
 
 namespace pixelroot32::platforms::mock {
@@ -13,3 +15,5 @@ namespace pixelroot32::platforms::mock {
 MockSDL2EventProvider* g_mockSDL2Events = nullptr;
 
 } // namespace pixelroot32::platforms::mock
+
+#endif // PLATFORM_NATIVE

--- a/test/unit/test_display_config/test_display_config.cpp
+++ b/test/unit/test_display_config/test_display_config.cpp
@@ -32,10 +32,12 @@ void tearDown(void) {
 void test_display_config_display_type_enum_values(void) {
     TEST_ASSERT_EQUAL_INT(0, static_cast<int>(DisplayType::ST7789));
     TEST_ASSERT_EQUAL_INT(1, static_cast<int>(DisplayType::ST7735));
-    TEST_ASSERT_EQUAL_INT(2, static_cast<int>(DisplayType::OLED_SSD1306));
-    TEST_ASSERT_EQUAL_INT(3, static_cast<int>(DisplayType::OLED_SH1106));
-    TEST_ASSERT_EQUAL_INT(4, static_cast<int>(DisplayType::NONE));
-    TEST_ASSERT_EQUAL_INT(5, static_cast<int>(DisplayType::CUSTOM));
+    TEST_ASSERT_EQUAL_INT(2, static_cast<int>(DisplayType::ILI9341));
+    TEST_ASSERT_EQUAL_INT(3, static_cast<int>(DisplayType::ILI9341_2));
+    TEST_ASSERT_EQUAL_INT(4, static_cast<int>(DisplayType::OLED_SSD1306));
+    TEST_ASSERT_EQUAL_INT(5, static_cast<int>(DisplayType::OLED_SH1106));
+    TEST_ASSERT_EQUAL_INT(6, static_cast<int>(DisplayType::NONE));
+    TEST_ASSERT_EQUAL_INT(7, static_cast<int>(DisplayType::CUSTOM));
 }
 
 // =============================================================================


### PR DESCRIPTION
- Add ILI9341 display type enum values and integrate them into the display factory. Conditionally compile mock SDL2 events only for native platform. 
- Fix tile animation enable flag to properly respect the PIXELROOT32_ENABLE_TILE_ANIMATIONS define, defaulting to false when undefined.