### PR TITLE
refactor(audio): implement NES-style deterministic noise and performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PixelRoot32 is not the product of a traditional electronics expert or a large en
 
 It was born from curiosity, experimentation, and a deep love for retro games from the 90s.
 
-Coming from a mobile development background with limited experience in C++, this project represents a leap into embedded systems. What made that possible is how accessible knowledge has become today — especially with the help of AI, lowering the barrier to building complex systems.
+Coming from a mobile development background with limited experience in C++, this project represents a leap into embedded systems. This was made possible by how accessible knowledge has become today—especially with AI-assisted tools lowering the barrier to building complex systems.
 
 PixelRoot32 is a reflection of that shift: exploring new domains driven by curiosity rather than specialization.
 

--- a/docs/ENGINE_PHILOSOPHY.md
+++ b/docs/ENGINE_PHILOSOPHY.md
@@ -6,7 +6,7 @@ It was born from curiosity, experimentation, and a deep love for retro games fro
 
 The journey started with a simple Raspberry Pi Zero project (PiGRRL Zero), exploring how far limited hardware could go. From there, the challenge evolved: rendering small games, experimenting with engines like Godot under constraints, and eventually discovering the ESP32 as a surprisingly capable platform for game development.
 
-Coming from a mobile development background with limited experience in C++, this project represents a leap into a different domain. What made that leap possible is how accessible knowledge has become today — especially with the help of AI, which significantly lowers the barrier to learning and building complex systems. PixelRoot32 is, in many ways, a reflection of that shift: the ability to explore new fields driven by curiosity rather than formal specialization.
+Coming from a mobile development background with limited experience in C++, this project represents a leap into a different domain. That leap was made possible by how accessible knowledge has become today—especially through AI-assisted tools that lower the barrier to learning and building complex systems. PixelRoot32, in many ways, reflects that shift: the ability to explore new fields driven by curiosity rather than formal specialization.
 
 PixelRoot32 exists as a personal exploration of what is possible when passion meets constraints.
 

--- a/docs/architecture/ARCH_AUDIO_SUBSYSTEM.md
+++ b/docs/architecture/ARCH_AUDIO_SUBSYSTEM.md
@@ -72,15 +72,19 @@ struct AudioChannel {
     float volume = 0.0f;
     float targetVolume = 0.0f;
     float dutyCycle = 0.5f;
-    uint16_t noiseRegister = 1;
-    unsigned long durationMs = 0;
-    unsigned long remainingMs = 0;
+    uint16_t noiseRegister = 1;         // Deprecated: legacy noise register
+    uint16_t lfsrState = 0x4000;        // NES-style 15-bit LFSR for deterministic noise
+
+    // Duration control (sample-accurate timing)
+    uint64_t remainingSamples = 0;
 
     void reset() {
         enabled = false;
         phase = 0.0f;
         volume = 0.0f;
-        remainingMs = 0;
+        remainingSamples = 0;
+        noiseRegister = 1;
+        lfsrState = 0x4000;
     }
 };
 ```
@@ -165,10 +169,12 @@ Important:
      - First half: `0 → 0.5` rises from -1 to +1.
      - Second half: `0.5 → 1.0` falls from +1 to -1.
 3. `NOISE`:
-   - Simple noise using `noiseRegister`:
-   - On each phase wrap (when `phase` resets) it updates:
-     - `noiseRegister = rand() & 0xFFFF;`
+   - NES-style 15-bit LFSR noise using `lfsrState`:
+   - Updates every sample (44,100 times/sec at 44.1kHz):
+     - `feedback = ((lfsrState & 1) ^ ((lfsrState >> 1) & 1));`
+     - `lfsrState = (lfsrState >> 1) | (feedback << 14);`
    - The least significant bit decides the sign of the sample.
+   - Deterministic: same input always produces same noise pattern.
 
 After computing the base value:
 
@@ -333,8 +339,9 @@ The engine provides two distinct backends for ESP32, allowing developers to choo
 - **Use case**: Retro audio using the ESP32's **internal 8-bit DAC** (GPIO 25 or 26), either
   driving a small speaker directly or feeding a simple amplifier like **PAM8302A**.
 - **Key points**:
-- Uses the ESP32 DAC driver (`dac_output_voltage`) for 0–255 output values.
+- Uses `dacWrite()` for direct register access (faster than `dac_output_voltage`).
 - **Software Mode**: Samples are pushed from a dedicated FreeRTOS task. (I2S-DMA mode is not supported due to hardware instability).
+- **Optimized**: Removed redundant delay for lower latency.
 - **Attenuation**: Includes a **0.7x** scale to prevent saturation on sensitive amplifiers like the PAM8302A.
 - **Limitations**:
   - 8-bit resolution (inherent background noise).
@@ -637,16 +644,17 @@ With the **Multi-Core Architecture (v0.7.0-dev)**, many previous limitations wer
 ### 8.2 Remaining Limitations
 
 - No exact cycle-accurate emulation of the NES APU.
-- **Noise Generator**: Still uses a simplified `rand()`-based approach instead of a precise deterministic LFSR.
 - **Pitch Sweeps**: Frequency slides (pitch slides) are not yet implemented.
 - **Complex Envelopes**: ADSR or complex multi-point envelopes are not supported (only linear interpolation).
+- **Music Sequencer**: Has note limit (MAX_NOTES_PER_FRAME = 8) to prevent CPU spikes, may skip notes when audio thread falls behind.
 
 ### 8.3 Future Extensions
 
-- **Deterministic LFSR**: Replace `rand()` with a proper 15-bit LFSR for authentic NES noise sounds.
+- ~~**Deterministic LFSR**~~: ✅ Implemented - NES-style 15-bit LFSR with taps at bits 0 and 1.
 - **Frequency Sweeps**: Add `frequencyDelta` to the scheduler for pitch slides.
 - **High-Level SFX Helpers**: Add methods like `playJumpSfx()`, `playExplosionSfx()` to `AudioEngine` for easier use.
 - **Advanced Music Tooling**: Better support for patterns and multi-track sequencing in the `MusicPlayer`.
+- **SIMD Optimizations**: Investigate SSE/AVX for native platforms and DSP instructions for ESP32-S3 (see research document).
 
 ---
 

--- a/docs/architecture/ARCH_AUDIO_SUBSYSTEM.md
+++ b/docs/architecture/ARCH_AUDIO_SUBSYSTEM.md
@@ -28,9 +28,10 @@ high-level architecture and the concrete implementation details.
 - Software mixing into a **mono** 16-bit (`int16_t`) stream.
 - **Event-driven** model: games fire short-lived `AudioEvent` instances (SFX, notes).
 - **Conditionally compiled**: Entire subsystem can be excluded with `PIXELROOT32_ENABLE_AUDIO=0` to save firmware size and RAM.
-- Fully **platform-agnostic** core:
-  - Wave, mixing, and timing logic lives in `AudioEngine`.
-  - Backends (SDL2, ESP32 I2S/DAC) only request PCM blocks.
+- **Platform-agnostic API** with concrete work split as follows:
+  - [`AudioEngine`](include/audio/AudioEngine.h) is a thin facade: it forwards `playEvent` / `setMasterVolume` as commands and delegates `generateSamples` to an `AudioScheduler`.
+  - **Mixing, channel state, and music sequencing** live inside scheduler implementations (see §4.1).
+  - Backends (SDL2, ESP32 I2S/DAC) pull PCM by calling `AudioEngine::generateSamples` from their callback or audio task.
 
 Main files:
 
@@ -99,8 +100,10 @@ Key characteristics:
   - `durationSamples` and `remainingSamples`:
   - Control the lifetime of each sound event in absolute sample counts.
   - Managed by the `AudioScheduler` during sample generation.
-- `noiseRegister`:
-  - Used as internal state for the noise channel.
+- `noiseRegister` / `lfsrState` / **`noisePeriodSamples` / `noiseCountdown`**:
+  - **`DefaultAudioScheduler`**: LFSR advanced **every output sample** (§3.3).
+  - **`ESP32AudioScheduler`**: same LFSR polynomial but **clocked** using `noisePeriodSamples` / `noiseCountdown` (§3.3).
+  - **`NativeAudioScheduler`**: `NOISE` still uses **`rand()`** + `noiseRegister` (§3.3).
 
 ### 2.3 AudioEvent
 
@@ -129,13 +132,13 @@ Defined in [`AudioEngine.h`](include/audio/AudioEngine.h) and
 
 ### 3.1 Channel initialization
 
-In the constructor:
+Channel arrays are owned by each `AudioScheduler` implementation, not by `AudioEngine`. On construction / `init`, schedulers assign:
 
 - `channels[0]` and `channels[1]` → `WaveType::PULSE`
 - `channels[2]` → `WaveType::TRIANGLE`
 - `channels[3]` → `WaveType::NOISE`
 
-Each channel is reset by calling `reset()`.
+Each channel is reset by calling `AudioChannel::reset()`.
 
 **Note**: This entire subsystem is only compiled when `PIXELROOT32_ENABLE_AUDIO=1`.
 
@@ -156,51 +159,31 @@ Important:
 
 ### 3.3 Per-channel sample generation
 
-`int16_t AudioEngine::generateSampleForChannel(AudioChannel& ch)`:
-
-- If the channel is disabled, returns `0`.
-- Depending on `ch.type`:
+Oscillator work is done inside each scheduler’s `generateSampleForChannel(AudioChannel& ch)` (naming matches the implementation). If the channel is disabled, the contribution is `0`.
 
 1. `PULSE`:
    - Square wave with duty cycle:
      - `sample = (phase < dutyCycle) ? 1.0f : -1.0f;`
 2. `TRIANGLE`:
-   - Approximate triangle wave in the range `[-1, 1]`:
-     - First half: `0 → 0.5` rises from -1 to +1.
-     - Second half: `0.5 → 1.0` falls from +1 to -1.
-3. `NOISE`:
-   - NES-style 15-bit LFSR noise using `lfsrState`:
-   - Updates every sample (44,100 times/sec at 44.1kHz):
+   - Triangle wave in `[-1, 1]`:
+     - First half of phase: rise from -1 to +1; second half: fall from +1 to -1.
+3. `NOISE` (implementation-dependent):
+   - **[`DefaultAudioScheduler`](src/audio/DefaultAudioScheduler.cpp)** (and the same pattern in tests driven by it): NES-style **15-bit LFSR** using `lfsrState`, advanced every sample:
      - `feedback = ((lfsrState & 1) ^ ((lfsrState >> 1) & 1));`
      - `lfsrState = (lfsrState >> 1) | (feedback << 14);`
-   - The least significant bit decides the sign of the sample.
-   - Deterministic: same input always produces same noise pattern.
+     - Sign from the LSB. **Deterministic** for a given initial state.
+   - **[`ESP32AudioScheduler`](src/audio/ESP32AudioScheduler.cpp)**: same 15-bit LFSR polynomial, but **clocked in software** at `sampleRate / frequency` (minimum one sample per step). `AudioEvent::frequency` for `NOISE` sets the **noise clock / coarseness** (NES-like hit vs static), not a musical pitch. State: `noisePeriodSamples`, `noiseCountdown` on [`AudioChannel`](include/audio/AudioTypes.h).
+   - **[`NativeAudioScheduler`](src/drivers/native/NativeAudioScheduler.cpp)**: `NOISE` still uses **`rand()`** + `noiseRegister` (not identical to ESP32 firmware).
 
-After computing the base value:
+After the waveform sample is computed:
 
-- Phase is advanced:
-
-```cpp
-ch.phase += ch.phaseIncrement;
-if (ch.phase >= 1.0f) {
-    ch.phase -= 1.0f;
-}
-```
-
-- Volume and the global master volume are applied and the result is scaled to `int16_t`:
-
-```cpp
-return (int16_t)(sample * ch.volume * masterVolume * 12000.0f);
-```
-
-- `ch.volume` is the per-event/channel volume in the range `[0.0f, 1.0f]`.
-- `masterVolume` is a global scalar configured via `setMasterVolume` (also `[0.0f, 1.0f]`).
-- The `12000.0f` factor gives a strong output on low-amplitude backends like the ESP32 DAC,
-  while the mixer still applies hard clipping after summing all channels.
+- Phase is advanced: `ch.phase += ch.phaseIncrement;` then wrap in `[0, 1)` (on ESP32, `NOISE` skips phase advance and uses `noiseCountdown` only).
+- Channel volume is applied as `sample * ch.volume` (and optional linear volume interpolation when `volumeDelta` is non-zero).
+- **Master volume** and **per-channel scaling (0.4×)** and **non-linear mix** are applied in `generateSamples`, not inside `generateSampleForChannel` (see §3.4). Legacy docs sometimes cited a `12000.0f` scale; current schedulers use the §3.4 mixer (`0.4` per-channel gain, soft saturation, then scale toward full `int16_t` range).
 
 ### 3.4 Mixing all channels (Non-Linear Mixer)
 
-`void AudioEngine::generateSamples(int16_t* stream, int length)`:
+`AudioEngine::generateSamples` forwards to the active `AudioScheduler::generateSamples(int16_t* stream, int length)`.
 
 The system uses a **non-linear mixing strategy** that adapts to the underlying hardware to maximize volume and quality while preventing digital clipping.
 
@@ -230,13 +213,21 @@ The asymptotic nature of the curve ensures that the output **never** exceeds the
 
 `void AudioEngine::playEvent(const AudioEvent& event)`:
 
-- Now acts as a **Command Producer**.
-- It enqueues an `AudioCommand` into a lock-free **Single Producer / Single Consumer (SPSC)** queue.
-- The `AudioScheduler` (running on Core 0 or a separate thread) consumes this command and:
-  - Looks for a free channel of the requested type (`WaveType`).
-  - Applies **voice stealing** if necessary (using the channel with the smallest `remainingSamples`).
-  - Converts the event's duration (seconds) into `remainingSamples` based on the current sample rate.
-  - Initializes the channel state (`enabled`, `frequency`, `phase`, `volume`, etc.).
+- Acts as a **Command Producer**.
+- It enqueues an `AudioCommand` into a lock-free **Single Producer / Single Consumer (SPSC)** ring buffer ([`AudioCommandQueue`](include/audio/AudioCommandQueue.h), capacity **128** entries).
+- The **audio consumer** (scheduler thread / ESP32 audio task / SDL callback path) dequeues and applies commands.
+
+**Queue contract and overflow**
+
+- The implementation is only safe with **one producer** and **one consumer**. Do not call `playEvent` / `submitCommand` from multiple threads unless you replace the queue with an MPMC-safe structure.
+- If the queue is **full**, `enqueue` **drops the newest command** and returns `false`. On **ESP32**, [`ESP32AudioScheduler::submitCommand`](src/audio/ESP32AudioScheduler.cpp) increments an atomic drop counter and may emit a throttled warning when `PIXELROOT32_DEBUG_MODE` is enabled. Other schedulers may still ignore the return value; avoid flooding more than ~127 outstanding commands between consumer passes.
+
+The scheduler then:
+
+- Looks for a free channel of the requested type (`WaveType`).
+- Applies **voice stealing** if necessary (using the channel with the smallest `remainingSamples`).
+- Converts the event's duration (seconds) into `remainingSamples` based on the current sample rate.
+- Initializes the channel state (`enabled`, `frequency`, `phase`, `volume`, etc.).
 
 ---
 
@@ -253,10 +244,15 @@ The `AudioScheduler` is the heart of the decoupled audio system. It:
 - Performs the actual software mixing (`generateSamples`).
 - Handles music sequencing (notes, durations, loops).
 
-There are two main implementations:
+There are **three** runtime-relevant implementations:
 
-- **`NativeAudioScheduler`**: Used for SDL2. Runs in a dedicated high-priority thread.
-- **`ESP32AudioScheduler`**: Used for ESP32. Runs as a pinned FreeRTOS task.
+| Scheduler | Typical use | Where mixing runs |
+|-----------|-------------|-------------------|
+| **`NativeAudioScheduler`** | SDL2 / `PLATFORM_NATIVE` | Dedicated `std::thread`; PCM is written to a ring buffer; SDL callback reads via `AudioEngine::generateSamples`. |
+| **`ESP32AudioScheduler`** | ESP32 firmware | Same **CPU context** as the backend’s audio task: the backend (e.g. I2S) creates a FreeRTOS task and calls `engine->generateSamples`, which runs the ESP32 scheduler’s mixer. |
+| **`DefaultAudioScheduler`** | `UNIT_TEST`, or builds without the above | Mixing runs **in whatever thread** invokes `generateSamples` (often the backend callback); no dedicated audio thread. |
+
+The header comment on `ESP32AudioScheduler` mentions a FreeRTOS task; in current wiring, **task creation lives in the ESP32 audio backends** ([`ESP32_I2S_AudioBackend`](src/drivers/esp32/ESP32_I2S_AudioBackend.cpp), DAC backend), not in `ESP32AudioScheduler::start()`.
 
 #### 4.1.1 Platform-Agnostic Core Management
 
@@ -284,7 +280,7 @@ The audio system behavior can be customized via `platforms/PlatformDefaults.h` o
 | `PIXELROOT32_USE_U8G2` | Enables support for the U8G2 display driver (future support). |
 | `PIXELROOT32_NO_TFT_ESPI` | Disables the default TFT_eSPI display driver. |
 
-### 6.3 Audio Backends
+### 4.3 Audio Backends (interface)
 
 Backends implement the abstract `AudioBackend` interface:
 
@@ -299,7 +295,7 @@ public:
 
 **Note**: Audio backends are only compiled and available when `PIXELROOT32_ENABLE_AUDIO=1`.
 
-### 4.1 SDL2 backend (Windows / Linux / Mac)
+### 4.4 SDL2 backend (Windows / Linux / Mac)
 
 Implemented in:
 
@@ -317,7 +313,7 @@ Key points:
 
 This completely decouples **audio timing** from the SDL2 game loop.
 
-### 4.2 ESP32 Backends
+### 4.5 ESP32 Backends
 
 The engine provides two distinct backends for ESP32, allowing developers to choose between high-quality I2S (external DAC) or retro-style internal DAC.
 
@@ -359,7 +355,7 @@ The engine provides two distinct backends for ESP32, allowing developers to choo
 | **I2S** | LRCK | GPIO 25 | **MAX98357A**: LRC (WS) |
 | **I2S** | DOUT | GPIO 22 | **MAX98357A**: DIN |
 
-### 4.3 Backend Configuration (in `main.cpp`)
+### 4.6 Backend Configuration (in `main.cpp`)
 
 To select a backend, simply instantiate the desired class and pass it to the `AudioConfig` struct.
 
@@ -579,6 +575,11 @@ Defined in [`MusicPlayer.h`](include/audio/MusicPlayer.h) and
 - Uses **sample-accurate timing** instead of `deltaTime`.
 - Triggers internal audio events directly in the audio thread/core.
 
+**Platform difference (catch-up behavior):**
+
+- [`DefaultAudioScheduler`](src/audio/DefaultAudioScheduler.cpp) and [`ESP32AudioScheduler`](src/audio/ESP32AudioScheduler.cpp) cap how many notes can execute per audio quantum with **`MAX_NOTES_PER_FRAME` (8)**. If time skips ahead, remaining notes are advanced with a **catch-up loop** that may **skip playing** some notes to bound CPU (see §8.2).
+- [`NativeAudioScheduler`](src/drivers/native/NativeAudioScheduler.cpp) uses an **uncapped** `while` for overdue notes: a large lag can process many note transitions in one step (**higher CPU spike risk** on desktop than on ESP32 for the same lag).
+
 ### 7.3 Integration with Engine
 
 `MusicPlayer` is owned by `Engine` alongside `AudioEngine`:
@@ -625,8 +626,7 @@ void GeometryJumpScene::init() {
 ```
 
 - Music uses one `PULSE` channel; the remaining channels stay available for SFX.
-- Because `MusicPlayer` is frame-driven, the melody timing is stable even if FPS
-  varies.
+- Timing is **sample-accurate** in the scheduler, so melody playback does not depend on render FPS; game logic should still avoid assuming instant delivery of `enqueue`d commands if the audio queue overflows (§3.5).
 
 ---
 
@@ -646,11 +646,13 @@ With the **Multi-Core Architecture (v0.7.0-dev)**, many previous limitations wer
 - No exact cycle-accurate emulation of the NES APU.
 - **Pitch Sweeps**: Frequency slides (pitch slides) are not yet implemented.
 - **Complex Envelopes**: ADSR or complex multi-point envelopes are not supported (only linear interpolation).
-- **Music Sequencer**: Has note limit (MAX_NOTES_PER_FRAME = 8) to prevent CPU spikes, may skip notes when audio thread falls behind.
+- **Music Sequencer**: [`DefaultAudioScheduler`](src/audio/DefaultAudioScheduler.cpp) and [`ESP32AudioScheduler`](src/audio/ESP32AudioScheduler.cpp) use **`MAX_NOTES_PER_FRAME = 8`** to prevent CPU spikes when the audio clock jumps ahead; **some notes may be skipped** in that catch-up path. [`NativeAudioScheduler`](src/drivers/native/NativeAudioScheduler.cpp) does **not** use this cap (different tradeoff: see §7.2).
+- **Command queue**: Fixed depth (128); overflow drops the newest command; **ESP32** tracks drops atomically (§3.5). Intended **SPSC** use.
+- **`MusicPlayer` state**: The high-level `MusicPlayer` object caches `playing` / `paused` / track pointer on the game side; if a command is dropped, that cache can **disagree** with the scheduler until the next successful command.
 
 ### 8.3 Future Extensions
 
-- ~~**Deterministic LFSR**~~: ✅ Implemented - NES-style 15-bit LFSR with taps at bits 0 and 1.
+- **Unified deterministic NOISE (Native)**: Replace `rand()` in [`NativeAudioScheduler`](src/drivers/native/NativeAudioScheduler.cpp) with the same **clocked LFSR** model as ESP32 (or full-rate LFSR like `DefaultAudioScheduler`) so desktop and firmware match.
 - **Frequency Sweeps**: Add `frequencyDelta` to the scheduler for pitch slides.
 - **High-Level SFX Helpers**: Add methods like `playJumpSfx()`, `playExplosionSfx()` to `AudioEngine` for easier use.
 - **Advanced Music Tooling**: Better support for patterns and multi-track sequencing in the `MusicPlayer`.
@@ -666,4 +668,4 @@ With the **Multi-Core Architecture (v0.7.0-dev)**, many previous limitations wer
   - Is platform-agnostic thanks to the `AudioBackend` and `AudioScheduler` interfaces.
   - Is **decoupled** from the game loop, running on Core 0 (ESP32) or a separate thread (SDL2).
   - Uses **sample-accurate timing** for both SFX and music.
-  - Is controlled from games through `AudioEngine` (SFX) and `MusicPlayer` (Music) via a lock-free command queue.
+  - Is controlled from games through `AudioEngine` (SFX) and `MusicPlayer` (Music) via a **lock-free SPSC command queue** (bounded capacity; **overflow drops** the latest command; see §3.5).

--- a/examples/snake/src/platforms/native.h
+++ b/examples/snake/src/platforms/native.h
@@ -26,7 +26,7 @@ pr32::graphics::DisplayConfig config(
 
 pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
-pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
+pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 
 pr32::core::Engine engine(config, inputConfig, audioConfig);
 

--- a/include/audio/AudioTypes.h
+++ b/include/audio/AudioTypes.h
@@ -38,21 +38,19 @@ namespace pixelroot32::audio {
         
         // Wave specific parameters
         float dutyCycle = 0.5f;    // For Pulse wave [0.0 - 1.0]
-        uint16_t noiseRegister = 1; // LFSR for Noise
+        uint16_t noiseRegister = 1; // Deprecated: legacy noise register
+        uint16_t lfsrState = 0x4000; // NES-style 15-bit LFSR for deterministic noise
 
-        // Duration control
-        unsigned long durationMs = 0;
-        unsigned long remainingMs = 0; // Deprecated in Phase 2
-        
-        uint64_t remainingSamples = 0; // Sample-accurate duration
+        // Duration control (sample-accurate timing)
+        uint64_t remainingSamples = 0;
 
         void reset() {
             enabled = false;
             phase = 0.0f;
             volume = 0.0f;
-            remainingMs = 0;
             remainingSamples = 0;
             noiseRegister = 1;
+            lfsrState = 0x4000; // Initialize LFSR to non-zero state
         }
     };
 

--- a/include/audio/AudioTypes.h
+++ b/include/audio/AudioTypes.h
@@ -41,6 +41,11 @@ namespace pixelroot32::audio {
         uint16_t noiseRegister = 1; // Deprecated: legacy noise register
         uint16_t lfsrState = 0x4000; // NES-style 15-bit LFSR for deterministic noise
 
+        /** Samples until next LFSR step on NOISE; `frequency` sets noise clock rate (not pitch). */
+        uint32_t noisePeriodSamples = 1;
+        /** Counts down each output sample; at 0 the LFSR advances and reloads to noisePeriodSamples. */
+        uint32_t noiseCountdown = 0;
+
         // Duration control (sample-accurate timing)
         uint64_t remainingSamples = 0;
 
@@ -51,6 +56,8 @@ namespace pixelroot32::audio {
             remainingSamples = 0;
             noiseRegister = 1;
             lfsrState = 0x4000; // Initialize LFSR to non-zero state
+            noisePeriodSamples = 1;
+            noiseCountdown = 0;
         }
     };
 

--- a/include/audio/DefaultAudioScheduler.h
+++ b/include/audio/DefaultAudioScheduler.h
@@ -36,6 +36,7 @@ namespace pixelroot32::audio {
         
         int sampleRate = 44100;
         float masterVolume = 1.0f;
+        int32_t masterVolumeScale = 65536; // Pre-computed for LUT path (Q16 fixed-point)
         uint64_t audioTimeSamples = 0;
         bool running = false;
 
@@ -46,6 +47,16 @@ namespace pixelroot32::audio {
         float tempoFactor = 1.0f;
         bool musicPlaying = false;
         bool musicPaused = false;
+
+        // Sequencer limits to prevent CPU spikes
+        static constexpr int MAX_NOTES_PER_FRAME = 8;
+        uint32_t notesSkipped = 0;
+        uint32_t maxNotesProcessed = 0;
+
+        // Performance metrics (when profiling enabled)
+        uint64_t totalGenerateTimeUs = 0;
+        uint32_t generateSampleCount = 0;
+        uint32_t maxGenerateTimeUs = 0;
 
         void processCommands();
         void executePlayEvent(const AudioEvent& event);

--- a/include/drivers/esp32/ESP32AudioScheduler.h
+++ b/include/drivers/esp32/ESP32AudioScheduler.h
@@ -9,6 +9,7 @@
 #include "audio/AudioScheduler.h"
 #include "audio/AudioCommandQueue.h"
 #include "audio/AudioMusicTypes.h"
+#include <atomic>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -16,13 +17,15 @@ namespace pixelroot32::audio {
 
     /**
      * @class ESP32AudioScheduler
-     * @brief Audio scheduler pinned to a specific core on ESP32.
-     * 
-     * Uses a FreeRTOS task to process commands and generate samples.
+     * @brief Audio mixer and sequencer for ESP32; runs in the backend audio task.
+     *
+     * The I2S/DAC backend creates the FreeRTOS task and calls generateSamples(); this
+     * class does not spawn its own task. Constructor arguments are reserved for API
+     * stability (see PlatformCapabilities used by the backend).
      */
     class ESP32AudioScheduler : public AudioScheduler {
     public:
-        ESP32AudioScheduler(int coreId = 0, int priority = configMAX_PRIORITIES - 1);
+        ESP32AudioScheduler(int reservedCoreId = 0, int reservedTaskPriority = configMAX_PRIORITIES - 1);
         ~ESP32AudioScheduler();
 
         void init(AudioBackend* backend, int sampleRate, const pixelroot32::platforms::PlatformCapabilities& caps) override;
@@ -43,10 +46,9 @@ namespace pixelroot32::audio {
         int32_t masterVolumeScale = 65536; // Pre-computed for LUT path (Q16 fixed-point)
         uint64_t audioTimeSamples = 0;
         
-        int coreId;
-        int priority;
         TaskHandle_t taskHandle = nullptr;
         volatile bool running = false;
+        std::atomic<uint32_t> droppedCommands{0};
 
         // Music Sequencer State
         const MusicTrack* currentTrack = nullptr;
@@ -65,9 +67,6 @@ namespace pixelroot32::audio {
         uint64_t totalGenerateTimeUs = 0;
         uint32_t generateSampleCount = 0;
         uint32_t maxGenerateTimeUs = 0;
-
-        static void taskWrapper(void* arg);
-        void run();
 
         void processCommands();
         void executePlayEvent(const AudioEvent& event);

--- a/include/drivers/esp32/ESP32AudioScheduler.h
+++ b/include/drivers/esp32/ESP32AudioScheduler.h
@@ -40,6 +40,7 @@ namespace pixelroot32::audio {
         AudioBackend* backend = nullptr;
         int sampleRate = 44100;
         float masterVolume = 1.0f;
+        int32_t masterVolumeScale = 65536; // Pre-computed for LUT path (Q16 fixed-point)
         uint64_t audioTimeSamples = 0;
         
         int coreId;
@@ -54,6 +55,16 @@ namespace pixelroot32::audio {
         float tempoFactor = 1.0f;
         bool musicPlaying = false;
         bool musicPaused = false;
+
+        // Sequencer limits to prevent CPU spikes
+        static constexpr int MAX_NOTES_PER_FRAME = 8;
+        uint32_t notesSkipped = 0;
+        uint32_t maxNotesProcessed = 0;
+
+        // Performance metrics (when profiling enabled)
+        uint64_t totalGenerateTimeUs = 0;
+        uint32_t generateSampleCount = 0;
+        uint32_t maxGenerateTimeUs = 0;
 
         static void taskWrapper(void* arg);
         void run();

--- a/src/audio/AudioEngine.cpp
+++ b/src/audio/AudioEngine.cpp
@@ -14,7 +14,9 @@
 
 namespace pixelroot32::audio {
 
-    AudioEngine::AudioEngine(const AudioConfig& config, const pixelroot32::platforms::PlatformCapabilities& caps) 
+    namespace platforms = pixelroot32::platforms;
+
+    AudioEngine::AudioEngine(const AudioConfig& config, const platforms::PlatformCapabilities& caps) 
         : config(config), capabilities(caps) {
         #ifdef ESP32
                 scheduler = std::unique_ptr<ESP32AudioScheduler>(new ESP32AudioScheduler(caps.audioCoreId, caps.audioPriority));

--- a/src/audio/DefaultAudioScheduler.cpp
+++ b/src/audio/DefaultAudioScheduler.cpp
@@ -20,7 +20,8 @@
 #endif
 
 namespace pixelroot32::audio {
-
+    
+    namespace platforms = pixelroot32::platforms;
     namespace logging = pixelroot32::core::logging;
     using logging::LogLevel;
     using logging::log;
@@ -36,7 +37,7 @@ namespace pixelroot32::audio {
         }
     }
 
-    void DefaultAudioScheduler::init(AudioBackend* /*backend*/, int sampleRate, const pixelroot32::platforms::PlatformCapabilities& /*caps*/) {
+    void DefaultAudioScheduler::init(AudioBackend* /*backend*/, int sampleRate, const platforms::PlatformCapabilities& /*caps*/) {
         this->sampleRate = sampleRate;
     }
 
@@ -59,7 +60,16 @@ namespace pixelroot32::audio {
     void DefaultAudioScheduler::generateSamples(int16_t* stream, int length) {
         if (!stream || length <= 0) return;
 
-        processCommands();
+        // Performance timing (when profiling enabled)
+        uint32_t startTime = 0;
+        if constexpr (platforms::config::EnableProfiling) {
+            startTime = micros();
+        }
+
+        // Only process commands if queue is not empty to avoid atomic overhead
+        if (!commandQueue.isEmpty()) {
+            processCommands();
+        }
 
         // Advance music sequencer (Phase 3)
         updateMusicSequencer(length);
@@ -103,14 +113,15 @@ namespace pixelroot32::audio {
                 }
             }
 
-            if (masterVolume != 1.0f) {
-                sum = (int32_t)(sum * masterVolume);
+            // Apply master volume using pre-computed Q16 fixed-point scale
+            if (masterVolumeScale != 65536) {
+                sum = (sum * masterVolumeScale) >> 16;
             }
 
             int32_t index = (sum + 131072) >> 8;
             if (index < 0) index = 0;
             if (index > 1024) index = 1024;
-            
+
             int16_t finalSample = audio_mixer_lut[index];
             stream[i] = finalSample;
 
@@ -150,7 +161,7 @@ namespace pixelroot32::audio {
         static uint64_t totalSamplesProcessed = 0;
         totalSamplesProcessed += length;
         if (totalSamplesProcessed >= (uint64_t)sampleRate) { // Approx every second
-            if constexpr (pixelroot32::platforms::config::EnableProfiling) {
+            if constexpr (platforms::config::EnableProfiling) {
                 if (currentPeak > 32767.0f) {
                     log(LogLevel::Profiling, "[AUDIO] PEAK DETECTED: %.0f (CLIPPING!)", currentPeak);
                 } else {
@@ -162,6 +173,16 @@ namespace pixelroot32::audio {
         }
         
         audioTimeSamples += length;
+
+        // Performance timing (when profiling enabled)
+        if constexpr (platforms::config::EnableProfiling) {
+            uint32_t elapsed = micros() - startTime;
+            totalGenerateTimeUs += elapsed;
+            generateSampleCount++;
+            if (elapsed > maxGenerateTimeUs) {
+                maxGenerateTimeUs = elapsed;
+            }
+        }
     }
 
     void DefaultAudioScheduler::processCommands() {
@@ -175,6 +196,8 @@ namespace pixelroot32::audio {
                     masterVolume = cmd.volume;
                     if (masterVolume > 1.0f) masterVolume = 1.0f;
                     if (masterVolume < 0.0f) masterVolume = 0.0f;
+                    // Pre-compute for LUT path (Q16 fixed-point)
+                    masterVolumeScale = (int32_t)(masterVolume * 65536.0f);
                     break;
                 case AudioCommandType::STOP_CHANNEL:
                     if (cmd.channelIndex < NUM_CHANNELS) {
@@ -210,7 +233,28 @@ namespace pixelroot32::audio {
     void DefaultAudioScheduler::updateMusicSequencer(int /*length*/) {
         if (!musicPlaying || musicPaused || !currentTrack) return;
 
+        int notesProcessed = 0;
         while (musicPlaying && currentTrack && audioTimeSamples >= nextNoteSample) {
+            if (notesProcessed >= MAX_NOTES_PER_FRAME) {
+                notesSkipped++;
+                // Skip ahead to catch up without playing
+                while (audioTimeSamples >= nextNoteSample && musicPlaying && currentTrack) {
+                    const MusicNote& note = currentTrack->notes[currentNoteIndex];
+                    uint64_t noteDurationSamples = (uint64_t)((note.duration / tempoFactor) * (float)sampleRate);
+                    nextNoteSample += noteDurationSamples;
+                    currentNoteIndex++;
+                    if (currentNoteIndex >= currentTrack->count) {
+                        if (currentTrack->loop) {
+                            currentNoteIndex = 0;
+                        } else {
+                            musicPlaying = false;
+                            currentTrack = nullptr;
+                        }
+                    }
+                }
+                break;
+            }
+
             playCurrentNote();
 
             // Calculate when the next note should play
@@ -228,10 +272,11 @@ namespace pixelroot32::audio {
                 }
             }
 
-            // Safety: if we are too far behind, catch up
-            if (nextNoteSample < audioTimeSamples && musicPlaying) {
-                // Optional: handle extreme lag by skipping notes or just letting it run fast
-            }
+            notesProcessed++;
+        }
+
+        if (notesProcessed > maxNotesProcessed) {
+            maxNotesProcessed = notesProcessed;
         }
     }
 
@@ -264,12 +309,10 @@ namespace pixelroot32::audio {
             ch->volume = event.volume;
             ch->targetVolume = event.volume;
             ch->volumeDelta = 0.0f;
-            
+
             // Convert seconds to samples
             ch->remainingSamples = (uint64_t)(event.duration * (float)sampleRate);
-            ch->durationMs = (unsigned long)(event.duration * 1000.0f);
-            ch->remainingMs = ch->durationMs;
-            
+
             if (event.type == WaveType::PULSE) {
                 ch->dutyCycle = event.duty;
             }
@@ -310,10 +353,11 @@ namespace pixelroot32::audio {
                 }
                 break;
             case WaveType::NOISE:
-                if (ch.phase < ch.phaseIncrement) {
-                    ch.noiseRegister = (uint16_t)(rand() & 0xFFFF);
-                }
-                sample = (ch.noiseRegister & 1) ? 1.0f : -1.0f;
+                // NES-style 15-bit LFSR with taps at bits 0 and 1
+                // Update every sample for better noise quality
+                uint16_t feedback = ((ch.lfsrState & 1) ^ ((ch.lfsrState >> 1) & 1));
+                ch.lfsrState = (ch.lfsrState >> 1) | (feedback << 14);
+                sample = (ch.lfsrState & 1) ? 1.0f : -1.0f;
                 break;
         }
 

--- a/src/audio/ESP32AudioScheduler.cpp
+++ b/src/audio/ESP32AudioScheduler.cpp
@@ -17,7 +17,9 @@
 
 namespace pixelroot32::audio {
 
+    namespace platforms = pixelroot32::platforms;
     namespace logging = pixelroot32::core::logging;
+    
     using logging::LogLevel;
     using logging::log;
 
@@ -29,7 +31,7 @@ namespace pixelroot32::audio {
         stop();
     }
 
-    void ESP32AudioScheduler::init(AudioBackend* backend, int sampleRate, const pixelroot32::platforms::PlatformCapabilities& /*caps*/) {
+    void ESP32AudioScheduler::init(AudioBackend* backend, int sampleRate, const platforms::PlatformCapabilities& /*caps*/) {
         this->backend = backend;
         this->sampleRate = sampleRate;
         for (int i = 0; i < NUM_CHANNELS; i++) {
@@ -68,7 +70,16 @@ namespace pixelroot32::audio {
     void ESP32AudioScheduler::generateSamples(int16_t* stream, int length) {
         if (!stream || length <= 0) return;
 
-        processCommands();
+        // Performance timing (when profiling enabled)
+        uint32_t startTime = 0;
+        if constexpr (platforms::config::EnableProfiling) {
+            startTime = micros();
+        }
+
+        // Only process commands if queue is not empty to avoid atomic overhead
+        if (!commandQueue.isEmpty()) {
+            processCommands();
+        }
         updateMusicSequencer(length);
 
         static float currentPeak = 0.0f;
@@ -118,9 +129,9 @@ namespace pixelroot32::audio {
                 }
             }
 
-            // Apply Master Volume
-            if (masterVolume != 1.0f) {
-                sum = (int32_t)(sum * masterVolume);
+            // Apply Master Volume using pre-computed Q16 fixed-point scale
+            if (masterVolumeScale != 65536) {
+                sum = (sum * masterVolumeScale) >> 16;
             }
 
             // Map sum [-131072, 131071] to LUT index [0, 1024]
@@ -128,7 +139,7 @@ namespace pixelroot32::audio {
             int32_t index = (sum + 131072) >> 8;
             if (index < 0) index = 0;
             if (index > 1024) index = 1024;
-            
+
             int16_t finalSample = audio_mixer_lut[index];
             stream[j] = finalSample;
 
@@ -142,7 +153,7 @@ namespace pixelroot32::audio {
         static uint32_t lastLog = 0;
         uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
         if (now - lastLog > 1000) {
-            if constexpr (pixelroot32::platforms::config::EnableProfiling) {
+            if constexpr (platforms::config::EnableProfiling) {
                 if (currentPeak > 32767.0f) {
                     log(LogLevel::Profiling, "[AUDIO] PEAK DETECTED: %.0f (CLIPPING!)", currentPeak);
                 } else {
@@ -154,6 +165,16 @@ namespace pixelroot32::audio {
         }
         
         audioTimeSamples += length;
+
+        // Performance timing (when profiling enabled)
+        if constexpr (platforms::config::EnableProfiling) {
+            uint32_t elapsed = micros() - startTime;
+            totalGenerateTimeUs += elapsed;
+            generateSampleCount++;
+            if (elapsed > maxGenerateTimeUs) {
+                maxGenerateTimeUs = elapsed;
+            }
+        }
     }
 
     void ESP32AudioScheduler::processCommands() {
@@ -167,6 +188,8 @@ namespace pixelroot32::audio {
                     masterVolume = cmd.volume;
                     if (masterVolume > 1.0f) masterVolume = 1.0f;
                     if (masterVolume < 0.0f) masterVolume = 0.0f;
+                    // Pre-compute for LUT path (Q16 fixed-point)
+                    masterVolumeScale = (int32_t)(masterVolume * 65536.0f);
                     break;
                 case AudioCommandType::STOP_CHANNEL:
                     if (cmd.channelIndex < NUM_CHANNELS) {
@@ -202,7 +225,28 @@ namespace pixelroot32::audio {
     void ESP32AudioScheduler::updateMusicSequencer(int /*length*/) {
         if (!musicPlaying || musicPaused || !currentTrack) return;
 
+        int notesProcessed = 0;
         while (musicPlaying && currentTrack && audioTimeSamples >= nextNoteSample) {
+            if (notesProcessed >= MAX_NOTES_PER_FRAME) {
+                notesSkipped++;
+                // Skip ahead to catch up without playing
+                while (audioTimeSamples >= nextNoteSample && musicPlaying && currentTrack) {
+                    const MusicNote& note = currentTrack->notes[currentNoteIndex];
+                    uint64_t noteDurationSamples = (uint64_t)((note.duration / tempoFactor) * (float)sampleRate);
+                    nextNoteSample += noteDurationSamples;
+                    currentNoteIndex++;
+                    if (currentNoteIndex >= currentTrack->count) {
+                        if (currentTrack->loop) {
+                            currentNoteIndex = 0;
+                        } else {
+                            musicPlaying = false;
+                            currentTrack = nullptr;
+                        }
+                    }
+                }
+                break;
+            }
+
             playCurrentNote();
 
             const MusicNote& note = currentTrack->notes[currentNoteIndex];
@@ -218,6 +262,12 @@ namespace pixelroot32::audio {
                     currentTrack = nullptr;
                 }
             }
+
+            notesProcessed++;
+        }
+
+        if (notesProcessed > maxNotesProcessed) {
+            maxNotesProcessed = notesProcessed;
         }
     }
 
@@ -288,13 +338,18 @@ namespace pixelroot32::audio {
                     sample = 3.0f - 4.0f * ch.phase;
                 }
                 break;
-            case WaveType::NOISE:
-                // Update noise register only on phase wrap
+            case WaveType::NOISE:  
                 if (ch.phase < ch.phaseIncrement) {
                     ch.noiseRegister = (uint16_t)(rand() & 0xFFFF);
                 }
                 sample = (ch.noiseRegister & 1) ? 1.0f : -1.0f;
-                break;
+                break;  
+                // NES-style 15-bit LFSR with taps at bits 0 and 1
+                // Update every sample for better noise quality
+                // uint16_t feedback = ((ch.lfsrState & 1) ^ ((ch.lfsrState >> 1) & 1));
+                // ch.lfsrState = (ch.lfsrState >> 1) | (feedback << 14);
+                // sample = (ch.lfsrState & 1) ? 1.0f : -1.0f;
+                // break;
         }
 
         ch.phase += ch.phaseIncrement;

--- a/src/audio/ESP32AudioScheduler.cpp
+++ b/src/audio/ESP32AudioScheduler.cpp
@@ -12,7 +12,6 @@
 #include <Arduino.h>
 #include <algorithm>
 #include <cstring>
-#include <cstdlib>
 #include <soc/soc_caps.h>
 
 namespace pixelroot32::audio {
@@ -23,8 +22,12 @@ namespace pixelroot32::audio {
     using logging::LogLevel;
     using logging::log;
 
-    ESP32AudioScheduler::ESP32AudioScheduler(int coreId, int priority)
-        : coreId(coreId), priority(priority) {
+    static inline void stepNoiseLfsr15(uint16_t& state) {
+        const uint16_t feedback = (uint16_t)(((state & 1u) ^ ((state >> 1) & 1u)) & 1u);
+        state = (uint16_t)((state >> 1) | (feedback << 14));
+    }
+
+    ESP32AudioScheduler::ESP32AudioScheduler(int /*reservedCoreId*/, int /*reservedTaskPriority*/) {
     }
 
     ESP32AudioScheduler::~ESP32AudioScheduler() {
@@ -48,7 +51,17 @@ namespace pixelroot32::audio {
     }
 
     void ESP32AudioScheduler::submitCommand(const AudioCommand& cmd) {
-        commandQueue.enqueue(cmd);
+        if (!commandQueue.enqueue(cmd)) {
+            droppedCommands.fetch_add(1u, std::memory_order_relaxed);
+#if defined(PIXELROOT32_DEBUG_MODE)
+            static uint32_t lastDropLogCount = 0;
+            const uint32_t total = droppedCommands.load(std::memory_order_relaxed);
+            if (total - lastDropLogCount >= 16u) {
+                lastDropLogCount = total;
+                log(LogLevel::Warning, "[AUDIO] command queue full; dropped %u total", (unsigned)total);
+            }
+#endif
+        }
     }
 
     void ESP32AudioScheduler::start() {
@@ -299,6 +312,20 @@ namespace pixelroot32::audio {
             ch->remainingSamples = (uint64_t)(event.duration * (float)sampleRate);
             if (event.type == WaveType::PULSE) {
                 ch->dutyCycle = event.duty;
+            } else if (event.type == WaveType::NOISE) {
+                float noiseHz = event.frequency;
+                if (noiseHz < 1.0f) {
+                    noiseHz = 1.0f;
+                }
+                uint32_t period = (uint32_t)((float)sampleRate / noiseHz);
+                if (period < 1u) {
+                    period = 1u;
+                }
+                ch->noisePeriodSamples = period;
+                ch->noiseCountdown = 1u;
+                ch->lfsrState = 0x4000;
+                ch->phase = 0.0f;
+                ch->phaseIncrement = 0.0f;
             }
         }
     }
@@ -338,22 +365,25 @@ namespace pixelroot32::audio {
                     sample = 3.0f - 4.0f * ch.phase;
                 }
                 break;
-            case WaveType::NOISE:  
-                if (ch.phase < ch.phaseIncrement) {
-                    ch.noiseRegister = (uint16_t)(rand() & 0xFFFF);
+            case WaveType::NOISE: {
+                if (ch.noiseCountdown > 0u) {
+                    ch.noiseCountdown--;
                 }
-                sample = (ch.noiseRegister & 1) ? 1.0f : -1.0f;
-                break;  
-                // NES-style 15-bit LFSR with taps at bits 0 and 1
-                // Update every sample for better noise quality
-                // uint16_t feedback = ((ch.lfsrState & 1) ^ ((ch.lfsrState >> 1) & 1));
-                // ch.lfsrState = (ch.lfsrState >> 1) | (feedback << 14);
-                // sample = (ch.lfsrState & 1) ? 1.0f : -1.0f;
-                // break;
+                if (ch.noiseCountdown == 0u) {
+                    stepNoiseLfsr15(ch.lfsrState);
+                    ch.noiseCountdown = ch.noisePeriodSamples;
+                }
+                sample = (ch.lfsrState & 1u) ? 1.0f : -1.0f;
+                break;
+            }
         }
 
-        ch.phase += ch.phaseIncrement;
-        if (ch.phase >= 1.0f) ch.phase -= 1.0f;
+        if (ch.type != WaveType::NOISE) {
+            ch.phase += ch.phaseIncrement;
+            if (ch.phase >= 1.0f) {
+                ch.phase -= 1.0f;
+            }
+        }
 
         if (ch.volumeDelta != 0.0f) {
             ch.volume += ch.volumeDelta;

--- a/src/drivers/esp32/ESP32_DAC_AudioBackend.cpp
+++ b/src/drivers/esp32/ESP32_DAC_AudioBackend.cpp
@@ -78,16 +78,16 @@ namespace pixelroot32::drivers::esp32 {
                 for (int i = 0; i < BUFFER_SAMPLES; i++) {
                     // Apply 0.7f scale for PAM8302A
                     int32_t scaled = (int32_t)(sampleBuffer[i] * 0.7f);
-                    
+
                     if (scaled > 32767) scaled = 32767;
                     if (scaled < -32768) scaled = -32768;
 
                     // Convert 16-bit signed to 8-bit unsigned
                     uint8_t dacValue = (uint8_t)((scaled + 32768) >> 8);
-                    dac_output_voltage(dacChannel, dacValue);
+                    // Use dacWrite() for direct register access (faster than dac_output_voltage)
+                    dacWrite(dacPin, dacValue);
                 }
-                
-                vTaskDelay(1); 
+
                 vTaskDelayUntil(&lastWakeTime, bufferTicks);
             } else {
                 vTaskDelay(10 / portTICK_PERIOD_MS);

--- a/src/drivers/esp32/ESP32_I2S_AudioBackend.cpp
+++ b/src/drivers/esp32/ESP32_I2S_AudioBackend.cpp
@@ -47,7 +47,7 @@ namespace pixelroot32::drivers::esp32 {
             .communication_format = I2S_COMM_FORMAT_STAND_I2S,
             .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
             .dma_buf_count = 8,
-            .dma_buf_len = 64, // Small buffers for low latency
+            .dma_buf_len = 128, // Increased from 64 to support 1024 samples (8 * 128 = 1024)
             .use_apll = false,
             .tx_desc_auto_clear = true
         };
@@ -86,7 +86,7 @@ namespace pixelroot32::drivers::esp32 {
     }
 
     void ESP32_I2S_AudioBackend::audioTaskLoop() {
-        const int BUFFER_SAMPLES = 256;
+        const int BUFFER_SAMPLES = 1024; // Increased from 256 to match Native configuration
         int16_t sampleBuffer[BUFFER_SAMPLES];
         size_t bytesWritten;
 


### PR DESCRIPTION
- Replace legacy random-based noise with NES-style 15-bit LFSR for deterministic noise patterns
- Add performance limits to music sequencer (MAX_NOTES_PER_FRAME=8) to prevent CPU spikes
- Pre-compute master volume as Q16 fixed-point for faster LUT mixing path
- Increase ESP32 I2S buffer size to 1024 samples to match native configuration
- Optimize ESP32 DAC backend by using dacWrite() for direct register access
- Add performance metrics collection when profiling is enabled
- Update documentation to reflect noise implementation and remaining limitations
- Introduce noisePeriodSamples and noiseCountdown for better control of noise generation timing.
- Update ESP32AudioScheduler to handle command queue overflow and log warnings when commands are dropped.
- Refactor noise generation logic to utilize a deterministic LFSR approach, improving noise quality.
- Adjust AudioEngine and AudioScheduler interfaces to streamline audio event processing and sample generation.
- Update documentation to reflect changes in audio architecture and noise handling mechanisms.
