### PR TITLE
feat(tilemap): add static tilemap layer cache for ESP32 rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,16 @@ build_flags =
 
 ### Fast Setup
 
-1. **Clone the samples repository:**
+1. **Clone this repository** and open an example under [`examples/`](examples/):
 
    ```bash
-   git clone https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Game-Samples.git
-   cd PixelRoot32-Game-Engine-Samples
+   git clone https://github.com/Gperez88/PixelRoot32-Game-Engine.git
+   cd PixelRoot32-Game-Engine/examples/hello_world
    ```
 
-2. **Open in VS Code** and select your environment (`env:esp32dev`, `env:esp32s3`, or `env:native`).
+   Each folder (`hello_world`, `animated_tilemap`, `snake`, `flappy_bird`, `physics`, `sprites`) is a **standalone PlatformIO project** with its own `platformio.ini`.
+
+2. **Open that example folder in VS Code** (File → Open Folder) and select your environment (`env:esp32dev`, `env:esp32cyd`, `env:esp32s3`, or `env:native`).
 3. **Build and Upload** using PlatformIO.
 
 > 📚 **More information:** See the [Getting Started Guide](https://docs.pixelroot32.org/getting_started/what_is_pixelroot32/).
@@ -124,13 +126,15 @@ To ensure high performance on ESP32, PixelRoot32 enforces strict development pat
 ### Online Resources
 
 - **[📖 Full Documentation](https://docs.pixelroot32.org)**: Guides, API reference, and tutorials.
-- **[🎮 Game Samples](https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Game-Samples)**: Complete examples to start building.
+- **[📦 Examples](https://github.com/Gperez88/PixelRoot32-Game-Engine/tree/main/examples)**: Runnable demos in-repo (`examples/*`, each with its own `platformio.ini`).
 - **[🛠️ Asset Tools](https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Sprite-Sheet-Compiler)**: Sprite compiler and development tools.
 
 ### Local Reference
 
+- **[Examples](examples/)**: Local path to the same demos (open a subfolder in PlatformIO).
 - **[API Reference](docs/API_REFERENCE.md)**: Class reference and usage.
-- **[Architecture](docs/ARCHITECTURE.md)**: System design and layer hierarchy.
+- **[Architecture](docs/ARCHITECTURE.md)**: System design and layer hierarchy (includes [ESP32 tilemap static cache](docs/ARCHITECTURE.md#esp32-rendering-pipeline-and-tilemap-caching)).
+- **[Animated tilemap example](examples/animated_tilemap/README.md)**: **Read this** if you use `AnimatedTilemapScene` or **`StaticTilemapLayerCache`**—documents engine snapshot API, **`invalidateStaticLayerCache()`**, and **static vs dynamic** layer groups (performance-critical on ESP32).
 - **[Physics System](docs/architecture/ARCH_PHYSICS_SUBSYSTEM.md)**: Flat Solver documentation.
 - **[Audio Subsystem](docs/architecture/ARCH_AUDIO_SUBSYSTEM.md)**: Sound engine details.
 - **[Migration v1.1.0](docs/MIGRATION_v1.1.0.md)**: Guide for upgrading from v1.0.0.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -98,6 +98,7 @@ Some modules are optional and can be disabled to save memory:
 
 ## Related Documentation
 
+- [Architecture](ARCHITECTURE.md) (includes [ESP32 rendering and tilemap caching](ARCHITECTURE.md#esp32-rendering-pipeline-and-tilemap-caching))
 - [Platform Compatibility Guide](PLATFORM_COMPATIBILITY.md)
 - [Getting Started Guide](GETTING_STARTED.md)
 - [Extending PixelRoot32](EXTENDING_PIXELROOT32.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ The architecture documentation is organized into **layers** (hardware to game co
 | **Physics** | [Physics Subsystem](architecture/ARCH_PHYSICS_SUBSYSTEM.md) | Flat Solver, collisions, CCD (ex-PHYSICS_*) |
 | **Memory** | [Memory System](architecture/ARCH_MEMORY_SYSTEM.md) | Smart pointers, RAII, ESP32 DRAM (ex-MEMORY_*) |
 | **Resolution Scaling** | [Resolution Scaling](architecture/ARCH_RESOLUTION_SCALING.md) | Logical vs physical resolution (ex-RESOLUTION_*) |
-| **Tile Animation** | [Tile Animation](architecture/ARCH_TILE_ANIMATION.md) | Lookup tables, O(1) resolve (ex-TILE_ANIMATION_*) |
+| **Tile Animation** | [Tile Animation](architecture/ARCH_TILE_ANIMATION.md) | Lookup tables, O(1) resolve; see also static layer cache in [ESP32 rendering](#esp32-rendering-pipeline-and-tilemap-caching) (ex-TILE_ANIMATION_*) |
 | **Touch Input** | [Touch Input](architecture/ARCH_TOUCH_INPUT.md) | Pipeline, XPT2046, calibration (ex-TOUCH_INPUT) |
 | **Extensibility** | [Extending PixelRoot32](EXTENDING_PIXELROOT32.md) | Custom drivers, configuration |
 
@@ -119,8 +119,38 @@ PixelRoot32 is a lightweight, modular 2D game engine written in C++17, designed 
 | Particles | `PIXELROOT32_ENABLE_PARTICLES` | Enabled |
 | Touch Input | `PIXELROOT32_ENABLE_TOUCH` | Disabled |
 | Tile Animations | `PIXELROOT32_ENABLE_TILE_ANIMATIONS` | Enabled |
+| Static tilemap FB snapshot (4bpp) | `PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE` | Enabled (`PlatformDefaults.h`) |
 | Tilemap Optimization | `PIXELROOT32_ENABLE_TILEMAP_OPTIMIZATION` | Enabled |
 | Debug Overlay | `PIXELROOT32_ENABLE_DEBUG_OVERLAY` | Disabled |
+
+---
+
+## ESP32 rendering pipeline and tilemap caching
+
+On ESP32 with **TFT_eSPI** (`TFT_eSPI_Drawer`), the logical framebuffer is typically an **8-bit color-depth sprite** (`TFT_eSprite`). Each frame:
+
+1. **`Renderer::beginFrame()`** obtains a pointer to that buffer via **`DrawSurface::getSpriteBuffer()`** (when the driver supports it), clears the buffer, then draws the scene.
+2. **2bpp / 4bpp tilemaps and sprites** can write **directly into that buffer** (matching TFT_eSPI’s 8bpp packing for RGB565), avoiding a virtual `drawPixel` per pixel where possible.
+3. **`present()` / `sendBuffer()`** converts logical 8bpp rows to **RGB565** using a LUT and pushes pixels to the panel via **DMA** (see [Driver Layer](architecture/ARCH_LAYER_DRIVERS.md), [System Layer / Renderer](architecture/ARCH_LAYER_SYSTEMS.md)).
+
+### Static tilemap layer cache (engine + scenes)
+
+The engine provides **`pixelroot32::graphics::StaticTilemapLayerCache`** (`include/graphics/StaticTilemapLayerCache.h`): a **4bpp tilemap** helper that, when **`getSpriteBuffer()`** is non-null, can snapshot the logical framebuffer after drawing a **static** group of **`TileMap4bppDrawSpec`** entries, then on subsequent frames **`memcpy`** that snapshot back and redraw only the **dynamic** group until the **camera sample** (`-getXOffset()`, `-getYOffset()`) changes or **`invalidate()`** runs.
+
+- **Allocation:** **`allocateForLogicalSize`** / **`allocateForRenderer`** in **`Scene::init()`** (about **W×H** bytes via `std::malloc`; not in `draw`/`update`).
+- **Opt-out:** build flag **`PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE=0`**, or **`setFramebufferCacheEnabled(false)`**.
+- **Reflection in config:** **`pixelroot32::platforms::config::EnableStaticTilemapFbCache`** (`EngineConfig.h`).
+
+**Example:** **`examples/animated_tilemap`** — **`AnimatedTilemapScene`** owns a **`StaticTilemapLayerCache`**, registers **background + ground** as **static** and **details** as **dynamic** (any split is possible via spec lists).
+
+**Game / scene developer contract**
+
+- Call **`invalidate()`** (or a scene wrapper like **`invalidateStaticLayerCache()`**) when something inside the **static** group changes visually, e.g. after **`TileAnimationManager::step()`** on a layer in that group, or when mutating **indices** / **palettes** / **`runtimeMask`** on those maps.
+- Layers in the **dynamic** group are drawn every frame on the fast path—no invalidation needed for **`step()`** on **dynamic-only** animators.
+- **Scroll:** cache rebuilds when the camera sample changes; no extra invalidation solely for scroll.
+- **`getSpriteBuffer() == nullptr`:** full redraw of all groups every frame; no snapshot used.
+
+For animation data flow and linking managers to tilemaps, see [Tile Animation](architecture/ARCH_TILE_ANIMATION.md). API surface: [API Reference — ESP32 graphics / tilemap cache](api/API_GRAPHICS.md#multi-layer-4bpp-tilemap-framebuffer-snapshot-statictilemaplayercache).
 
 ---
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -497,6 +497,7 @@ The engine uses a **Math Policy Layer** to support both FPU (Float) and non-FPU 
   - Keep tile indices in a compact `uint8_t` array and reuse tiles across the map to minimize RAM and flash usage on ESP32.
   - *Trade-off*: Greatly reduces background RAM compared to full bitmaps, but adds a predictable per-tile draw cost; avoid unnecessarily large maps or resolutions on ESP32.
   - For side-scrolling platformers, combine tilemaps with `Camera2D` and `Renderer::setDisplayOffset` instead of manually offsetting individual actors. Keep camera logic centralized (for example in a `Scene`-level camera object) and use different parallax factors per layer to achieve multi-layer scrolling without additional allocations.
+  - **ESP32 / 4bpp multi-layer fast path:** use **`StaticTilemapLayerCache`** for snapshotted **static** `TileMap4bpp` layers plus per-frame **dynamic** layers. Call **`allocateForRenderer`** (or **`allocateForLogicalSize`**) from **`Scene::init()`** only; call **`invalidate()`** when any **static** layer’s pixels change (e.g. after **`TileAnimationManager::step()`** on that layer). Do not hand-roll `malloc`/`memcpy` in every scene—see [Architecture — Static tilemap layer cache](ARCHITECTURE.md#static-tilemap-layer-cache-engine--scenes).
 
 ### Tile Animation Usage
 
@@ -595,6 +596,8 @@ void MyScene::update(unsigned long dt) {
 2. **Shared animation state**: All instances of a tile share the same animation frame. For independent animations, use different base tile indices.
 
 3. **Global timing**: All animations advance together. For desynchronized animations (e.g., two water pools with different phases), create separate animation managers with different frame offsets, or use conditional `step()` calls.
+
+4. **`StaticTilemapLayerCache`:** If a tilemap is in the **static** snapshot group, **`step()`** on its **`TileAnimationManager`** requires **`invalidate()`** on the cache (or move that map to the **dynamic** group). **Dynamic**-group layers do not need cache invalidation for animation updates.
 
 ---
 

--- a/docs/api/API_CONFIG.md
+++ b/docs/api/API_CONFIG.md
@@ -35,6 +35,7 @@ This document covers global configuration options, build flags, and compile-time
 | `PIXELROOT32_ENABLE_PROFILING` | Enable profiling hooks in physics pipeline. | Disabled |
 | `PIXELROOT32_ENABLE_TOUCH` | Enable automatic touch processing in Engine (mouse-to-touch on Native, touch point injection on ESP32). | `0` (disabled) |
 | `PIXELROOT32_ENABLE_TILEMAP_OPTIMIZATION` | Enable tilemap optimizations (TileCache, ChunkManager, DirtyTileTracker). | `1` |
+| `PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE` | Enable **`StaticTilemapLayerCache`** (4bpp direct logical framebuffer snapshot). Set `0` to save ~W×H RAM or force full redraw. | `1` (`PlatformDefaults.h`) |
 | `PIXELROOT32_TILE_CACHE_SIZE` | LRU cache size for pre-rendered tiles. | `16` |
 | `PIXELROOT32_DIRTY_TRACKER_SIZE` | Number of tiles to track for animation changes. | `256` |
 | `PIXELROOT32_CHUNK_SIZE` | Chunk size for viewport culling (tiles per chunk). | `8` |

--- a/docs/api/API_GRAPHICS.md
+++ b/docs/api/API_GRAPHICS.md
@@ -15,7 +15,7 @@ High-level graphics rendering system. Provides a unified API for drawing shapes,
 ### Public Methods
 
 - **`void beginFrame()`**
-    Prepares the buffer for a new frame (clears screen).
+    Prepares the buffer for a new frame (clears screen). On drivers that support it (e.g. **TFT_eSPI_Drawer**), refreshes the internal pointer used for **direct logical framebuffer writes** (`DrawSurface::getSpriteBuffer()`) before clearing, so **2bpp / 4bpp** tile and sprite paths can avoid per-pixel virtual `drawPixel` calls.
 
 - **`void endFrame()`**
     Finalizes the frame and sends the buffer to the display.
@@ -121,6 +121,27 @@ The engine includes several low-level optimizations for the ESP32 platform to ma
 - **IRAM Execution**: Critical rendering functions (`drawPixel`, `drawSpriteInternal`, `resolveColor`, `drawTileMap`) are decorated with `IRAM_ATTR` to run from internal RAM, bypassing the slow SPI Flash latency.
 - **Palette Caching**: Tilemaps cache the resolved RGB565 LUT per tile.
 - **Viewport Culling**: All tilemap rendering functions automatically skip tiles that are outside the current screen boundaries.
+- **Direct logical framebuffer**: **`DrawSurface::getSpriteBuffer()`** exposes the **TFT_eSPI** 8bpp sprite memory when available; **`Renderer::beginFrame()`** caches that pointer so **2bpp / 4bpp** rasterization can write packed pixels directly (same packing as **`TFT_eSprite::drawPixel`** for 8bpp). **`DrawSurface::drawTileDirect()`** allows blitting pre-packed 8bpp tile rows where the driver implements it.
+
+### Multi-layer 4bpp tilemap framebuffer snapshot: `StaticTilemapLayerCache`
+
+**Header:** `graphics/StaticTilemapLayerCache.h` (engine API).
+
+Use this when a **direct logical 8bpp sprite buffer** exists (`DrawSurface::getSpriteBuffer()` after `beginFrame`) to avoid redrawing “static” **4bpp** tilemaps every frame: the engine draws the static group, copies the framebuffer into an internal buffer, then each frame restores with **`memcpy`** and redraws only the **dynamic** group until the sampled camera changes or you **invalidate**.
+
+| Type / method | Role |
+|---------------|------|
+| **`TileMap4bppDrawSpec`** | `{ const TileMap4bpp* map; int originX; int originY; }` — `map == nullptr` entries are skipped. |
+| **`allocateForLogicalSize(w,h)`** / **`allocateForRenderer(renderer)`** | Pre-allocate **W×H** bytes during **`Scene::init()`** (not in `draw`/`update`). Returns `false` if allocation fails → full-draw fallback. |
+| **`invalidate()`** | Mark cache stale (tile/palette/mask changes, or **`step()`** on animators bound to **static** layers). |
+| **`draw(renderer, cameraSampleX, cameraSampleY, staticSpecs, staticCount, dynamicSpecs, dynamicCount)`** | Camera samples are typically **`-renderer.getXOffset()`** / **`-renderer.getYOffset()`** so scroll triggers rebuild. |
+| **`setFramebufferCacheEnabled(false)`** | Runtime opt-out per scene (e.g. profiling); compile-time: **`PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE=0`**. |
+
+**Memory:** about **W×H** bytes (malloc-backed in `allocate*`; no heap use inside `draw`). If **`getSpriteBuffer()`** is **`nullptr`**, the implementation draws all groups every frame (same as SDL2 / non-sprite drivers).
+
+**Example:** **`examples/animated_tilemap`** — `AnimatedTilemapScene` holds a **`StaticTilemapLayerCache`**, calls **`allocateForRenderer(engine.getRenderer())`** in **`init()`**, builds **`TileMap4bppDrawSpec`** arrays for **background + ground** (static) and **details** (dynamic), and exposes **`invalidateStaticLayerCache()`** as a thin wrapper over **`invalidate()`**.
+
+For the full pipeline diagram and layering context, see [Architecture — ESP32 rendering pipeline and tilemap caching](../ARCHITECTURE.md#esp32-rendering-pipeline-and-tilemap-caching).
 
 ---
 
@@ -508,6 +529,8 @@ Abstract interface for platform-specific drawing operations.
 - **`virtual void clearBuffer()`**: Clears the frame buffer.
 - **`virtual void sendBuffer()`**: Sends the frame buffer to the display.
 - **`virtual void drawPixel(int x, int y, uint16_t color)`**: Draws a single pixel.
+- **`virtual uint8_t* getSpriteBuffer()`**: Returns a pointer to the **logical** framebuffer for direct CPU writes when supported (**TFT_eSPI_Drawer** 8bpp sprite); default returns **`nullptr`** (e.g. **SDL2_Drawer**).
+- **`virtual void drawTileDirect(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint8_t* data)`**: Optional 8bpp tile blit into that buffer; default no-op.
 - **`virtual void drawLine(...)`**, **`drawRectangle(...)`**, **`drawCircle(...)`**, etc.
 
 ---

--- a/docs/architecture/ARCH_MEMORY_SYSTEM.md
+++ b/docs/architecture/ARCH_MEMORY_SYSTEM.md
@@ -134,6 +134,8 @@ Available RAM (ESP32):     ~400 KB (classic) / ~512 KB (S3)
 
 > **Note:** These values are for TFT (16-bit) displays. OLED displays use significantly less memory.
 
+**Optional `StaticTilemapLayerCache` (4bpp tilemap snapshot):** when enabled (`PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE`, default `1`), scenes may allocate a **second** logical **W×H** byte buffer (same order as one fullscreen 8bpp logical surface) via **`allocateForRenderer` / `allocateForLogicalSize`** during **`Scene::init()`** only—no heap traffic in **`draw`/`update`**. Budget an extra **~57 KB** at **240×240** if you use the fast path; set the flag to **`0`** or skip **`allocate*`** to avoid that cost (full redraw fallback).
+
 ### Per-Entity Memory Costs
 
 | Component | Memory Cost |

--- a/examples/animated_tilemap/README.md
+++ b/examples/animated_tilemap/README.md
@@ -1,20 +1,66 @@
 # Animated Tilemap Example
 
-Demonstrates animated tile maps with color palette cycling.
+Demonstrates **4bpp** animated tilemaps, multi-palette setup (`ColorPaletteManager`), optional **scene arena**, and the engine **`StaticTilemapLayerCache`** when the driver exposes a direct logical 8bpp sprite buffer (typical **ESP32 + TFT_eSPI**).
+
+## Requirements (build flags)
+
+- **`PIXELROOT32_ENABLE_TILE_ANIMATIONS`**
+- **`PIXELROOT32_ENABLE_4BPP_SPRITES`** (this scene’s tilemaps are 4bpp)
+
+See **`platformio.ini`** in this folder for **`native`**, **`esp32dev`**, and **`esp32cyd`** presets.
+
+## How this scene uses the engine cache
+
+Snapshot logic is **`pixelroot32::graphics::StaticTilemapLayerCache`** (`graphics/StaticTilemapLayerCache.h`), not hand-rolled `memcpy` in the scene.
+
+1. **`init()`**: `tilemapLayerCache.clear()`, then after level/palette setup **`invalidate()`** and **`allocateForRenderer(engine.getRenderer())`** (reserves **W×H** bytes once; `false` → full-draw fallback, no crash).
+2. **`draw()`**: builds **`TileMap4bppDrawSpec`** arrays — **background + ground** = **static** group, **details** = **dynamic** — and passes camera samples **`-renderer.getXOffset()`** / **`-renderer.getYOffset()`**, then **`Scene::draw(renderer)`**.
+3. **`invalidateStaticLayerCache()`** forwards to **`tilemapLayerCache.invalidate()`**.
+
+**Global `Engine`:** `AnimatedTilemapScene.cpp` expects **`extern pixelroot32::core::Engine engine`** (provided by your platform file, e.g. **`platforms/esp32_dev.h`** / **`native.h`** via **`main.cpp`**).
+
+## Invalidation and performance (important)
+
+| Situation | What to do |
+|-----------|------------|
+| Something in the **static** group must change visually (tiles, palette, mask, or **`step()`** on an animator bound to **background** or **ground**) | Call **`invalidateStaticLayerCache()`** (or the fast path can show stale pixels). |
+| Only **details** (dynamic group) animate | You **do not** need invalidation for correctness; omit **`invalidateStaticLayerCache()`** in **`update()`** if ground/background are truly static so the **restore** branch can run when the camera is stable. |
+| **Ground** is in the **static** group **and** you **`step()`** its animator every frame | You must **invalidate every frame** (as in the current **`AnimatedTilemapScene.cpp`**) or move **ground** to the **dynamic** specs in **`draw()`** — otherwise water/fire on ground would look wrong. |
+| Camera / scroll only | Rebuild follows offset samples; no invalidation needed **only** for scroll. |
+| **`getSpriteBuffer()`** is **`nullptr`** (e.g. some native paths) | All layers drawn every frame; snapshot unused. |
+
+**Current example code:** `update()` calls **`getGroundAnimManager().step()`**, **`getDetailsAnimManager().step()`**, then **`invalidateStaticLayerCache()`** every frame. That keeps **ground** animations correct while **ground** stays in the static group, at the cost of **rebuilding the snapshot every frame** on the ESP32 fast path. To maximize **`memcpy`** restore wins, restrict **`step()` + invalidate** to what your **static** group actually needs (or reclassify layers).
+
+## Disabling the snapshot
+
+- **Compile-time:** `-DPIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE=0` (default is **`1`** in **`PlatformDefaults.h`**). Saves ~**W×H** bytes RAM.
+- **Runtime:** call **`setFramebufferCacheEnabled(false)`** on your **`StaticTilemapLayerCache`** instance. This example keeps the cache **private**; add a small public wrapper on **`AnimatedTilemapScene`** if you need toggling from game code.
+
+## Documentation links
+
+- API detail: [Graphics module — `StaticTilemapLayerCache`](../../docs/api/API_GRAPHICS.md#multi-layer-4bpp-tilemap-framebuffer-snapshot-statictilemaplayercache)
+- Pipeline / layering: [Architecture — ESP32 rendering and tilemap caching](../../docs/ARCHITECTURE.md#esp32-rendering-pipeline-and-tilemap-caching)
+- Static cache concept: [Architecture — Static tilemap layer cache](../../docs/ARCHITECTURE.md#static-tilemap-layer-cache-engine--scenes)
 
 ## Features
 
-- Animated tilemap rendering
-- Color palette animation
-- Scene arena usage
-- 2bpp and 4bpp sprite rendering
+- Animated tilemaps + **`TileAnimationManager`**
+- Multi-palette / **`ColorPaletteManager`**
+- Optional **`PIXELROOT32_ENABLE_SCENE_ARENA`** in this example’s **`platformio.ini`**
+- 2bpp/4bpp build flags enabled for the driver stack; layer data here is **4bpp**
+- Engine **`StaticTilemapLayerCache`** (~**W×H** RAM when allocated and flag enabled)
 
 ## Build
 
+Run from **`examples/animated_tilemap`** (this directory):
+
 ```bash
-# Native (PC with SDL2)
+# Native (SDL2) — paths in platformio.ini may need local SDL include/lib on Windows
 pio run -e native
 
-# ESP32
+# ESP32 (ST7789 240×240)
 pio run -e esp32dev
+
+# ESP32 CYD-style (ILI9341 240×320)
+pio run -e esp32cyd
 ```

--- a/examples/animated_tilemap/platformio.ini
+++ b/examples/animated_tilemap/platformio.ini
@@ -13,7 +13,9 @@ extra_configs = lib/platformio.ini
 
 [env:native]
 extends = base_native
-lib_deps = gperez88/PixelRoot32-Game-Engine@^1.1.0
+lib_deps = 
+    ;gperez88/PixelRoot32-Game-Engine@1.1.0
+    https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Game-Engine.git#feat/touch-screen-support
 build_flags = 
     ${base_native.build_flags}
     -D PHYSICAL_DISPLAY_WIDTH=240
@@ -38,7 +40,9 @@ build_flags =
 extends = base_esp32
 board = esp32dev
 framework = arduino
-lib_deps = gperez88/PixelRoot32-Game-Engine@^1.1.0
+lib_deps = 
+    ;gperez88/PixelRoot32-Game-Engine@1.1.0
+    https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Game-Engine.git#feat/touch-screen-support
 build_flags = 
     ${base_esp32.build_flags}
     -D PHYSICAL_DISPLAY_WIDTH=240
@@ -47,6 +51,7 @@ build_flags =
     -D PIXELROOT32_ENABLE_2BPP_SPRITES
     -D PIXELROOT32_ENABLE_4BPP_SPRITES
     -D PIXELROOT32_ENABLE_SCENE_ARENA
+    -D PIXELROOT32_ENABLE_TILE_ANIMATIONS=1
     ; TFT config (ST7789 240x240)
     -D USER_SETUP_LOADED=1
     -D ST7789_DRIVER
@@ -57,7 +62,45 @@ build_flags =
     -D TFT_DC=2
     -D TFT_RST=4
     -D TFT_CS=-1
+    -D TOUCH_CS=-1
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=20000000
     -Isrc
     -O2
+
+[env:esp32cyd]
+extends = base_esp32
+board = esp32dev
+framework = arduino
+lib_deps = 
+    ;gperez88/PixelRoot32-Game-Engine@1.1.0
+    https://github.com/PixelRoot32-Game-Engine/PixelRoot32-Game-Engine.git#feat/touch-screen-support
+build_flags = 
+    ${base_esp32.build_flags}
+	-D PIXELROOT32_ENABLE_DEBUG_OVERLAY
+    -D PIXELROOT32_ENABLE_2BPP_SPRITES
+    -D PIXELROOT32_ENABLE_4BPP_SPRITES
+	-D PIXELROOT32_ENABLE_SCENE_ARENA
+    -D PIXELROOT32_ENABLE_TILE_ANIMATIONS=1
+    -D PHYSICAL_DISPLAY_WIDTH=240
+    -D PHYSICAL_DISPLAY_HEIGHT=320
+    -D PLATFORM_ESP32CYD
+    ; TFT config (ILI9341_2 240x320)
+	-D USER_SETUP_LOADED=1
+    ; No touch configuration for this example.
+    -D ILI9341_2_DRIVER
+	-D TFT_BACKLIGHT_ON=HIGH
+	-D TFT_INVERSION_ON
+	-D TFT_WIDTH=240
+	-D TFT_HEIGHT=320
+	-D TFT_BL=21
+	-D TFT_MISO=12
+	-D TFT_MOSI=13
+	-D TFT_SCLK=14
+	-D TFT_DC=2
+	-D TFT_RST=-1
+	-D TFT_CS=15
+	-D TOUCH_CS=-1
+	-D SPI_FREQUENCY=55000000
+	-D SPI_READ_FREQUENCY=20000000
+	-D SPI_TOUCH_FREQUENCY=2500000

--- a/examples/animated_tilemap/src/AnimatedTilemapScene.cpp
+++ b/examples/animated_tilemap/src/AnimatedTilemapScene.cpp
@@ -13,8 +13,8 @@ extern pr32::core::Engine engine;
 
 namespace animatedtilemap {
 
-using gfx = pr32::graphics;
-using logging = pr32::core::logging;
+namespace gfx = pr32::graphics;
+namespace logging = pr32::core::logging;
 
 using gfx::Color;
 using pr32::math::Vector2;
@@ -51,12 +51,10 @@ AnimatedTilemapScene::AnimatedTilemapScene()
     levelData = {nullptr, nullptr, nullptr, 0, 0, 0};
 }
 
-AnimatedTilemapScene::~AnimatedTilemapScene() {
-    // Cleanup is handled by the scene arena system
-}
-
 void AnimatedTilemapScene::init() {
     animatedtiles::init();
+
+    tilemapLayerCache.clear();
 
     #ifdef PIXELROOT32_ENABLE_SCENE_ARENA
     static uint8_t sceneArenaBuffer[8192];
@@ -71,6 +69,9 @@ void AnimatedTilemapScene::init() {
     levelWidth = pixelroot32::math::toScalar(levelData.mapWidth * levelData.tileSize);
 
     colorPaletteManager.initalizeGamePalettes();
+
+    tilemapLayerCache.invalidate();
+    (void)tilemapLayerCache.allocateForRenderer(engine.getRenderer());
 
     setupTilemapLayers();
 }
@@ -87,37 +88,44 @@ void AnimatedTilemapScene::setupLevelData() {
 }
 
 void AnimatedTilemapScene::setupTilemapLayers() {
-    if (levelData.background) {
-        addEntity(pr32::core::arenaNew<TileMapLayerEntity>(
-            arena, levelData.background, levelData.mapWidth, levelData.mapHeight, 
-            levelData.tileSize, 0));
-    }
-    
-    if (levelData.ground) {
-        addEntity(pr32::core::arenaNew<TileMapLayerEntity>(
-            arena, levelData.ground, levelData.mapWidth, levelData.mapHeight, 
-            levelData.tileSize, 1));
-    }
-
-    if(levelData.details) {
-        addEntity(pr32::core::arenaNew<TileMapLayerEntity>(
-            arena, levelData.details, levelData.mapWidth, levelData.mapHeight, 
-            levelData.tileSize, 2));
-    }
+    // Tilemaps are drawn in draw() via StaticTilemapLayerCache (background + ground snapshotted;
+    // details redrawn each frame when fast path applies). Adjust TileMap4bppDrawSpec lists in draw()
+    // for other layer splits. Use TileMapLayerEntity + Scene::draw for the generic entity path.
 }
 
 void AnimatedTilemapScene::update(unsigned long deltaTime) {
 
-    // Update animated tiles
+    // Update animated tiles — if you enable stepping, also call invalidateStaticLayerCache()
+    // when the stepped manager affects background or ground layers (details-only fast path).
     animatedtiles::getGroundAnimManager().step();
     animatedtiles::getDetailsAnimManager().step();
+
+    invalidateStaticLayerCache();
     
     // Update scene entities
     Scene::update(deltaTime);
 }
 
+void AnimatedTilemapScene::invalidateStaticLayerCache() {
+    tilemapLayerCache.invalidate();
+}
+
 void AnimatedTilemapScene::draw(gfx::Renderer& renderer) {
-    // Draw world entities (tilemaps, actors, etc.)
+    const int camX = -renderer.getXOffset();
+    const int camY = -renderer.getYOffset();
+
+    const gfx::TileMap4bppDrawSpec staticLayers[] = {
+        {levelData.background, 0, 0},
+        {levelData.ground, 0, 0},
+    };
+    const gfx::TileMap4bppDrawSpec dynamicLayers[] = {
+        {levelData.details, 0, 0},
+    };
+
+    tilemapLayerCache.draw(renderer, camX, camY,
+        staticLayers, sizeof(staticLayers) / sizeof(staticLayers[0]),
+        dynamicLayers, sizeof(dynamicLayers) / sizeof(dynamicLayers[0]));
+
     Scene::draw(renderer);
 }
 

--- a/examples/animated_tilemap/src/AnimatedTilemapScene.h
+++ b/examples/animated_tilemap/src/AnimatedTilemapScene.h
@@ -8,10 +8,8 @@
 #include <graphics/Renderer.h>
 #include <graphics/Color.h>
 #include <graphics/TileAnimation.h>
+#include <graphics/StaticTilemapLayerCache.h>
 #include <platforms/EngineConfig.h>
-
-#include <vector>
-#include <memory>
 
 #include "assets/ColorPaletteManager.h"
 
@@ -39,11 +37,17 @@ namespace animatedtilemap {
 class AnimatedTilemapScene : public pixelroot32::core::Scene {
 public:
     AnimatedTilemapScene();
-    virtual ~AnimatedTilemapScene();
+    ~AnimatedTilemapScene() override = default;
 
     void init() override;
     void update(unsigned long deltaTime) override;
     void draw(pixelroot32::graphics::Renderer& renderer) override;
+
+    /**
+     * When background/ground tile animations or tile data change, call this so the
+     * static layer cache is rebuilt (required for correct visuals with the fast path).
+     */
+    void invalidateStaticLayerCache();
 
 protected:
     struct LevelMapData {
@@ -63,6 +67,8 @@ protected:
 private:
     void setupLevelData();
     void setupTilemapLayers();
+
+    pixelroot32::graphics::StaticTilemapLayerCache tilemapLayerCache;
 };
 
 /**
@@ -76,7 +82,7 @@ public:
     void draw(pixelroot32::graphics::Renderer& renderer) override;
 
 private:
-    std::unique_ptr<const pixelroot32::graphics::TileMap4bpp> tileMap;
+    const pixelroot32::graphics::TileMap4bpp* tileMap;
 };
 
 } // namespace animatedtilemap

--- a/examples/animated_tilemap/src/main.cpp
+++ b/examples/animated_tilemap/src/main.cpp
@@ -1,5 +1,7 @@
 #ifdef PLATFORM_NATIVE
 #include "platforms/native.h"
+#elif defined(PLATFORM_ESP32CYD)
+#include "platforms/esp32_cyd.h"
 #else
 #include "platforms/esp32_dev.h"
 #endif

--- a/examples/animated_tilemap/src/platforms/esp32_cyd.h
+++ b/examples/animated_tilemap/src/platforms/esp32_cyd.h
@@ -1,0 +1,41 @@
+#ifdef PLATFORM_ESP32CYD
+
+#include <Arduino.h>
+#include <drivers/esp32/TFT_eSPI_Drawer.h>
+#include <core/Engine.h>
+#include <core/Log.h>
+#include <platforms/EngineConfig.h>
+
+#include "AnimatedTilemapScene.h"
+
+namespace pr32 = pixelroot32;
+
+// ESP32-2432S028 (CYD): ILI9341 240x320 + XPT2046 (TOUCH_CS=33, shared SPI — see TFT_eSPI User_Setup).
+
+// Not using touch for this example.
+
+pr32::graphics::DisplayConfig config(
+    pr32::graphics::DisplayType::ILI9341_2,
+    DISPLAY_ROTATION,
+    PHYSICAL_DISPLAY_WIDTH,
+    PHYSICAL_DISPLAY_HEIGHT,
+    LOGICAL_WIDTH,
+    LOGICAL_HEIGHT,
+    X_OFF_SET,
+    Y_OFF_SET
+);
+
+pr32::core::Engine engine(config);
+
+animatedtilemap::AnimatedTilemapScene animatedTilemapScene;
+
+void setup() {
+    engine.init();
+    engine.setScene(&animatedTilemapScene);
+}
+
+void loop() {
+    engine.run();
+}
+
+#endif

--- a/include/drivers/esp32/TFT_eSPI_Drawer.h
+++ b/include/drivers/esp32/TFT_eSPI_Drawer.h
@@ -70,14 +70,14 @@ public:
      * @param height Tile height in pixels
      * @param data Pointer to 8bpp tile data (one byte per pixel, index into palette)
      */
-    void drawTileDirect(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t* data);
+    void drawTileDirect(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t* data) override;
 
     /**
      * @brief Get pointer to sprite buffer for direct manipulation.
      * 
      * @return Pointer to 8bpp sprite buffer, or nullptr if sprite not created
      */
-    uint8_t* getSpriteBuffer();
+    uint8_t* getSpriteBuffer() override;
 
     /**
      * @brief Processes system events. Always true for embedded.

--- a/include/graphics/Renderer.h
+++ b/include/graphics/Renderer.h
@@ -674,8 +674,11 @@ public:
           xOffset(other.xOffset),
           yOffset(other.yOffset),
           offsetBypass(other.offsetBypass),
-          currentRenderContext(other.currentRenderContext)
-    {}
+          currentRenderContext(other.currentRenderContext),
+          logicalFrameBuffer8(nullptr)
+    {
+        other.logicalFrameBuffer8 = nullptr;
+    }
 
     Renderer& operator=(Renderer&& other) noexcept {
         if (this != &other) {
@@ -687,6 +690,8 @@ public:
             yOffset = other.yOffset;
             offsetBypass = other.offsetBypass;
             currentRenderContext = other.currentRenderContext;
+            logicalFrameBuffer8 = nullptr;
+            other.logicalFrameBuffer8 = nullptr;
         }
         return *this;
     }
@@ -1039,6 +1044,9 @@ private:
 #endif
 
     PaletteContext* currentRenderContext = nullptr;
+
+    /// 8bpp logical framebuffer pointer when the DrawSurface exposes it (e.g. TFT_eSPI sprite); nullptr otherwise.
+    uint8_t* logicalFrameBuffer8 = nullptr;
     
     // Sprite palette slot context for multi-palette sprites
     static constexpr uint8_t kSpritePaletteSlotContextInactive = 0xFF;

--- a/include/graphics/StaticTilemapLayerCache.h
+++ b/include/graphics/StaticTilemapLayerCache.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#pragma once
+
+#include <cstddef>
+
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+#include <cstdlib>
+#include <memory>
+#endif
+
+#include "graphics/Renderer.h"
+#include "platforms/PlatformDefaults.h"
+
+namespace pixelroot32::graphics {
+
+/**
+ * @brief One drawable 4bpp tilemap layer with an origin in logical coordinates.
+ *
+ * Entries with map == nullptr are skipped. Use any number of static layers
+ * (snapshotted together) and dynamic layers (redrawn every frame after restore).
+ */
+struct TileMap4bppDrawSpec {
+    const TileMap4bpp* map;
+    int originX;
+    int originY;
+};
+
+/**
+ * @brief Centralized framebuffer snapshot for static 4bpp tilemap layers.
+ *
+ * On drivers that expose a direct logical 8bpp sprite buffer (e.g. TFT_eSPI),
+ * this avoids redrawing “static” layers every frame when the sampled camera
+ * position is unchanged and the cache has not been invalidated.
+ *
+ * Override points:
+ * - Compile-time: set @c PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE to 0 in build flags.
+ * - Run-time: setFramebufferCacheEnabled(false) per scene or platform init.
+ * - No sprite buffer or failed allocation: automatically falls back to full draw.
+ *
+ * Allocate during scene @c init() via allocateForLogicalSize() or allocateForRenderer()
+ * so the game loop does not hit the heap (see ARCH_MEMORY_SYSTEM.md).
+ */
+class StaticTilemapLayerCache {
+public:
+    StaticTilemapLayerCache() = default;
+
+    /** Releases the snapshot buffer and marks the cache invalid. */
+    void clear();
+
+    /**
+     * @brief Pre-allocate the snapshot for a logical framebuffer of width * height bytes.
+     * @return false if dimensions are invalid or allocation failed.
+     */
+    [[nodiscard]] bool allocateForLogicalSize(int width, int height);
+
+    /** @brief Same as allocateForLogicalSize(renderer.getLogicalWidth/Height()). */
+    [[nodiscard]] bool allocateForRenderer(const Renderer& renderer);
+
+    /** Force a full rebuild on the next draw (tile data, palette, stepped static animations, etc.). */
+    void invalidate();
+
+    /**
+     * @param cameraSampleX  Typically @c -renderer.getXOffset() (must match what should trigger rebuilds).
+     * @param cameraSampleY  Typically @c -renderer.getYOffset().
+     */
+    void draw(Renderer& renderer,
+              int cameraSampleX,
+              int cameraSampleY,
+              const TileMap4bppDrawSpec* staticLayers,
+              std::size_t staticLayerCount,
+              const TileMap4bppDrawSpec* dynamicLayers,
+              std::size_t dynamicLayerCount);
+
+    void setFramebufferCacheEnabled(bool enabled);
+    [[nodiscard]] bool isFramebufferCacheEnabled() const;
+
+private:
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    /** std::malloc / std::free — STYLE_GUIDE forbids operator new; avoid game-loop alloc. */
+    struct CacheBufferDeleter {
+        void operator()(uint8_t* p) const noexcept {
+            std::free(p);
+        }
+    };
+    std::unique_ptr<uint8_t, CacheBufferDeleter> cacheBytes;
+    std::size_t cacheByteCount = 0;
+    int lastCameraX = 0;
+    int lastCameraY = 0;
+    bool cacheValid = false;
+    bool userInvalidated = true;
+    bool framebufferCacheEnabled = true;
+#endif
+};
+
+} // namespace pixelroot32::graphics

--- a/include/platforms/EngineConfig.h
+++ b/include/platforms/EngineConfig.h
@@ -318,6 +318,12 @@ namespace pixelroot32::platforms::config {
     inline constexpr bool EnableTileAnimations = true;
     #endif
 
+    #if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    inline constexpr bool EnableStaticTilemapFbCache = true;
+    #else
+    inline constexpr bool EnableStaticTilemapFbCache = false;
+    #endif
+
     inline unsigned long profilerMicros() {
         return micros();
     }

--- a/include/platforms/PlatformDefaults.h
+++ b/include/platforms/PlatformDefaults.h
@@ -46,6 +46,17 @@
 #define PIXELROOT32_ENABLE_PARTICLES 1
 #endif
 
+// -----------------------------------------------------------------------------
+// Static tilemap framebuffer cache (4bpp direct sprite buffer path)
+// -----------------------------------------------------------------------------
+// When enabled, StaticTilemapLayerCache can snapshot the logical 8bpp framebuffer
+// after drawing “static” layers and restore it on subsequent frames until the
+// camera moves or the cache is invalidated. Set to 0 per env to force the
+// full-draw fallback on low-RAM targets or when profiling without the fast path.
+#if !defined(PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE)
+#define PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE 1
+#endif
+
 // =============================================================================
 // Target-dependent feature defaults
 // =============================================================================

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -27,6 +27,14 @@ namespace pixelroot32::graphics {
         return c != Color::Transparent;
     }
 
+    /// Match TFT_eSprite::drawPixel for 8bpp sprites (TFT_eSPI Extensions/Sprite.cpp).
+    inline uint8_t packRgb565ToTftSprite8(uint16_t rgb565) {
+        return static_cast<uint8_t>(
+            ((rgb565 & 0xE000) >> 8) |
+            ((rgb565 & 0x0700) >> 6) |
+            ((rgb565 & 0x0018) >> 3));
+    }
+
     Renderer::Renderer(const DisplayConfig& config) 
         : config(config),
           logicalWidth(config.logicalWidth),
@@ -81,6 +89,7 @@ namespace pixelroot32::graphics {
     }
 
     void Renderer::beginFrame() {
+        logicalFrameBuffer8 = getDrawSurface().getSpriteBuffer();
         getDrawSurface().clearBuffer();
     }
 
@@ -313,12 +322,15 @@ namespace pixelroot32::graphics {
             int startX = offsetBypass ? x : xOffset + x;
             int startY = offsetBypass ? y : yOffset + y;
 
+            uint8_t* const fb8 = logicalFrameBuffer8;
+
             // Data: 16-bit words (8 pixels per word). Compiler pack_2bpp: LSB = left pixel (bitOffset = (col&7)<<1), word order [left, right]
             for (int row = 0; row < sprite.height; ++row) {
                 const int logicalY = startY + row;
                 if (logicalY < 0 || logicalY >= screenH) continue;
 
                 const uint16_t* rowWords = reinterpret_cast<const uint16_t*>(sprite.data + row * rowStrideBytes);
+                uint8_t* dstRow = fb8 ? (fb8 + logicalY * screenW) : nullptr;
 
                 for (int col = 0; col < sprite.width; ++col) {
                     const int wordIdx = col >> 3; // 8 pixels per word; word 0 = left half, word 1 = right half
@@ -330,7 +342,11 @@ namespace pixelroot32::graphics {
                     const int logicalX = flipX ? startX + (sprite.width - 1 - col) : startX + col;
                     if (logicalX < 0 || logicalX >= screenW) continue;
 
-                    getDrawSurface().drawPixel(logicalX, logicalY, paletteLUT[val]);
+                    if (dstRow) {
+                        dstRow[logicalX] = packRgb565ToTftSprite8(paletteLUT[val]);
+                    } else {
+                        getDrawSurface().drawPixel(logicalX, logicalY, paletteLUT[val]);
+                    }
                 }
             }
         }
@@ -372,23 +388,65 @@ namespace pixelroot32::graphics {
             int startX = offsetBypass ? x : xOffset + x;
             int startY = offsetBypass ? y : yOffset + y;
 
+            uint8_t* const fb8 = logicalFrameBuffer8;
+
             for (int row = 0; row < sprite.height; ++row) {
                 const int logicalY = startY + row;
                 if (logicalY < 0 || logicalY >= screenH) continue;
 
                 const uint8_t* rowData = sprite.data + row * rowStrideBytes;
 
-                for (int col = 0; col < sprite.width; ++col) {
-                    const int byteIdx = col >> 1;
-                    const int bitOffset = (col & 1) << 2;
-                    const uint8_t val = (rowData[byteIdx] >> bitOffset) & 0x0F;
+                if (fb8 && !flipX) {
+                    uint8_t* dstRow = fb8 + logicalY * screenW;
+                    int col = 0;
+                    for (; col + 1 < sprite.width; col += 2) {
+                        const uint8_t b = rowData[col >> 1];
+                        const uint8_t v0 = b & 0x0F;
+                        const uint8_t v1 = (b >> 4) & 0x0F;
+                        const int lx0 = startX + col;
+                        const int lx1 = startX + col + 1;
+                        if (v0 != 0 && lx0 >= 0 && lx0 < screenW) {
+                            dstRow[lx0] = packRgb565ToTftSprite8(paletteLUT[v0]);
+                        }
+                        if (v1 != 0 && lx1 >= 0 && lx1 < screenW) {
+                            dstRow[lx1] = packRgb565ToTftSprite8(paletteLUT[v1]);
+                        }
+                    }
+                    if (col < sprite.width) {
+                        const int byteIdx = col >> 1;
+                        const int bitOffset = (col & 1) << 2;
+                        const uint8_t val = (rowData[byteIdx] >> bitOffset) & 0x0F;
+                        if (val != 0) {
+                            const int lx = startX + col;
+                            if (lx >= 0 && lx < screenW) {
+                                dstRow[lx] = packRgb565ToTftSprite8(paletteLUT[val]);
+                            }
+                        }
+                    }
+                } else if (fb8) {
+                    uint8_t* dstRow = fb8 + logicalY * screenW;
+                    for (int col = 0; col < sprite.width; ++col) {
+                        const int byteIdx = col >> 1;
+                        const int bitOffset = (col & 1) << 2;
+                        const uint8_t val = (rowData[byteIdx] >> bitOffset) & 0x0F;
+                        if (val == 0) continue;
+                        const int logicalX = startX + (sprite.width - 1 - col);
+                        if (logicalX < 0 || logicalX >= screenW) continue;
+                        dstRow[logicalX] = packRgb565ToTftSprite8(paletteLUT[val]);
+                    }
+                } else {
+                    for (int col = 0; col < sprite.width; ++col) {
+                        const int byteIdx = col >> 1;
+                        const int bitOffset = (col & 1) << 2;
+                        const uint8_t val = (rowData[byteIdx] >> bitOffset) & 0x0F;
 
-                    if (val == 0) continue;
+                        if (val == 0) continue;
 
-                    const int logicalX = flipX ? startX + (sprite.width - 1 - col) : startX + col;
-                    if (logicalX < 0 || logicalX >= screenW) continue;
+                        const int logicalX = flipX ? startX + (sprite.width - 1 - col) : startX + col;
+                        if (logicalX < 0 || logicalX >= screenW) continue;
 
-                    getDrawSurface().drawPixel(logicalX, logicalY, paletteLUT[val]);
+                        getDrawSurface().drawPixel(logicalX, logicalY, paletteLUT[val]);
+                    }
                 }
             }
         }

--- a/src/graphics/StaticTilemapLayerCache.cpp
+++ b/src/graphics/StaticTilemapLayerCache.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#include "graphics/StaticTilemapLayerCache.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace pixelroot32::graphics {
+
+namespace {
+
+void drawSpecs(Renderer& renderer, const TileMap4bppDrawSpec* layers, std::size_t count) {
+    if (!layers || count == 0) {
+        return;
+    }
+    for (std::size_t i = 0; i < count; ++i) {
+        const TileMap4bpp* m = layers[i].map;
+        if (!m) {
+            continue;
+        }
+        renderer.drawTileMap(*m, layers[i].originX, layers[i].originY);
+    }
+}
+
+void drawAllLayers(Renderer& renderer,
+                   const TileMap4bppDrawSpec* staticLayers,
+                   std::size_t staticLayerCount,
+                   const TileMap4bppDrawSpec* dynamicLayers,
+                   std::size_t dynamicLayerCount) {
+    drawSpecs(renderer, staticLayers, staticLayerCount);
+    drawSpecs(renderer, dynamicLayers, dynamicLayerCount);
+}
+
+} // namespace
+
+void StaticTilemapLayerCache::clear() {
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    cacheBytes.reset();
+    cacheByteCount = 0;
+    cacheValid = false;
+    userInvalidated = true;
+#endif
+}
+
+bool StaticTilemapLayerCache::allocateForLogicalSize(int width, int height) {
+#if !PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    (void)width;
+    (void)height;
+    return true;
+#else
+    if (width <= 0 || height <= 0) {
+        clear();
+        return false;
+    }
+    const std::size_t n = static_cast<std::size_t>(width) * static_cast<std::size_t>(height);
+    if (cacheBytes && cacheByteCount == n) {
+        invalidate();
+        return true;
+    }
+    cacheBytes.reset();
+    cacheByteCount = 0;
+    // malloc (not operator new per STYLE_GUIDE); nullptr on OOM without abort.
+    uint8_t* raw = static_cast<uint8_t*>(std::malloc(n));
+    if (!raw) {
+        return false;
+    }
+    cacheBytes.reset(raw);
+    cacheByteCount = n;
+    cacheValid = false;
+    userInvalidated = true;
+    return true;
+#endif
+}
+
+bool StaticTilemapLayerCache::allocateForRenderer(const Renderer& renderer) {
+    return allocateForLogicalSize(renderer.getLogicalWidth(), renderer.getLogicalHeight());
+}
+
+void StaticTilemapLayerCache::invalidate() {
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    cacheValid = false;
+    userInvalidated = true;
+#endif
+}
+
+void StaticTilemapLayerCache::setFramebufferCacheEnabled(bool enabled) {
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    if (framebufferCacheEnabled == enabled) {
+        return;
+    }
+    framebufferCacheEnabled = enabled;
+    invalidate();
+#else
+    (void)enabled;
+#endif
+}
+
+bool StaticTilemapLayerCache::isFramebufferCacheEnabled() const {
+#if PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    return framebufferCacheEnabled;
+#else
+    return false;
+#endif
+}
+
+void StaticTilemapLayerCache::draw(Renderer& renderer,
+                                   int cameraSampleX,
+                                   int cameraSampleY,
+                                   const TileMap4bppDrawSpec* staticLayers,
+                                   std::size_t staticLayerCount,
+                                   const TileMap4bppDrawSpec* dynamicLayers,
+                                   std::size_t dynamicLayerCount) {
+#if !PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+    drawAllLayers(renderer, staticLayers, staticLayerCount, dynamicLayers, dynamicLayerCount);
+    return;
+#else
+    if (!framebufferCacheEnabled) {
+        drawAllLayers(renderer, staticLayers, staticLayerCount, dynamicLayers, dynamicLayerCount);
+        return;
+    }
+
+    bool hasStatic = false;
+    if (staticLayers) {
+        for (std::size_t i = 0; i < staticLayerCount; ++i) {
+            if (staticLayers[i].map) {
+                hasStatic = true;
+                break;
+            }
+        }
+    }
+
+    if (!hasStatic) {
+        drawSpecs(renderer, dynamicLayers, dynamicLayerCount);
+        return;
+    }
+
+    uint8_t* fb = renderer.getDrawSurface().getSpriteBuffer();
+    const int w = renderer.getLogicalWidth();
+    const int h = renderer.getLogicalHeight();
+    const std::size_t bufBytes = static_cast<std::size_t>(w) * static_cast<std::size_t>(h);
+
+    if (!fb || !cacheBytes || cacheByteCount != bufBytes) {
+        drawAllLayers(renderer, staticLayers, staticLayerCount, dynamicLayers, dynamicLayerCount);
+        return;
+    }
+
+    const bool camMoved = (cameraSampleX != lastCameraX || cameraSampleY != lastCameraY);
+    const bool needRebuild = !cacheValid || camMoved || userInvalidated;
+
+    if (needRebuild) {
+        drawSpecs(renderer, staticLayers, staticLayerCount);
+        std::memcpy(cacheBytes.get(), fb, bufBytes);
+        drawSpecs(renderer, dynamicLayers, dynamicLayerCount);
+        lastCameraX = cameraSampleX;
+        lastCameraY = cameraSampleY;
+        cacheValid = true;
+        userInvalidated = false;
+    } else {
+        std::memcpy(fb, cacheBytes.get(), bufBytes);
+        drawSpecs(renderer, dynamicLayers, dynamicLayerCount);
+    }
+#endif
+}
+
+} // namespace pixelroot32::graphics


### PR DESCRIPTION
Introduce StaticTilemapLayerCache to snapshot logical framebuffer for static 4bpp tilemap layers, enabling fast path rendering on ESP32 with TFT_eSPI_Drawer. The cache reduces per-frame redraw overhead by restoring static layers via memcpy and only redrawing dynamic layers when camera is stable.

- Add PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE build flag (default enabled)
- Update animated_tilemap example to demonstrate cache usage with background/ground (static) and details (dynamic) layers
- Add ESP32CYD platform support and update documentation
- Optimize 2bpp/4bpp sprite rendering to use direct framebuffer writes when available
- Add invalidation mechanism for animation updates affecting static layers