### PR TITLE
test: add unit tests for input and graphics modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Generate Coverage Report
       run: |
         lcov --capture --directory . --output-file coverage.info
-        lcov --remove coverage.info '/usr/*' '*/.pio/*' '*/test/*' '*/drivers/native/*' '*/drivers/esp32/*' '*/src/core/Engine.cpp' '*/src/graphics/Renderer.cpp' '*/src/physics/TileConsumptionHelper.cpp' '*/include/graphics/BaseDrawSurface.h' '*/include/graphics/DrawSurface.h' '*/include/graphics/ui/UICheckbox.h' '*/src/graphics/StaticTilemapLayerCache.cpp' '*/src/input/adapters/XPT2046Adapter.cpp' '*/src/input/TouchCalibration.cpp' '*/src/graphics/ui/UIManager.cpp' '*/src/graphics/ui/UICheckBox.cpp' '*/src/input/InputManager.cpp' '*/include/graphics/TileCache.h' '*/include/graphics/ChunkManager.h' '*/include/core/Scene.h' --output-file coverage.info --ignore-errors unused
+        lcov --remove coverage.info '/usr/*' '*/.pio/*' '*/test/*' '*/drivers/native/*' '*/drivers/esp32/*' '*/src/core/Engine.cpp' '*/src/graphics/Renderer.cpp' '*/src/physics/TileConsumptionHelper.cpp' '*/include/graphics/BaseDrawSurface.h' '*/include/graphics/DrawSurface.h' '*/include/graphics/ui/UICheckbox.h' '*/include/graphics/TileCache.h' '*/include/graphics/ChunkManager.h' '*/include/core/Scene.h' --output-file coverage.info --ignore-errors unused
         lcov --list coverage.info
         genhtml coverage.info --output-directory coverage_report
 

--- a/test/unit/test_input_manager/test_input_manager.cpp
+++ b/test/unit/test_input_manager/test_input_manager.cpp
@@ -1,5 +1,8 @@
 #include <unity.h>
+#include "../../test_config.h"
 #include "input/InputManager.h"
+#include "input/InputConfig.h"
+#include "input/TouchEvent.h"
 #include <vector>
 
 using namespace pixelroot32::input;
@@ -110,6 +113,121 @@ void test_input_manager_out_of_bounds(void) {
     TEST_ASSERT_FALSE(manager.isButtonClicked(5));
 }
 
+void test_input_manager_multiple_buttons(void) {
+    InputConfig config(3, 10, 11, 12);
+    InputManager manager(config);
+    manager.init();
+    
+    mockKeyboardState[10] = 1;
+    mockKeyboardState[12] = 1;
+    manager.update(1, mockKeyboardState);
+    
+    TEST_ASSERT_TRUE(manager.isButtonDown(0));
+    TEST_ASSERT_FALSE(manager.isButtonDown(1));
+    TEST_ASSERT_TRUE(manager.isButtonDown(2));
+}
+
+void test_input_manager_button_state_persistence(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    mockKeyboardState[10] = 1;
+    manager.update(1, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonDown(0));
+    
+    manager.update(50, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonDown(0));
+    
+    mockKeyboardState[10] = 0;
+    manager.update(200, mockKeyboardState);
+    TEST_ASSERT_FALSE(manager.isButtonDown(0));
+}
+
+void test_input_manager_is_button_pressed_clears_after_frame(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    mockKeyboardState[10] = 1;
+    manager.update(1, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonPressed(0));
+    
+    manager.update(50, mockKeyboardState);
+    TEST_ASSERT_FALSE(manager.isButtonPressed(0));
+}
+
+void test_input_manager_is_button_released_clears_after_frame(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    mockKeyboardState[10] = 1;
+    manager.update(1, mockKeyboardState);
+    
+    mockKeyboardState[10] = 0;
+    manager.update(101, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonReleased(0));
+    
+    manager.update(50, mockKeyboardState);
+    TEST_ASSERT_FALSE(manager.isButtonReleased(0));
+}
+
+void test_input_manager_touch_events_empty(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    TouchEvent events[5];
+    uint8_t count = manager.getTouchEvents(events, 5);
+    TEST_ASSERT_EQUAL(0, count);
+    
+    TEST_ASSERT_FALSE(manager.hasTouchEvents());
+}
+
+void test_input_manager_get_touch_state_idle(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    TouchState state = manager.getTouchState(0);
+    TEST_ASSERT_EQUAL(static_cast<uint8_t>(TouchState::Idle), static_cast<uint8_t>(state));
+}
+
+void test_input_manager_invalid_button_index_all_methods(void) {
+    InputConfig config(1, 10);
+    InputManager manager(config);
+    manager.init();
+    
+    TEST_ASSERT_FALSE(manager.isButtonDown(99));
+    TEST_ASSERT_FALSE(manager.isButtonPressed(99));
+    TEST_ASSERT_FALSE(manager.isButtonReleased(99));
+    TEST_ASSERT_FALSE(manager.isButtonClicked(99));
+}
+
+void test_input_manager_zero_button_count(void) {
+    InputConfig config(0);
+    InputManager manager(config);
+    manager.init();
+    
+    TEST_ASSERT_FALSE(manager.isButtonDown(0));
+    TEST_ASSERT_FALSE(manager.isButtonPressed(0));
+}
+
+void test_input_manager_config_max_buttons(void) {
+    InputConfig config(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    InputManager manager(config);
+    manager.init();
+    
+    mockKeyboardState[0] = 1;
+    manager.update(1, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonDown(0));
+    
+    mockKeyboardState[15] = 1;
+    manager.update(1, mockKeyboardState);
+    TEST_ASSERT_TRUE(manager.isButtonDown(15));
+}
+
 int main(int argc, char **argv) {
     UNITY_BEGIN();
     RUN_TEST(test_input_manager_initialization);
@@ -118,5 +236,14 @@ int main(int argc, char **argv) {
     RUN_TEST(test_input_manager_debouncing);
     RUN_TEST(test_input_manager_click);
     RUN_TEST(test_input_manager_out_of_bounds);
+    RUN_TEST(test_input_manager_multiple_buttons);
+    RUN_TEST(test_input_manager_button_state_persistence);
+    RUN_TEST(test_input_manager_is_button_pressed_clears_after_frame);
+    RUN_TEST(test_input_manager_is_button_released_clears_after_frame);
+    RUN_TEST(test_input_manager_touch_events_empty);
+    RUN_TEST(test_input_manager_get_touch_state_idle);
+    RUN_TEST(test_input_manager_invalid_button_index_all_methods);
+    RUN_TEST(test_input_manager_zero_button_count);
+    RUN_TEST(test_input_manager_config_max_buttons);
     return UNITY_END();
 }

--- a/test/unit/test_static_tilemap_layer_cache/test_static_tilemap_layer_cache.cpp
+++ b/test/unit/test_static_tilemap_layer_cache/test_static_tilemap_layer_cache.cpp
@@ -1,0 +1,237 @@
+/**
+ * @file test_static_tilemap_layer_cache.cpp
+ * @brief Unit tests for graphics/StaticTilemapLayerCache module
+ * @version 1.0
+ * @date 2026-04-05
+ * 
+ * Tests for StaticTilemapLayerCache - framebuffer cache for static tilemap layers.
+ */
+
+#include <unity.h>
+#include "../test_config.h"
+#include "graphics/StaticTilemapLayerCache.h"
+
+#ifdef PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE
+
+using namespace pixelroot32::graphics;
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+void test_cache_default_constructor(void) {
+    StaticTilemapLayerCache cache;
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_allocate_valid_size(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool result = cache.allocateForLogicalSize(240, 240);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_allocate_invalid_width(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool result = cache.allocateForLogicalSize(0, 240);
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_cache_allocate_invalid_height(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool result = cache.allocateForLogicalSize(240, 0);
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_cache_allocate_negative_dimensions(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool result = cache.allocateForLogicalSize(-100, -100);
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_cache_allocate_same_size_twice(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool result1 = cache.allocateForLogicalSize(240, 240);
+    TEST_ASSERT_TRUE(result1);
+    
+    bool result2 = cache.allocateForLogicalSize(240, 240);
+    TEST_ASSERT_TRUE(result2);
+}
+
+void test_cache_allocate_different_size(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(240, 240);
+    bool result = cache.allocateForLogicalSize(320, 240);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_cache_clear(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(240, 240);
+    cache.clear();
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_invalidate(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(240, 240);
+    cache.invalidate();
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_set_enabled_true(void) {
+    StaticTilemapLayerCache cache;
+    
+    cache.setFramebufferCacheEnabled(true);
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_set_enabled_false(void) {
+    StaticTilemapLayerCache cache;
+    cache.setFramebufferCacheEnabled(true);
+    
+    cache.setFramebufferCacheEnabled(false);
+    
+    TEST_ASSERT_FALSE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_toggle_enabled_twice(void) {
+    StaticTilemapLayerCache cache;
+    
+    cache.setFramebufferCacheEnabled(true);
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+    
+    cache.setFramebufferCacheEnabled(false);
+    TEST_ASSERT_FALSE(cache.isFramebufferCacheEnabled());
+    
+    cache.setFramebufferCacheEnabled(true);
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_multiple_allocate_calls(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(100, 100);
+    (void)cache.allocateForLogicalSize(200, 200);
+    (void)cache.allocateForLogicalSize(320, 240);
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_allocate_then_clear_then_allocate_again(void) {
+    StaticTilemapLayerCache cache;
+    
+    bool r1 = cache.allocateForLogicalSize(240, 240);
+    TEST_ASSERT_TRUE(r1);
+    
+    cache.clear();
+    
+    bool r2 = cache.allocateForLogicalSize(240, 240);
+    TEST_ASSERT_TRUE(r2);
+}
+
+void test_cache_invalidate_clears_valid_flag(void) {
+    StaticTilemapLayerCache cache;
+    (void)cache.allocateForLogicalSize(240, 240);
+    
+    cache.invalidate();
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_multiple_invalidate_calls(void) {
+    StaticTilemapLayerCache cache;
+    (void)cache.allocateForLogicalSize(240, 240);
+    
+    cache.invalidate();
+    cache.invalidate();
+    cache.invalidate();
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_enable_disable_preserves_allocation(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(240, 240);
+    cache.setFramebufferCacheEnabled(false);
+    
+    TEST_ASSERT_FALSE(cache.isFramebufferCacheEnabled());
+    
+    cache.setFramebufferCacheEnabled(true);
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+void test_cache_clear_then_invalidate(void) {
+    StaticTilemapLayerCache cache;
+    
+    (void)cache.allocateForLogicalSize(240, 240);
+    cache.clear();
+    cache.invalidate();
+    
+    TEST_ASSERT_TRUE(cache.isFramebufferCacheEnabled());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_cache_default_constructor);
+    RUN_TEST(test_cache_allocate_valid_size);
+    RUN_TEST(test_cache_allocate_invalid_width);
+    RUN_TEST(test_cache_allocate_invalid_height);
+    RUN_TEST(test_cache_allocate_negative_dimensions);
+    RUN_TEST(test_cache_allocate_same_size_twice);
+    RUN_TEST(test_cache_allocate_different_size);
+    RUN_TEST(test_cache_clear);
+    RUN_TEST(test_cache_invalidate);
+    RUN_TEST(test_cache_set_enabled_true);
+    RUN_TEST(test_cache_set_enabled_false);
+    RUN_TEST(test_cache_toggle_enabled_twice);
+    RUN_TEST(test_cache_multiple_allocate_calls);
+    RUN_TEST(test_cache_allocate_then_clear_then_allocate_again);
+    RUN_TEST(test_cache_invalidate_clears_valid_flag);
+    RUN_TEST(test_cache_multiple_invalidate_calls);
+    RUN_TEST(test_cache_enable_disable_preserves_allocation);
+    RUN_TEST(test_cache_clear_then_invalidate);
+    
+    return UNITY_END();
+}
+
+#else
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_cache_disabled(void) {
+    TEST_IGNORE_MESSAGE("PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE not defined");
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_cache_disabled);
+    return UNITY_END();
+}
+
+#endif

--- a/test/unit/test_touch_calibration/test_touch_calibration.cpp
+++ b/test/unit/test_touch_calibration/test_touch_calibration.cpp
@@ -1,0 +1,478 @@
+/**
+ * @file test_touch_calibration.cpp
+ * @brief Unit tests for input/TouchCalibration module
+ * @version 1.0
+ * @date 2026-04-05
+ * 
+ * Tests for TouchCalibration - touch coordinate transformation and calibration.
+ */
+
+#include <unity.h>
+#include "../test_config.h"
+#include "input/TouchAdapter.h"
+#include "input/TouchPoint.h"
+
+using namespace pixelroot32::input;
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+void test_touch_calibration_default_constructor(void) {
+    TouchCalibration calib;
+    
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation0), 
+                            static_cast<uint8_t>(calib.rotation));
+}
+
+void test_touch_calibration_for_resolution_320x240(void) {
+    TouchCalibration calib = TouchCalibration::forResolution(320, 240);
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(320.0f / 4096.0f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(240.0f / 4096.0f, calib.scaleY);
+}
+
+void test_touch_calibration_for_resolution_240x320(void) {
+    TouchCalibration calib = TouchCalibration::forResolution(240, 320);
+    
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(240.0f / 4096.0f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(320.0f / 4096.0f, calib.scaleY);
+}
+
+void test_touch_calibration_for_resolution_zero_dimensions(void) {
+    TouchCalibration calib = TouchCalibration::forResolution(0, 0);
+    
+    TEST_ASSERT_EQUAL_INT16(0, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(0, calib.displayHeight);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+}
+
+void test_touch_calibration_for_resolution_negative_dimensions(void) {
+    TouchCalibration calib = TouchCalibration::forResolution(-100, -200);
+    
+    TEST_ASSERT_EQUAL_INT16(-100, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(-200, calib.displayHeight);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+}
+
+void test_touch_calibration_transform_no_scale_no_offset(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = 0;
+    calib.offsetY = 0;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(100, 50, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(100, result.x);
+    TEST_ASSERT_EQUAL_INT16(50, result.y);
+    TEST_ASSERT_TRUE(result.pressed);
+    TEST_ASSERT_EQUAL_UINT8(0, result.id);
+    TEST_ASSERT_EQUAL_UINT32(1000, result.ts);
+}
+
+void test_touch_calibration_transform_with_scale(void) {
+    TouchCalibration calib;
+    calib.scaleX = 0.5f;
+    calib.scaleY = 0.5f;
+    calib.offsetX = 0;
+    calib.offsetY = 0;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(200, 100, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(100, result.x);
+    TEST_ASSERT_EQUAL_INT16(50, result.y);
+}
+
+void test_touch_calibration_transform_with_offset(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = 10;
+    calib.offsetY = -5;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(100, 50, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(110, result.x);
+    TEST_ASSERT_EQUAL_INT16(45, result.y);
+}
+
+void test_touch_calibration_transform_combined_scale_and_offset(void) {
+    TouchCalibration calib;
+    calib.scaleX = 2.0f;
+    calib.scaleY = 0.5f;
+    calib.offsetX = -10;
+    calib.offsetY = 20;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(100, 100, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(190, result.x);  // (100 * 2.0) + (-10) = 190
+    TEST_ASSERT_EQUAL_INT16(70, result.y);  // (100 * 0.5) + 20 = 70
+}
+
+void test_touch_calibration_transform_not_pressed(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    
+    TouchPoint result = calib.transform(100, 50, false, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(100, result.x);
+    TEST_ASSERT_EQUAL_INT16(50, result.y);
+    TEST_ASSERT_FALSE(result.pressed);
+}
+
+void test_touch_calibration_transform_clamp_negative_to_zero(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = -50;
+    calib.offsetY = -50;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(10, 10, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(0, result.x);
+    TEST_ASSERT_EQUAL_INT16(0, result.y);
+}
+
+void test_touch_calibration_transform_clamp_positive_to_max(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = 50;
+    calib.offsetY = 50;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchPoint result = calib.transform(300, 200, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(320, result.x);
+    TEST_ASSERT_EQUAL_INT16(240, result.y);
+}
+
+void test_touch_calibration_apply_rotation_0(void) {
+    TouchCalibration calib;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    int16_t outX, outY;
+    calib.applyRotation(100, 50, outX, outY);
+    
+    TEST_ASSERT_EQUAL_INT16(100, outX);
+    TEST_ASSERT_EQUAL_INT16(50, outY);
+}
+
+void test_touch_calibration_apply_rotation_90(void) {
+    TouchCalibration calib;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation90;
+    
+    int16_t outX, outY;
+    calib.applyRotation(100, 50, outX, outY);
+    
+    TEST_ASSERT_EQUAL_INT16(240 - 50, outX);  // height - y
+    TEST_ASSERT_EQUAL_INT16(100, outY);        // x
+}
+
+void test_touch_calibration_apply_rotation_180(void) {
+    TouchCalibration calib;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation180;
+    
+    int16_t outX, outY;
+    calib.applyRotation(100, 50, outX, outY);
+    
+    TEST_ASSERT_EQUAL_INT16(320 - 100, outX);  // width - x
+    TEST_ASSERT_EQUAL_INT16(240 - 50, outY);   // height - y
+}
+
+void test_touch_calibration_apply_rotation_270(void) {
+    TouchCalibration calib;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation270;
+    
+    int16_t outX, outY;
+    calib.applyRotation(100, 50, outX, outY);
+    
+    TEST_ASSERT_EQUAL_INT16(50, outX);          // y
+    TEST_ASSERT_EQUAL_INT16(320 - 100, outY);   // width - x
+}
+
+void test_touch_calibration_set_rotation(void) {
+    TouchCalibration calib;
+    
+    calib.setRotation(TouchRotation::Rotation90);
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation90),
+                            static_cast<uint8_t>(calib.rotation));
+    
+    calib.setRotation(TouchRotation::Rotation180);
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation180),
+                            static_cast<uint8_t>(calib.rotation));
+}
+
+void test_touch_calibration_inverted_rotation_0(void) {
+    TouchCalibration calib;
+    calib.rotation = TouchRotation::Rotation0;
+    
+    TouchRotation inv = calib.inverted();
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation0),
+                            static_cast<uint8_t>(inv));
+}
+
+void test_touch_calibration_inverted_rotation_90(void) {
+    TouchCalibration calib;
+    calib.rotation = TouchRotation::Rotation90;
+    
+    TouchRotation inv = calib.inverted();
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation270),
+                            static_cast<uint8_t>(inv));
+}
+
+void test_touch_calibration_inverted_rotation_180(void) {
+    TouchCalibration calib;
+    calib.rotation = TouchRotation::Rotation180;
+    
+    TouchRotation inv = calib.inverted();
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation180),
+                            static_cast<uint8_t>(inv));
+}
+
+void test_touch_calibration_inverted_rotation_270(void) {
+    TouchCalibration calib;
+    calib.rotation = TouchRotation::Rotation270;
+    
+    TouchRotation inv = calib.inverted();
+    TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>(TouchRotation::Rotation90),
+                            static_cast<uint8_t>(inv));
+}
+
+void test_touch_calibration_preset_ili9341_320x240(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ILI9341_320x240);
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(1.05f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(1.10f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(-15, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(-20, calib.offsetY);
+}
+
+void test_touch_calibration_preset_st7789_240x320(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ST7789_240x320);
+    
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(0.9f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(0.9f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+}
+
+void test_touch_calibration_preset_st7789_240x240(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ST7789_240x240);
+    
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(0.88f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(0.88f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(10, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(10, calib.offsetY);
+}
+
+void test_touch_calibration_preset_st7735_128x160(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ST7735_128x160);
+    
+    TEST_ASSERT_EQUAL_INT16(128, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(160, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(0.65f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(0.65f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(10, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(25, calib.offsetY);
+}
+
+void test_touch_calibration_preset_st7735_128x128(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ST7735_128x128);
+    
+    TEST_ASSERT_EQUAL_INT16(128, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(128, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(0.62f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(0.62f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+}
+
+void test_touch_calibration_preset_ili9488_320x480(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::ILI9488_320x480);
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(480, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(1.08f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(1.08f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+}
+
+void test_touch_calibration_preset_gc9a01_240x240(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::GC9A01_240x240);
+    
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_FLOAT_EQUAL(0.90f, calib.scaleX);
+    TEST_ASSERT_FLOAT_EQUAL(0.90f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+}
+
+void test_touch_calibration_preset_none(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::None);
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetX);
+    TEST_ASSERT_EQUAL_INT16(0, calib.offsetY);
+}
+
+void test_touch_calibration_preset_custom(void) {
+    TouchCalibration calib = TouchCalibration::fromPreset(DisplayPreset::Custom);
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+}
+
+void test_touch_calibration_transform_with_rotation_90(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = 0;
+    calib.offsetY = 0;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation90;
+    
+    TouchPoint result = calib.transform(50, 100, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(240 - 100, result.x);  // height - y = 140
+    TEST_ASSERT_EQUAL_INT16(50, result.y);         // x = 50
+}
+
+void test_touch_calibration_transform_with_rotation_180(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    calib.offsetX = 0;
+    calib.offsetY = 0;
+    calib.displayWidth = 320;
+    calib.displayHeight = 240;
+    calib.rotation = TouchRotation::Rotation180;
+    
+    TouchPoint result = calib.transform(50, 100, true, 0, 1000);
+    
+    TEST_ASSERT_EQUAL_INT16(320 - 50, result.x);  // width - x = 270
+    TEST_ASSERT_EQUAL_INT16(240 - 100, result.y); // height - y = 140
+}
+
+void test_touch_calibration_transform_touch_id_preserved(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    
+    TouchPoint result = calib.transform(100, 50, true, 5, 1000);
+    
+    TEST_ASSERT_EQUAL_UINT8(5, result.id);
+}
+
+void test_touch_calibration_transform_timestamp_preserved(void) {
+    TouchCalibration calib;
+    calib.scaleX = 1.0f;
+    calib.scaleY = 1.0f;
+    
+    TouchPoint result = calib.transform(100, 50, true, 0, 12345678);
+    
+    TEST_ASSERT_EQUAL_UINT32(12345678, result.ts);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_touch_calibration_default_constructor);
+    RUN_TEST(test_touch_calibration_for_resolution_320x240);
+    RUN_TEST(test_touch_calibration_for_resolution_240x320);
+    RUN_TEST(test_touch_calibration_for_resolution_zero_dimensions);
+    RUN_TEST(test_touch_calibration_for_resolution_negative_dimensions);
+    
+    RUN_TEST(test_touch_calibration_transform_no_scale_no_offset);
+    RUN_TEST(test_touch_calibration_transform_with_scale);
+    RUN_TEST(test_touch_calibration_transform_with_offset);
+    RUN_TEST(test_touch_calibration_transform_combined_scale_and_offset);
+    RUN_TEST(test_touch_calibration_transform_not_pressed);
+    RUN_TEST(test_touch_calibration_transform_clamp_negative_to_zero);
+    RUN_TEST(test_touch_calibration_transform_clamp_positive_to_max);
+    RUN_TEST(test_touch_calibration_transform_with_rotation_90);
+    RUN_TEST(test_touch_calibration_transform_with_rotation_180);
+    RUN_TEST(test_touch_calibration_transform_touch_id_preserved);
+    RUN_TEST(test_touch_calibration_transform_timestamp_preserved);
+    
+    RUN_TEST(test_touch_calibration_apply_rotation_0);
+    RUN_TEST(test_touch_calibration_apply_rotation_90);
+    RUN_TEST(test_touch_calibration_apply_rotation_180);
+    RUN_TEST(test_touch_calibration_apply_rotation_270);
+    
+    RUN_TEST(test_touch_calibration_set_rotation);
+    
+    RUN_TEST(test_touch_calibration_inverted_rotation_0);
+    RUN_TEST(test_touch_calibration_inverted_rotation_90);
+    RUN_TEST(test_touch_calibration_inverted_rotation_180);
+    RUN_TEST(test_touch_calibration_inverted_rotation_270);
+    
+    RUN_TEST(test_touch_calibration_preset_ili9341_320x240);
+    RUN_TEST(test_touch_calibration_preset_st7789_240x320);
+    RUN_TEST(test_touch_calibration_preset_st7789_240x240);
+    RUN_TEST(test_touch_calibration_preset_st7735_128x160);
+    RUN_TEST(test_touch_calibration_preset_st7735_128x128);
+    RUN_TEST(test_touch_calibration_preset_ili9488_320x480);
+    RUN_TEST(test_touch_calibration_preset_gc9a01_240x240);
+    RUN_TEST(test_touch_calibration_preset_none);
+    RUN_TEST(test_touch_calibration_preset_custom);
+    
+    return UNITY_END();
+}

--- a/test/unit/test_uimanager/test_uimanager.cpp
+++ b/test/unit/test_uimanager/test_uimanager.cpp
@@ -1,0 +1,449 @@
+/**
+ * @file test_uimanager.cpp
+ * @brief Unit tests for graphics/ui/UIManager module
+ * @version 1.0
+ * @date 2026-04-05
+ * 
+ * Tests for UIManager - touch UI element registry and event routing.
+ */
+
+#include <unity.h>
+#include "../test_config.h"
+#include "graphics/ui/UIManager.h"
+#include "graphics/ui/UITouchElement.h"
+#include "input/TouchEvent.h"
+
+using namespace pixelroot32::graphics::ui;
+using namespace pixelroot32::input;
+
+class MockUITouchElement : public UITouchElement {
+public:
+    MockUITouchElement(int16_t x, int16_t y, uint16_t w, uint16_t h)
+        : UITouchElement(x, y, w, h, UIWidgetType::Button) {}
+    
+    bool processEvent(const TouchEvent& event) override {
+        (void)event;
+        return true;
+    }
+};
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+void test_uimanager_default_constructor(void) {
+    UIManager manager;
+    
+    TEST_ASSERT_EQUAL(0, manager.getElementCount());
+    TEST_ASSERT_EQUAL(16, manager.getMaxElements());
+    TEST_ASSERT_FALSE(manager.isFull());
+}
+
+void test_uimanager_add_element(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    
+    bool result = manager.addElement(&element);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL(1, manager.getElementCount());
+    TEST_ASSERT_FALSE(manager.isFull());
+}
+
+void test_uimanager_add_null_element(void) {
+    UIManager manager;
+    
+    bool result = manager.addElement(nullptr);
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_uimanager_add_duplicate_element(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    
+    manager.addElement(&element);
+    bool result = manager.addElement(&element);
+    
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL(1, manager.getElementCount());
+}
+
+void test_uimanager_is_full(void) {
+    UIManager manager;
+    
+    for (int i = 0; i < 16; i++) {
+        auto* elem = new MockUITouchElement(i * 10, 0, 50, 50);
+        manager.addElement(elem);
+    }
+    
+    TEST_ASSERT_TRUE(manager.isFull());
+    TEST_ASSERT_EQUAL(16, manager.getElementCount());
+}
+
+void test_uimanager_find_free_slot_empty(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    auto* elem = manager.getElementAt(0);
+    TEST_ASSERT_NOT_NULL(elem);
+}
+
+void test_uimanager_get_element_invalid_id(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    auto* elem = manager.getElement(200);
+    TEST_ASSERT_NULL(elem);
+}
+
+void test_uimanager_remove_by_id(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    uint8_t id = element.getWidgetData().id;
+    bool result = manager.removeElement(id);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL(0, manager.getElementCount());
+}
+
+void test_uimanager_remove_by_id_not_found(void) {
+    UIManager manager;
+    
+    bool result = manager.removeElement(200);
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_uimanager_remove_by_widget(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    bool result = manager.removeElement(&element.getWidgetData());
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL(0, manager.getElementCount());
+}
+
+void test_uimanager_remove_by_null_widget(void) {
+    UIManager manager;
+    
+    bool result = manager.removeElement(static_cast<UITouchWidget*>(nullptr));
+    
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_uimanager_clear(void) {
+    UIManager manager;
+    MockUITouchElement element1(0, 0, 100, 50);
+    MockUITouchElement element2(100, 0, 100, 50);
+    manager.addElement(&element1);
+    manager.addElement(&element2);
+    
+    TEST_ASSERT_EQUAL(2, manager.getElementCount());
+    
+    manager.clear();
+    
+    TEST_ASSERT_EQUAL(0, manager.getElementCount());
+    TEST_ASSERT_FALSE(manager.isFull());
+}
+
+void test_uimanager_process_events_empty(void) {
+    UIManager manager;
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 10;
+    event.y = 10;
+    
+    uint8_t count = manager.processEvents(&event, 1);
+    
+    TEST_ASSERT_EQUAL(0, count);
+}
+
+void test_uimanager_process_touch_down_no_hit(void) {
+    UIManager manager;
+    MockUITouchElement element(100, 100, 50, 50);
+    manager.addElement(&element);
+    
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 10;
+    event.y = 10;
+    
+    uint8_t count = manager.processEvents(&event, 1);
+    
+    TEST_ASSERT_EQUAL(0, count);
+}
+
+void test_uimanager_process_touch_down_hit(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 50;
+    event.y = 25;
+    
+    uint8_t count = manager.processEvents(&event, 1);
+    
+    TEST_ASSERT_EQUAL(1, count);
+}
+
+void test_uimanager_captured_widget_after_touch_down(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 50;
+    event.y = 25;
+    manager.processEvents(&event, 1);
+    
+    auto* captured = manager.getCapturedWidget();
+    TEST_ASSERT_NOT_NULL(captured);
+}
+
+void test_uimanager_capture_cleared_on_touch_up(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent down;
+    down.setType(TouchEventType::TouchDown);
+    down.x = 50;
+    down.y = 25;
+    manager.processEvents(&down, 1);
+    
+    TEST_ASSERT_NOT_NULL(manager.getCapturedWidget());
+    
+    TouchEvent up;
+    up.setType(TouchEventType::TouchUp);
+    up.x = 50;
+    up.y = 25;
+    manager.processEvents(&up, 1);
+    
+    TEST_ASSERT_NULL(manager.getCapturedWidget());
+}
+
+void test_uimanager_get_hover_widget(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    manager.updateHover(50, 25);
+    
+    auto* hover = manager.getHoverWidget();
+    TEST_ASSERT_NOT_NULL(hover);
+}
+
+void test_uimanager_update_hover_no_hit(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    manager.updateHover(500, 500);
+    
+    TEST_ASSERT_NULL(manager.getHoverWidget());
+}
+
+void test_uimanager_clear_consume_flags(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 50;
+    event.y = 25;
+    manager.processEvents(&event, 1);
+    
+    manager.clearConsumeFlags();
+    
+    TEST_ASSERT_TRUE(true);
+}
+
+void test_uimanager_release_capture(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent down;
+    down.setType(TouchEventType::TouchDown);
+    down.x = 50;
+    down.y = 25;
+    manager.processEvents(&down, 1);
+    
+    TEST_ASSERT_NOT_NULL(manager.getCapturedWidget());
+    
+    manager.releaseCapture();
+    
+    TEST_ASSERT_NULL(manager.getCapturedWidget());
+}
+
+void test_uimanager_remove_clears_captured_widget(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent down;
+    down.setType(TouchEventType::TouchDown);
+    down.x = 50;
+    down.y = 25;
+    manager.processEvents(&down, 1);
+    
+    TEST_ASSERT_NOT_NULL(manager.getCapturedWidget());
+    
+    uint8_t id = element.getWidgetData().id;
+    manager.removeElement(id);
+    
+    TEST_ASSERT_NULL(manager.getCapturedWidget());
+}
+
+void test_uimanager_get_elements_array(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    auto** elements = manager.getElements();
+    TEST_ASSERT_NOT_NULL(elements);
+    TEST_ASSERT_EQUAL(&element, elements[0]);
+}
+
+void test_uimanager_process_event_single(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent event;
+    event.setType(TouchEventType::TouchDown);
+    event.x = 50;
+    event.y = 25;
+    
+    bool result = manager.processEvent(event);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_uimanager_drag_events_routed_to_captured(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent down;
+    down.setType(TouchEventType::TouchDown);
+    down.x = 50;
+    down.y = 25;
+    manager.processEvents(&down, 1);
+    
+    TouchEvent drag;
+    drag.setType(TouchEventType::DragMove);
+    drag.x = 60;
+    drag.y = 30;
+    uint8_t count = manager.processEvents(&drag, 1);
+    
+    TEST_ASSERT_EQUAL(1, count);
+}
+
+void test_uimanager_drag_end_clears_capture(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    TouchEvent down;
+    down.setType(TouchEventType::TouchDown);
+    down.x = 50;
+    down.y = 25;
+    manager.processEvents(&down, 1);
+    
+    TEST_ASSERT_NOT_NULL(manager.getCapturedWidget());
+    
+    TouchEvent dragEnd;
+    dragEnd.setType(TouchEventType::DragEnd);
+    dragEnd.x = 50;
+    dragEnd.y = 25;
+    manager.processEvents(&dragEnd, 1);
+    
+    TEST_ASSERT_NULL(manager.getCapturedWidget());
+}
+
+void test_uimanager_out_of_range_index(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    auto* elem = manager.getElementAt(99);
+    TEST_ASSERT_NULL(elem);
+}
+
+void test_uimanager_get_element_at(void) {
+    UIManager manager;
+    MockUITouchElement element(0, 0, 100, 50);
+    manager.addElement(&element);
+    
+    auto* elem = manager.getElementAt(0);
+    TEST_ASSERT_NOT_NULL(elem);
+    TEST_ASSERT_EQUAL(&element, elem);
+}
+
+void test_uimanager_id_wrapping(void) {
+    UIManager manager;
+    
+    MockUITouchElement element1(0, 0, 50, 50);
+    manager.addElement(&element1);
+    uint8_t id1 = element1.getWidgetData().id;
+    
+    manager.clear();
+    
+    MockUITouchElement element2(0, 0, 50, 50);
+    manager.addElement(&element2);
+    uint8_t id2 = element2.getWidgetData().id;
+    
+    TEST_ASSERT_NOT_EQUAL(id1, id2);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_uimanager_default_constructor);
+    RUN_TEST(test_uimanager_add_element);
+    RUN_TEST(test_uimanager_add_null_element);
+    RUN_TEST(test_uimanager_add_duplicate_element);
+    RUN_TEST(test_uimanager_is_full);
+    RUN_TEST(test_uimanager_find_free_slot_empty);
+    RUN_TEST(test_uimanager_get_element_invalid_id);
+    RUN_TEST(test_uimanager_remove_by_id);
+    RUN_TEST(test_uimanager_remove_by_id_not_found);
+    RUN_TEST(test_uimanager_remove_by_widget);
+    RUN_TEST(test_uimanager_remove_by_null_widget);
+    RUN_TEST(test_uimanager_clear);
+    RUN_TEST(test_uimanager_process_events_empty);
+    RUN_TEST(test_uimanager_process_touch_down_no_hit);
+    RUN_TEST(test_uimanager_process_touch_down_hit);
+    RUN_TEST(test_uimanager_captured_widget_after_touch_down);
+    RUN_TEST(test_uimanager_capture_cleared_on_touch_up);
+    RUN_TEST(test_uimanager_get_hover_widget);
+    RUN_TEST(test_uimanager_update_hover_no_hit);
+    RUN_TEST(test_uimanager_clear_consume_flags);
+    RUN_TEST(test_uimanager_release_capture);
+    RUN_TEST(test_uimanager_remove_clears_captured_widget);
+    RUN_TEST(test_uimanager_get_elements_array);
+    RUN_TEST(test_uimanager_process_event_single);
+    RUN_TEST(test_uimanager_drag_events_routed_to_captured);
+    RUN_TEST(test_uimanager_drag_end_clears_capture);
+    RUN_TEST(test_uimanager_out_of_range_index);
+    RUN_TEST(test_uimanager_get_element_at);
+    RUN_TEST(test_uimanager_id_wrapping);
+    
+    return UNITY_END();
+}

--- a/test/unit/test_xpt2046_adapter/test_xpt2046_adapter.cpp
+++ b/test/unit/test_xpt2046_adapter/test_xpt2046_adapter.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file test_xpt2046_adapter.cpp
+ * @brief Unit tests for input/adapters/XPT2046Adapter module
+ * @version 1.0
+ * @date 2026-04-05
+ * 
+ * Tests for XPT2046Adapter - SPI touch controller driver.
+ * 
+ * NOTE: This adapter has heavy hardware dependencies (SPI, GPIO).
+ * These tests verify static configuration and constants only.
+ * Full functionality requires ESP32 hardware or extensive SPI mocks.
+ */
+
+#include <unity.h>
+#include "../test_config.h"
+#include "input/adapters/XPT2046Adapter.h"
+
+using namespace pixelroot32::input;
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+void test_xpt2046_spi_clock_hz(void) {
+    TEST_ASSERT_EQUAL(2500000U, XPT2046Adapter::SPI_CLOCK_HZ);
+}
+
+void test_xpt2046_chip_select_pin(void) {
+    TEST_ASSERT_EQUAL(5, XPT2046Adapter::CHIP_SELECT_PIN);
+}
+
+void test_xpt2046_irq_pin(void) {
+    TEST_ASSERT_EQUAL(4, XPT2046Adapter::IRQ_PIN);
+}
+
+void test_xpt2046_uses_spi(void) {
+    TEST_ASSERT_TRUE(XPT2046Adapter::USES_SPI);
+}
+
+void test_xpt2046_register_x(void) {
+    TEST_ASSERT_EQUAL(0x10, XPT2046Adapter::REG_X);
+}
+
+void test_xpt2046_register_y(void) {
+    TEST_ASSERT_EQUAL(0x50, XPT2046Adapter::REG_Y);
+}
+
+void test_xpt2046_register_z1(void) {
+    TEST_ASSERT_EQUAL(0x30, XPT2046Adapter::REG_Z1);
+}
+
+void test_xpt2046_register_z2(void) {
+    TEST_ASSERT_EQUAL(0x70, XPT2046Adapter::REG_Z2);
+}
+
+void test_xpt2046_calibration_default(void) {
+    TouchCalibration calib = XPT2046Adapter::calibration;
+    
+    TEST_ASSERT_EQUAL_INT16(320, calib.displayWidth);
+    TEST_ASSERT_EQUAL_INT16(240, calib.displayHeight);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleX);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, calib.scaleY);
+}
+
+void test_xpt2046_is_initialized_default(void) {
+    TEST_ASSERT_FALSE(XPT2046Adapter::isInitialized);
+}
+
+void test_xpt2046_was_pressed_default(void) {
+    TEST_ASSERT_FALSE(XPT2046Adapter::wasPressed);
+}
+
+void test_xpt2046_last_press_time_default(void) {
+    TEST_ASSERT_EQUAL(0U, XPT2046Adapter::lastPressTime);
+}
+
+void test_xpt2046_last_read_time_default(void) {
+    TEST_ASSERT_EQUAL(0U, XPT2046Adapter::lastReadTime);
+}
+
+void test_xpt2046_median_index_default(void) {
+    TEST_ASSERT_EQUAL(0, XPT2046Adapter::medianIndex);
+}
+
+void test_xpt2046_median_filter_array_size(void) {
+    TEST_ASSERT_EQUAL(5U, sizeof(XPT2046Adapter::medianX) / sizeof(int16_t));
+    TEST_ASSERT_EQUAL(5U, sizeof(XPT2046Adapter::medianY) / sizeof(int16_t));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_xpt2046_spi_clock_hz);
+    RUN_TEST(test_xpt2046_chip_select_pin);
+    RUN_TEST(test_xpt2046_irq_pin);
+    RUN_TEST(test_xpt2046_uses_spi);
+    RUN_TEST(test_xpt2046_register_x);
+    RUN_TEST(test_xpt2046_register_y);
+    RUN_TEST(test_xpt2046_register_z1);
+    RUN_TEST(test_xpt2046_register_z2);
+    RUN_TEST(test_xpt2046_calibration_default);
+    RUN_TEST(test_xpt2046_is_initialized_default);
+    RUN_TEST(test_xpt2046_was_pressed_default);
+    RUN_TEST(test_xpt2046_last_press_time_default);
+    RUN_TEST(test_xpt2046_last_read_time_default);
+    RUN_TEST(test_xpt2046_median_index_default);
+    RUN_TEST(test_xpt2046_median_filter_array_size);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
Add comprehensive unit tests for XPT2046Adapter, InputManager, StaticTilemapLayerCache, UIManager, and TouchCalibration modules. These tests verify configuration constants, state management, touch event processing, and calibration transformations. Also update CI coverage exclusion list to reflect new test files.