### PR TITLE
chore: bump version to 1.5.0 and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.5.0
+
+### 🚀 Rendering Performance & Graphics
+
+- **Dirty Regions Pipeline**: Introduced `DirtyGrid` optimization featuring a double dirty grid system to eliminate mandatory full-frame redraws. Uses selective row-run 8bpp clearing and `__builtin_popcount` optimizations to drastically reduce memory bandwidth and CPU overhead on ESP32.
+- **Static Tilemap Integration**: Integrated Dirty Regions with `StaticTilemapLayerCache` for fast-path `memcpy` background restores. Added `LayerType` (Static vs. Dynamic) for intelligent dirty marking and optimized animated tile tracking.
+- **Robustness & Refactoring**: Improved error handling for `DirtyGrid` memory allocations and simplified framebuffer clearing loop conditions for better maintainability.
+
+### 🔊 Audio System
+
+- **No-FPU Optimizations**: Added Q15 fixed-point implementations for LFO (triangle waves, tremolo, vibrato) and High-Pass Filter (HPF) to enable high-performance audio synthesis on platforms without a floating-point unit (like ESP32-C3), completely avoiding slow soft-float operations.
+- **Audio Hot Path Optimization**: Replaced conditional branching in wave generation with a static function pointer array dispatch, significantly reducing branch mispredictions during audio rendering.
+- **Configurable Block Size**: Added an optional `blockSize` parameter to `AudioScheduler::init()` for platform-specific tuning (e.g., 128 samples for ESP32-C3 vs 256 for FPU platforms).
+
+### 🎮 Examples
+
+- **2048 Puzzle Game**: Added a complete 2048 clone showcasing grid mechanics, UI layout elements, NES-style sound effects, and dual-platform support (Native SDL2 with keyboard / ESP32-CYD with touch).
+
+### 🧪 Testing & QA
+
+- **Collision System Tests**: Added comprehensive unit tests verifying sensor contacts, velocity integration, penetration correction, and boundary scenarios.
+- **Expanded Coverage**: Expanded test coverage across multiple systems including `AudioScheduler`, `DrawSurface`, `SceneManager`, `InputManager`, `TileAnimationManager`, `DisplayConfig`, and `TouchStateMachine`.
+- **Meaningful Assertions**: Replaced placeholder assertions with exact value verification and expanded edge case handling across the testing suite.
+
+### ⚡ Memory Optimization
+
+- **`InputConfig` Fixed-Size Arrays**: Replaced `std::vector` with `std::array<T,N>{}` in `InputConfig` to eliminate heap allocation, prevent memory fragmentation, and ensure deterministic O(1) access times on ESP32. Added `static_assert` compile-time validation and template variadic constructor that auto-deduces input count, removing the need for explicit `count` parameter.
+
+> **Migration guide**: [MIGRATION_v1.5.0](docs/migration/migration-v1-5-0.md)
+
 ## 1.4.0
 
 ### 🔊 Audio System

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To use PixelRoot32 in your own project, add the following to the `lib_deps` opti
 
 ```ini
 lib_deps =
-    gperez88/PixelRoot32-Game-Engine@^1.3.0
+    gperez88/PixelRoot32-Game-Engine@^1.5.0
 ```
 
 PlatformIO will automatically download and install the library and its dependencies during the next build.

--- a/README.md
+++ b/README.md
@@ -76,91 +76,18 @@ Watch PixelRoot32 running on ESP32 with example games:
 
 - **Cross-Platform**: Develop on PC (Windows/Linux/macOS) and deploy on ESP32.
 - **Scene-Entity System**: Intuitive management of Scenes, Entities, and Actors.
-- **High Performance**: Optimized for ESP32 with DMA transfers and IRAM-cached rendering.
+- **High Performance**: Optimized for ESP32 with DMA transfers, IRAM-cached rendering, and a Dirty Regions pipeline.
 - **Sprite System**: Support for 1bpp/2bpp/4bpp sprites with multi-palette selection, flipping, rotation, and animation.
-- **Tilemap Support**: Optimized rendering with viewport culling, multi-palette, and tile animations.
+- **Tilemap Support**: Optimized rendering with viewport culling, static layer caching, multi-palette, and tile animations.
 - **Tile Animation System**: Frame-based animations (water, lava) with O(1) frame resolution and zero-allocation policy.
 - **Independent Resolution Scaling**: Render at low logical resolutions (e.g., 128x128) and scale to physical displays (e.g., 240x240).
-- **NES-Style Audio**: Built-in 4-channel audio subsystem (Pulse, Triangle, Noise).
+- **NES-Style Audio**: Built-in dynamic 8-voice audio subsystem with fixed-point No-FPU optimizations (Pulse, Triangle, Noise, Sine, Saw).
 - **Lightweight UI**: Label, Button, and Checkbox with automatic layouts.
 - **AABB Physics**: Godot-style physics with Kinematic/Rigid actors, sensors, and one-way platforms.
 - **Indexed Color Palettes**: Optimized palettes (PR32, NES, GameBoy, PICO-8) with multi-palette support.
 - **Modular Architecture**: Compile only needed subsystems via `PIXELROOT32_ENABLE_*` flags to reduce firmware size.
 
 > 💡 **Detailed info:** Check out the [Full Feature List](https://docs.pixelroot32.org/#getting-started).
-
----
-
-## ⚠️ Known Issues
-
-### DMA + ESP32-S3 + Arduino Core > 2.0.14
-
-**Problem**: When using ESP32-S3 with Arduino Core versions newer than 2.0.14, DMA-based transfers may freeze after the first frame. This is a known issue affecting the ESP32-S3 GDMA subsystem in ESP-IDF 4.4.7+ (used by Arduino Core 2.0.15+).
-
-**Symptoms**:
-
-- Display freezes after rendering the first frame
-- DMA transfer not completing
-- Random crashes during display initialization
-
-**Workaround**: Use Arduino Core 2.0.14 (the last stable version before the GDMA changes).
-
-In PlatformIO, this is configured via the `platform_packages` directive:
-
-```ini
-[env:esp32s3]
-platform_packages =
-    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32#2.0.14
-```
-
-> **Note**: This workaround is already configured in the `hello_world` example's `platformio.ini` for ESP32-S3. If you create new projects, ensure this is set when targeting ESP32-S3.
-
-> **💡 Ongoing Solution**: Work is underway for a definitive fix by migrating from `TFT_eSPI` to `LovyanGFX`. This change will provide better alignment with modern drivers and significantly improved stability on ESP32-S3.
-
-**Related Issues**:
-
-- [espressif/arduino-esp32 #9618](https://github.com/espressif/arduino-esp32/issues/9618) - Original report: ESP32-S3 DMA issues with Core > 2.0.14
-- [TFT_eSPI #3329](https://github.com/Bodmer/TFT_eSPI/issues/3329)
-- [TFT_eSPI #3367](https://github.com/Bodmer/TFT_eSPI/issues/3367)
-- [ESP32-HUB75-MatrixPanel-DMA #775](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/issues/775)
-
----
-
-### Framework Cache Corruption (pins_arduino.h missing)
-
-**Problem**: When Arduino Core packages become corrupted (especially after changing versions like the DMA workaround), you may encounter:
-
-```bash
-fatal error: pins_arduino.h: No such file or directory
-```
-
-**Symptoms**:
-
-- Build fails with `pins_arduino.h` not found
-- Previously working projects suddenly stop compiling
-- Happens after changing Arduino Core versions (e.g., applying the DMA workaround)
-
-**Solution**:
-
-1. Clean the build cache:
-
-   ```bash
-   pio run --target clean
-   ```
-
-2. Remove the corrupted framework package:
-
-   ```bash
-   rmdir /s /q %USERPROFILE%\.platformio\packages\framework-arduinoespressif32
-   ```
-
-3. Rebuild - PlatformIO will reinstall the framework:
-
-   ```bash
-   pio run
-   ```
-
-**Prevention**: After changing `platform_packages` for Arduino Core versions, always run a clean build to ensure the framework is properly reinstalled.
 
 ---
 
@@ -269,25 +196,32 @@ To ensure high performance on ESP32, PixelRoot32 enforces strict development pat
 
 ## 🕒 Changelog
 
-## 1.4.0
+## 1.5.0
+
+### 🚀 Rendering Performance & Graphics
+
+- **Dirty Regions Pipeline**: Implemented `DirtyGrid` optimization with a double dirty grid to eliminate mandatory full-frame redraws, drastically reducing memory bandwidth on ESP32.
+- **Static Tilemap Integration**: Integrated Dirty Regions with `StaticTilemapLayerCache` using fast-path `memcpy` background restores and intelligent dynamic-only dirty marking.
 
 ### 🔊 Audio System
 
-- **Single-Core ESP32 Optimization**: Q15 fixed-point envelope generation for RISC-V cores, dynamic buffer sizing, and `taskYIELD()` scheduling for better CPU sharing.
-- **Dynamic Voice Pooling**: Refactored `ApuCore` to support up to 8 simultaneous voices with voice stealing logic.
-- **Enhanced Waveforms**: Added SINE and SAW waveforms with optional linear frequency sweep for PULSE and TRIANGLE types.
-- **NES-Style Game Audio**: Layered tracks (triangle bass, pulse arpeggio, noise drums) with dynamic tempo scaling in Brick Breaker, Space Invaders, and Tic-Tac-Toe.
+- **No-FPU Optimizations**: Added Q15 fixed-point LFO (triangle waves, tremolo, vibrato) and High-Pass Filter (HPF) to eliminate slow soft-float operations on platforms like ESP32-C3.
+- **Performance**: Replaced conditional branching with a static function pointer array dispatch in wave generation to reduce branch mispredictions.
+- **Configurable Block Size**: Added `blockSize` parameter to `AudioScheduler` for platform-specific tuning.
 
-### 🎨 UI/Graphics
+### 🎮 Examples
 
-- **Scalar Casting Fix**: Added explicit cast to prevent precision loss when converting Scalar values to integer coordinates.
+- **2048 Puzzle Game**: Added a complete 2048 clone showcasing UI layouts, grid mechanics, NES-style audio, and dual-platform support (Native/ESP32-CYD).
 
-### 📚 Documentation
+### 🧪 Testing & QA
 
-- **Structure Restructuring**: Reorganized docs into modular directories (architecture, api, guide, reference, migration, philosophy).
-- **New Guides**: Added guides for testing, resolution scaling, multi-palette, tilemaps, platform config, and getting started.
-- **API Documentation**: Generated auto-generated API docs for all engine components.
-- **Doxygen Comments**: Added comprehensive Doxygen documentation to key engine headers.
+- **Collision System Tests**: Added comprehensive physics unit tests for sensor contacts, velocity integration, and penetration correction.
+- **Expanded Coverage**: Improved assertions and expanded test coverage across audio, scene, input, graphics, and UI modules.
+
+### ⚡ Memory Optimization
+
+- **`InputConfig` API Change**: The `count` parameter is no longer required. Use `InputConfig(PIN1, PIN2, ...)` instead of `InputConfig(count, PIN1, PIN2, ...)`. See [migration guide](../docs/migration/migration-v1-5-0.md).
+
 
 Full changelog: [CHANGELOG.md](CHANGELOG.md)
 

--- a/docs/api/generated/audio/ApuCore.md
+++ b/docs/api/generated/audio/ApuCore.md
@@ -25,35 +25,143 @@ Mixing curve:
 On cores without an FPU (ESP32-C3) the integer-optimised path uses
 `audio_mixer_lut` which is pre-fitted to the same curve.
 
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `audioTimeSamples` | `uint64_t` | Global sample counter at capture. |
+| `peak` | `float` | Peak sample magnitude [0.0 - 1.0]. |
+| `clipped` | `bool` | Whether any sample exceeded ±32767. |
+
 ## Methods
 
 ### `void init(int sampleRate)`
 
+**Description:**
+
+Configures the output sample rate.
+
+**Parameters:**
+
+- `sampleRate`: Sample rate in Hz (e.g., 22050, 44100).
+
+Safe to call before start(). Pre-calculates internal timing values.
+
 ### `bool submitCommand(const AudioCommand& cmd)`
 
-**Returns:** false if the SPSC queue was full.
+**Description:**
+
+Enqueues a command for processing.
+
+**Parameters:**
+
+- `cmd`: The audio command to enqueue.
+
+**Returns:** true if the command was enqueued, false if the queue was full.
 
 ### `void generateSamples(int16_t* stream, int length)`
 
+**Description:**
+
+Generates audio samples.
+
+**Parameters:**
+
+- `stream`: Output buffer (mono, int16 samples).
+- `length`: Number of samples to generate.
+
+Processes all pending commands, updates music sequencer, and synthesizes
+voices into the output buffer. Applies master volume, bitcrush, and DC blocking.
+
 ### `uint32_t getDroppedCommands() const`
+
+**Description:**
+
+Returns the total number of commands dropped since construction. @return Monotonic count.
+
+**Returns:** Monotonic count.
 
 ### `void setSequencerNoteLimit(size_t limit)`
 
+**Description:**
+
+Sets the maximum notes processed per audio frame.
+
+**Parameters:**
+
+- `limit`: Max notes [1-1000], clamped to safe bounds internally.
+
+Bounded processing prevents audio starvation when many notes queue up.
+
 ### `size_t getSequencerNoteLimit() const`
+
+**Description:**
+
+Gets current max notes per frame setting. @return Current limit.
+
+**Returns:** Current limit.
 
 ### `size_t getDeferredNotes() const`
 
+**Description:**
+
+Returns notes deferred to next frame due to note limit. @return Deferred count.
+
+**Returns:** Deferred count.
+
 ### `bool isMusicPlaying() const`
+
+**Description:**
+
+Reports if music is currently playing. @return true if playing.
+
+**Returns:** true if playing.
 
 ### `bool isMusicPaused() const`
 
+**Description:**
+
+Reports if music is paused. @return true if paused.
+
+**Returns:** true if paused.
+
 ### `int getSampleRate() const`
+
+**Description:**
+
+Gets the configured sample rate. @return Sample rate in Hz.
+
+**Returns:** Sample rate in Hz.
 
 ### `void reset()`
 
+**Description:**
+
+Resets all state to initial values.
+
 ### `void setPostMixMono(void (*fn)(int16_t* mono, int length, void* user), void* user)`
 
+**Description:**
+
+Sets an optional post-mix callback.
+
+**Parameters:**
+
+- `fn`: Function pointer: void(int16_t* mono, int length, void* user).
+- `user`: User data passed to the callback.
+
+Called after bitcrush on the final mono buffer. Runs in audio thread context.
+
 ### `void getAndResetProfileStats(ProfileEntry* out, uint8_t& count)`
+
+**Description:**
+
+Reads and clears all profile entries.
+
+**Parameters:**
+
+- `out`: Array of ProfileEntry to fill.
+- `count`: On input: max entries. On output: actual count written.
 
 ### `size_t countEnabledVoicesForTesting() const`
 

--- a/docs/api/generated/audio/AudioBackend.md
+++ b/docs/api/generated/audio/AudioBackend.md
@@ -8,11 +8,31 @@
 
 Abstract interface for platform-specific audio drivers.
 
-This class abstracts the underlying audio hardware or API (e.g., SDL2, I2S).
-It is responsible for requesting audio samples from the AudioEngine and
-pushing them to the output device.
+This class abstracts the underlying audio hardware or API (e.g., SDL2 on native,
+I2S on ESP32). It is responsible for requesting audio samples from the AudioEngine
+and pushing them to the output device. Platforms implement this interface to
+bridge between the engine's sample generation and the actual hardware.
+
+Typical lifecycle:
+1. init() is called with an AudioEngine pointer.
+2. The backend sets up the audio output (I2S, SDL audio, etc.).
+3. In its output callback, the backend calls engine->generateSamples().
+4. On destruction, resources are cleaned up.
 
 ## Methods
+
+### `virtual void init(AudioEngine* engine, const pixelroot32::platforms::PlatformCapabilities& caps = pixelroot32::platforms::PlatformCapabilities())`
+
+**Description:**
+
+Initializes the audio backend.
+
+**Parameters:**
+
+- `engine`: Pointer to the AudioEngine instance to request samples from.
+       Must not be nullptr.
+- `caps`: Platform capabilities to guide backend initialization
+       (e.g., core pinning on ESP32, thread priorities).
 
 ### `virtual int getSampleRate() const`
 
@@ -20,4 +40,4 @@ pushing them to the output device.
 
 Returns the configured sample rate of the backend.
 
-**Returns:** Sample rate in Hz (e.g., 22050, 44100).
+**Returns:** Sample rate in Hz (e.g., 22050, 44100, 48000).

--- a/docs/api/generated/audio/AudioChannel.md
+++ b/docs/api/generated/audio/AudioChannel.md
@@ -10,6 +10,21 @@ Represents the internal state of a single audio channel.
 
 Designed to be static and memory-efficient.
 
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `sweepSamplesTotal` | `uint32_t` | Total samples for the sweep. |
+| `sweepSamplesRemaining` | `uint32_t` | Samples remaining in the sweep. |
+| `sweepStartHz` | `float` | Starting frequency in Hz. |
+| `sweepEndHz` | `float` | Ending frequency in Hz. |
+| `sweepStartIncQ32` | `uint32_t` | Q32 phase increment at sweep start. |
+| `sweepEndIncQ32` | `uint32_t` | Q32 phase increment at sweep end. |
+
 ## Methods
 
 ### `void reset()`
+
+**Description:**
+
+Resets the channel to a clean disabled state.

--- a/docs/api/generated/audio/AudioCommandQueue.md
+++ b/docs/api/generated/audio/AudioCommandQueue.md
@@ -6,11 +6,18 @@
 
 ## Description
 
-Multi-Producer Single-Consumer lock-free ring buffer for AudioCommands.
+Multi-Producer Single-Consumer (MPSC) lock-free ring buffer for AudioCommands.
 
-Fixed size, no allocation. Supports multiple concurrent producer threads.
-If the queue is full, the newest command is dropped and droppedCommands is incremented.
-Uses compare-and-swap (CAS) for atomic ring index advancement.
+Fixed-size, zero-allocation queue designed for real-time audio thread communication.
+Supports multiple concurrent producer threads (e.g., game logic, music sequencer)
+and a single consumer thread (the audio thread).
+
+Drop policy: When the queue is full, the newest command is silently dropped and
+the droppedCommands counter is incremented. Callers can monitor this via
+getDroppedCommands() for diagnostics.
+
+Thread-safety: Uses compare-and-swap (CAS) for atomic ring index advancement.
+The producer path is wait-free; the consumer path is lock-free.
 
 ## Methods
 

--- a/docs/api/generated/audio/AudioConfig.md
+++ b/docs/api/generated/audio/AudioConfig.md
@@ -15,3 +15,18 @@ Configuration for the Audio subsystem.
 | `backend` | `AudioBackend*` | Pointer to the platform-specific audio backend. |
 | `sampleRate` | `int` | Desired sample rate in Hz. |
 | `blockSize` | `int` | Audio block size (samples). Must be multiple of 128. |
+
+## Methods
+
+### `: backend(backend), sampleRate(sampleRate), blockSize(blockSize)`
+
+**Description:**
+
+Constructs an AudioConfig with platform-adaptive block size.
+
+**Parameters:**
+
+- `backend`: Pointer to the audio backend implementation. May be nullptr for headless configs.
+- `sampleRate`: Desired sample rate in Hz (default 22050 for retro feel).
+- `blockSize`: Audio block size in samples. Defaults to 256 on FPU platforms, 128 on no-FPU platforms.
+       Must be a multiple of 128 for I2S DMA alignment.

--- a/docs/api/generated/audio/AudioEngine.md
+++ b/docs/api/generated/audio/AudioEngine.md
@@ -6,25 +6,92 @@
 
 ## Description
 
-Core class for the NES-like audio subsystem.
+Facade class for the NES-style audio subsystem.
+
+Provides a high-level API for playing sound events, controlling volume,
+and managing music playback. Internally delegates to an AudioScheduler
+(typically DefaultAudioScheduler) which owns the ApuCore for synthesis.
+
+Usage:
+1. Construct with an AudioConfig and PlatformCapabilities.
+2. Call init() to set up the scheduler and backend.
+3. Call playEvent() to trigger one-shot sounds.
+4. Use MusicPlayer for music track sequencing.
 
 ## Methods
 
 ### `void init()`
 
+**Description:**
+
+Initializes the engine and its internal scheduler.
+
 ### `void generateSamples(int16_t* stream, int length)`
+
+**Description:**
+
+Generates audio samples into the output buffer.
+
+**Parameters:**
+
+- `stream`: Output buffer (mono, int16 samples).
+- `length`: Number of samples to generate.
 
 ### `void playEvent(const AudioEvent& event)`
 
+**Description:**
+
+Triggers a one-shot sound event.
+
+**Parameters:**
+
+- `event`: The event to play (type, frequency, duration, volume).
+
 ### `void setMasterVolume(float volume)`
+
+**Description:**
+
+Sets the master volume for all audio output.
+
+**Parameters:**
+
+- `volume`: Volume level [0.0 = silent, 1.0 = full].
 
 ### `float getMasterVolume() const`
 
+**Description:**
+
+Gets the current master volume. @return Volume [0.0 - 1.0].
+
+**Returns:** Volume [0.0 - 1.0].
+
 ### `void setMasterBitcrush(uint8_t bits)`
+
+**Description:**
+
+Sets the master bitcrusher effect on the final output.
+
+**Parameters:**
+
+- `bits`: Bit depth reduction [0 = off, 1-15 = re-quantize to N bits].
 
 ### `uint8_t getMasterBitcrush() const`
 
+**Description:**
+
+Gets the current master bitcrush setting. @return Bit depth (0 = off).
+
+**Returns:** Bit depth (0 = off).
+
 ### `void submitCommand(const AudioCommand& cmd)`
+
+**Description:**
+
+Submits a raw audio command to the scheduler.
+
+**Parameters:**
+
+- `cmd`: The command to execute.
 
 ### `bool isMusicPlaying() const`
 
@@ -35,8 +102,20 @@ Reports the real-time music transport state from the
 
 ### `bool isMusicPaused() const`
 
+### `void setScheduler(std::unique_ptr<AudioScheduler> scheduler)`
+
+**Description:**
+
+Replaces the scheduler with a custom implementation.
+
+**Parameters:**
+
+- `scheduler`: Unique pointer to the new scheduler. Takes ownership.
+
 ### `AudioScheduler* getScheduler() const`
 
 **Description:**
 
-Gets the underlying scheduler for diagnostics/profiling.
+Gets the current scheduler for diagnostics or profiling.
+
+**Returns:** Pointer to the current AudioScheduler, or nullptr if not set.

--- a/docs/api/generated/audio/AudioScheduler.md
+++ b/docs/api/generated/audio/AudioScheduler.md
@@ -14,27 +14,41 @@ or in a dedicated audio thread.
 
 ## Methods
 
+### `virtual void init(AudioBackend* backend, int sampleRate, const pixelroot32::platforms::PlatformCapabilities& caps = pixelroot32::platforms::PlatformCapabilities(), int blockSize = 256)`
+
+**Description:**
+
+Initializes the scheduler.
+
+**Parameters:**
+
+- `backend`: The audio backend to use for output.
+- `sampleRate`: The output sample rate in Hz.
+- `caps`: Platform capabilities to guide core pinning or threading decisions.
+- `blockSize`: Audio block size in samples for I2S DMA and ring buffer operations.
+       Must be a multiple of 128.
+
 ### `virtual void submitCommand(const AudioCommand& cmd)`
 
 **Description:**
 
-Submits a command to the scheduler.
+Submits a command to the scheduler for execution.
 
 **Parameters:**
 
-- `cmd`: The command to execute.
+- `cmd`: The command to enqueue (PLAY_EVENT, STOP_CHANNEL, etc.).
 
 ### `virtual void start()`
 
 **Description:**
 
-Starts the scheduler execution.
+Starts the scheduler execution. Enables audio generation.
 
 ### `virtual void stop()`
 
 **Description:**
 
-Stops the scheduler execution.
+Stops the scheduler execution. Silences all voices.
 
 ### `virtual bool isIndependent() const`
 
@@ -42,11 +56,21 @@ Stops the scheduler execution.
 
 Checks if the scheduler runs in an independent thread.
 
+**Returns:** true if the scheduler owns a dedicated audio thread, false if it
+       runs synchronously with the backend's callback.
+
 ### `virtual void generateSamples(int16_t* stream, int length)`
 
 **Description:**
 
-Generates samples. Should be called by the backend or scheduler thread.
+Generates samples into the provided buffer.
+
+**Parameters:**
+
+- `stream`: Pointer to the output buffer (mono, int16 samples).
+- `length`: Number of samples to generate (must match blockSize).
+
+Called by the backend (or scheduler thread) to fill the audio buffer.
 
 ### `virtual bool isMusicPlaying() const`
 

--- a/docs/api/generated/audio/DefaultAudioScheduler.md
+++ b/docs/api/generated/audio/DefaultAudioScheduler.md
@@ -8,19 +8,58 @@
 
 ## Description
 
-Backend-driven scheduler used on platforms without a dedicated
-       audio task.
+Backend-driven scheduler used on platforms without a dedicated audio task.
 
 Delegates all synthesis to ApuCore; generateSamples() runs in whichever
-context the backend invokes it (tests, simulators without a thread,
-etc.).
+context the backend invokes it (tests, simulators without a thread, etc.).
+Does not own a thread — audio generation is driven by the backend's callback.
+
+For platforms with a dedicated audio task (e.g., FreeRTOS on ESP32),
+      use a scheduler that spawns its own thread instead.
 
 ## Inheritance
 
 [AudioScheduler](./AudioScheduler.md) → `DefaultAudioScheduler`
 
+::: tip
+For platforms with a dedicated audio task (e.g., FreeRTOS on ESP32),
+      use a scheduler that spawns its own thread instead.
+:::
+
 ## Methods
+
+### `bool isMusicPlaying() const`
+
+**Description:**
+
+Generates samples via ApuCore. @param stream Output buffer. @param length Sample count.
+
+**Parameters:**
+
+- `stream`: Output buffer.
+
+### `bool isMusicPaused() const`
+
+### `ApuCore& getApuCore()`
+
+**Description:**
+
+Returns reference to the ApuCore for diagnostics. @return ApuCore reference.
+
+**Returns:** ApuCore reference.
 
 ### `const ApuCore& core() const`
 
+**Description:**
+
+Exposes the underlying core for tests or higher-level queries. @return Const ApuCore reference.
+
+**Returns:** Const ApuCore reference.
+
 ### `ApuCore& core()`
+
+**Description:**
+
+Exposes the underlying core for tests or higher-level queries. @return ApuCore reference.
+
+**Returns:** ApuCore reference.

--- a/docs/api/generated/audio/EnvelopeState.md
+++ b/docs/api/generated/audio/EnvelopeState.md
@@ -1,0 +1,40 @@
+# EnvelopeState
+
+<Badge type="info" text="Struct" />
+
+**Source:** `AudioTypes.h`
+
+## Description
+
+Holds ADSR envelope state for a single voice.
+
+Tracks the attack/decay/sustain/release stages and provides both
+floating-point and Q15 fixed-point variants to support platforms
+without an FPU (e.g., ESP32-C3 RISC-V).
+
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `attackSamples` | `uint32_t` | Samples for attack phase (0 = instantaneous). |
+| `decaySamples` | `uint32_t` | Samples for decay phase. |
+| `sustainLevel` | `float` | Target volume at sustain phase [0.0 - 1.0]. |
+| `releaseSamples` | `uint32_t` | Samples for release phase. |
+| `sampleCounter` | `uint32_t` | Counter within current stage. |
+| `currentLevel` | `float` | Current envelope amplitude [0.0 - 1.0]. |
+| `attackDelta` | `float` | Volume increment per sample during attack: 1.0 / attackSamples. |
+| `decayDelta` | `float` | Volume decrement per sample during decay: (1.0 - sustainLevel) / decaySamples. |
+| `releaseDelta` | `float` | Volume decrement per sample during release: sustainLevel / releaseSamples. |
+| `currentLevelQ15` | `int32_t` | Q15 mirror of currentLevel (-32768 to +32768). |
+| `attackDeltaQ15` | `int32_t` | Q15 attack delta: 32768 / attackSamples. |
+| `decayDeltaQ15` | `int32_t` | Q15 decay delta: (32768 - sustainLevelQ15) / decaySamples. |
+| `sustainLevelQ15` | `int32_t` | Q15 sustain level. |
+| `releaseDeltaQ15` | `int32_t` | Q15 release delta: sustainLevelQ15 / releaseSamples. |
+
+## Methods
+
+### `void reset()`
+
+**Description:**
+
+Resets all envelope state to OFF.

--- a/docs/api/generated/audio/InstrumentPreset.md
+++ b/docs/api/generated/audio/InstrumentPreset.md
@@ -19,6 +19,47 @@ For percussion instruments (duty == 0):
 
 ## Methods
 
+### `inline MusicNote makeNote(const InstrumentPreset& preset, Note note, float duration)`
+
+**Description:**
+
+Constructs a MusicNote using the preset's default octave.
+
+**Parameters:**
+
+- `preset`: The instrument preset defining default volume and octave.
+- `note`: The musical note to play.
+- `duration`: Note duration in seconds.
+
+**Returns:** A MusicNote with the preset's base volume and default octave.
+
+### `inline MusicNote makeNote(const InstrumentPreset& preset, Note note, uint8_t octave, float duration)`
+
+**Description:**
+
+Constructs a MusicNote with a specific octave override.
+
+**Parameters:**
+
+- `preset`: The instrument preset defining default volume and other parameters.
+- `note`: The musical note to play.
+- `octave`: The octave for this note (overrides preset default).
+- `duration`: Note duration in seconds.
+
+**Returns:** A MusicNote with the preset's base volume and specified octave.
+
+### `inline MusicNote makeRest(float duration)`
+
+**Description:**
+
+Constructs a rest (silence) note.
+
+**Parameters:**
+
+- `duration`: Duration of the rest in seconds.
+
+**Returns:** A MusicNote representing silence.
+
 ### `inline float instrumentToFrequency(const InstrumentPreset& preset, Note /*note*/, uint8_t /*octave*/)`
 
 **Parameters:**

--- a/docs/api/generated/audio/LfoState.md
+++ b/docs/api/generated/audio/LfoState.md
@@ -1,0 +1,36 @@
+# LfoState
+
+<Badge type="info" text="Struct" />
+
+**Source:** `AudioTypes.h`
+
+## Description
+
+Holds LFO (Low-Frequency Oscillator) state for pitch or volume modulation.
+
+Supports both floating-point and Q15 fixed-point variants for no-FPU platforms.
+The LFO produces a sine-like waveform that can modulate pitch (vibrato) or
+volume (tremolo) of a voice.
+
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `enabled` | `bool` | Whether the LFO is active. |
+| `target` | `LfoTarget` | What the LFO modulates: PITCH or VOLUME. |
+| `depth` | `float` | Modulation depth (pitch: ratio e.g. 0.05; volume: 0.0-1.0). |
+| `periodSamples` | `uint32_t` | LFO period in samples (derived from lfoFrequency). |
+| `sampleCounter` | `uint32_t` | Current sample position within the period. |
+| `currentValue` | `float` | Current LFO output value [-1.0 to +1.0]. |
+| `depthQ15` | `int32_t` | Q15 depth: 0-32768 maps to 0.0-1.0. |
+| `currentValueQ15` | `int32_t` | Q15 output: -32768 to +32768 maps to -1.0 to +1.0. |
+| `delaySamples` | `uint16_t` | Samples to wait before LFO starts (in seconds * sampleRate). |
+| `delayCounter` | `uint16_t` | Countdown for delay phase. |
+
+## Methods
+
+### `void reset()`
+
+**Description:**
+
+Resets all LFO state to disabled.

--- a/docs/api/generated/audio/MusicPlayer.md
+++ b/docs/api/generated/audio/MusicPlayer.md
@@ -6,7 +6,11 @@
 
 ## Description
 
-Simple sequencer to play MusicTracks.
+Simple sequencer to play MusicTracks using the AudioEngine.
+
+Provides a high-level interface for music playback with tempo control,
+pause/resume, and master volume management. Wraps audio commands to the
+engine's scheduler.
 
 ## Methods
 
@@ -18,25 +22,25 @@ Starts playing a track.
 
 **Parameters:**
 
-- `track`: The track to play.
+- `track`: The MusicTrack to play. Must remain in scope for duration.
 
 ### `void stop()`
 
 **Description:**
 
-Stops playback and silences the channel.
+Stops playback and silences all voices.
 
 ### `void pause()`
 
 **Description:**
 
-Pauses playback.
+Pauses playback at the current position.
 
 ### `void resume()`
 
 **Description:**
 
-Resumes playback.
+Resumes playback from the paused position.
 
 ### `bool isPlaying() const`
 
@@ -54,7 +58,7 @@ Sets the global tempo scaling factor.
 
 **Parameters:**
 
-- `factor`: 1.0f is normal speed, 2.0f is double speed.
+- `factor`: 1.0f is normal speed, 2.0f is double speed, 0.5f is half speed.
 
 ### `float getTempoFactor() const`
 
@@ -72,7 +76,7 @@ Sets the tempo in BPM (beats per minute).
 
 **Parameters:**
 
-- `bpm`: Beats per minute (default 150).
+- `bpm`: Beats per minute (affects note timing resolution).
 
 ### `float getBPM() const`
 
@@ -94,11 +98,11 @@ Gets the number of currently active tracks.
 
 **Description:**
 
-Sets the master volume level.
+Sets the master volume level for music playback.
 
 **Parameters:**
 
-- `volume`: Volume level (0.0f = silent, 1.0f = full volume).
+- `volume`: Volume level [0.0f = silent, 1.0f = full volume].
 
 ### `float getMasterVolume() const`
 
@@ -106,4 +110,4 @@ Sets the master volume level.
 
 Gets the current master volume level.
 
-**Returns:** Current volume (0.0f - 1.0f).
+**Returns:** Current volume [0.0f - 1.0f].

--- a/docs/api/generated/core/Actor.md
+++ b/docs/api/generated/core/Actor.md
@@ -29,6 +29,24 @@ enemies, and projectiles.
 
 ## Methods
 
+### `: Entity(x, y, w, h, EntityType::ACTOR)`
+
+**Description:**
+
+Constructor using Scalar coordinates.
+
+### `: Entity(pos, w, h, EntityType::ACTOR)`
+
+**Description:**
+
+Constructor using Vector2 position.
+
+### `void setCollisionLayer(pixelroot32::physics::CollisionLayer l)`
+
+### `void setCollisionMask(pixelroot32::physics::CollisionLayer m)`
+
+### `void update(unsigned long deltaTime)`
+
 ### `bool isInLayer(uint16_t targetLayer) const`
 
 ### `virtual Rect getHitBox()`

--- a/docs/api/generated/core/Engine.md
+++ b/docs/api/generated/core/Engine.md
@@ -65,7 +65,50 @@ Sets the current active scene.
 
 - `newScene`: Pointer to the new Scene to become active.
 
-### `* Use this to inject touch points on ESP32(via TouchManager)`
+### `std::optional<Scene*> getCurrentScene() const`
+
+**Description:**
+
+Retrieves the currently active scene.
+
+**Returns:** Optional pointer to the current Scene, or nullopt if none is set.
+
+### `void setRenderer(pixelroot32::graphics::Renderer&& newRenderer)`
+
+**Description:**
+
+Replaces the current renderer instance.
+
+**Parameters:**
+
+- `newRenderer`: R-value reference to the new Renderer to use.
+
+### `pixelroot32::graphics::Renderer& getRenderer()`
+
+**Description:**
+
+Provides access to the Renderer subsystem.
+
+**Returns:** Reference to the current Renderer.
+
+### `pixelroot32::input::InputManager& getInputManager()`
+
+**Description:**
+
+Provides access to the InputManager subsystem.
+
+**Returns:** Reference to the InputManager    .
+
+### `pixelroot32::input::TouchEventDispatcher& getTouchDispatcher()`
+
+**Description:**
+
+Provides access to the touch event system.
+
+**Returns:** Reference to the TouchEventDispatcher.
+
+Use this to inject touch points on ESP32 (via TouchManager):
+  engine.getTouchDispatcher().processTouch(id, pressed, x, y, timestamp);
 
 ### `bool hasTouchEvents() const`
 
@@ -75,7 +118,26 @@ Check if there are pending touch events.
 
 **Returns:** true if there are events in the queue.
 
-### `* On ESP32, call this once in setup() after touchManager.init()`
+### `void setTouchManager(pixelroot32::input::TouchManager* touchManager)`
+
+**Description:**
+
+Set the TouchManager for automatic touch processing.
+
+**Parameters:**
+
+- `touchManager`: Pointer to the TouchManager instance.
+
+On ESP32, call this once in setup() after touchManager.init():
+  touchManager.init();
+  engine.setTouchManager(&touchManager);
+
+Then in loop(), just call engine.run() - Engine handles:
+  - Polling touchManager.getTouchPoints() each frame
+  - Detecting touch release (when count goes from >0 to 0)
+  - Sending gesture events to the current scene
+
+This eliminates the need to manually inject touch points or track release state.
 
 ### `void connectInputToDrawer()`
 
@@ -88,6 +150,34 @@ Connect InputManager to Drawer for mouse-to-touch mapping.
 - `inputManager`: Pointer to the InputManager.
 
 Called automatically in init() for Native builds.
+
+### `graphics::ui::UIManager& getUIManager()`
+
+**Description:**
+
+Provides access to the UI system via the current scene.
+
+**Returns:** Reference to the current scene's UIManager.
+
+::: tip
+Asserts if no scene is currently active.
+:::
+
+### `pixelroot32::audio::AudioEngine& getAudioEngine()`
+
+**Description:**
+
+Provides access to the AudioEngine subsystem.
+
+**Returns:** Reference to the AudioEngine.
+
+### `pixelroot32::audio::MusicPlayer& getMusicPlayer()`
+
+**Description:**
+
+Provides access to the MusicPlayer subsystem.
+
+**Returns:** Reference to the MusicPlayer.
 
 ### `const PlatformCapabilities& getPlatformCapabilities() const`
 
@@ -108,3 +198,10 @@ Updates the game logic.
 **Description:**
 
 Renders the current frame.
+
+### `void drawDebugOverlay(pixelroot32::graphics::Renderer& r)`
+
+**Description:**
+
+Draws a debug overlay with real-time engine metrics.
+Shows FPS, CPU usage (estimated), and RAM usage.

--- a/docs/api/generated/core/Entity.md
+++ b/docs/api/generated/core/Entity.md
@@ -63,6 +63,40 @@ Sets the render layer.
 
 - `layer`: The layer index (0 to MaxLayers-1). Clamped if exceeded.
 
+### `: position(pos), width(w), height(h), type(t)`
+
+**Description:**
+
+Constructor.
+
+**Parameters:**
+
+- `position`: Initial position.
+- `w`: Width.
+- `h`: Height.
+- `t`: EntityType.
+
+### `: position(x, y), width(w), height(h), type(t)`
+
+**Description:**
+
+Constructor.
+
+**Parameters:**
+
+- `x`: Initial X position.
+- `y`: Initial Y position.
+- `w`: Width.
+- `h`: Height.
+- `t`: EntityType.
+
+### `: position(pixelroot32::math::toScalar(x), pixelroot32::math::toScalar(y)), width(w), height(h), type(t)`
+
+**Description:**
+
+Constructor with float coordinates for convenience.
+Only enabled if Scalar is NOT float to avoid ambiguity.
+
 ### `virtual void update(unsigned long deltaTime)`
 
 **Description:**
@@ -72,3 +106,13 @@ Updates the entity's logic.
 **Parameters:**
 
 - `deltaTime`: Time elapsed since the last frame in milliseconds.
+
+### `virtual void draw(pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Renders the entity.
+
+**Parameters:**
+
+- `renderer`: Reference to the renderer to use for drawing.

--- a/docs/api/generated/core/PhysicsActor.md
+++ b/docs/api/generated/core/PhysicsActor.md
@@ -72,6 +72,14 @@ Gets information about collisions with the world boundaries.
 
 **Returns:** A WorldCollisionInfo struct containing collision flags.
 
+### `bool isPhysicsBody() const`
+
+**Description:**
+
+Checks if this actor is a physics-enabled body.
+
+**Returns:** true.
+
 ### `void resetWorldCollisionInfo()`
 
 **Description:**
@@ -106,6 +114,42 @@ Sets the mass of the actor.
 
 - `m`: Mass value.
 
+### `pixelroot32::math::Scalar getMass() const`
+
+**Description:**
+
+Gets the mass of the actor.
+
+**Returns:** Mass as Scalar.
+
+### `void setGravityScale(pixelroot32::math::Scalar scale)`
+
+**Description:**
+
+Sets the gravity scale.
+
+**Parameters:**
+
+- `scale`: Multiplier for the world gravity.
+
+### `pixelroot32::math::Scalar getGravityScale() const`
+
+**Description:**
+
+Gets the gravity scale.
+
+**Returns:** Gravity scale as Scalar.
+
+### `virtual void integrate(pixelroot32::math::Scalar dt)`
+
+**Description:**
+
+Integrates velocity to update position.
+
+**Parameters:**
+
+- `dt`: Delta time in seconds (as Scalar).
+
 ### `virtual void resolveWorldBounds()`
 
 **Description:**
@@ -122,6 +166,79 @@ Sets the linear velocity of the actor using floats.
 
 - `x`: Horizontal velocity.
 - `y`: Vertical velocity.
+
+### `void setVelocity(pixelroot32::math::Scalar x, pixelroot32::math::Scalar y)`
+
+**Description:**
+
+Sets the linear velocity of the actor using Scalars.
+
+**Parameters:**
+
+- `x`: Horizontal velocity.
+- `y`: Vertical velocity.
+
+### `void setVelocity(const pixelroot32::math::Vector2& v)`
+
+**Description:**
+
+Sets the linear velocity of the actor using a Vector2.
+
+**Parameters:**
+
+- `v`: Velocity vector.
+
+### `pixelroot32::math::Scalar getVelocityX() const`
+
+**Description:**
+
+Gets the horizontal velocity.
+
+**Returns:** Horizontal velocity as Scalar.
+
+### `pixelroot32::math::Scalar getVelocityY() const`
+
+**Description:**
+
+Gets the vertical velocity.
+
+**Returns:** Vertical velocity as Scalar.
+
+### `const pixelroot32::math::Vector2& getVelocity() const`
+
+**Description:**
+
+Gets the velocity vector.
+
+**Returns:** Reference to the velocity Vector2.
+
+### `void setRestitution(pixelroot32::math::Scalar r)`
+
+**Description:**
+
+Sets the restitution (bounciness) of the actor.
+
+**Parameters:**
+
+- `r`: Restitution value (0.0 to 1.0+). 1.0 means no energy is lost on bounce.
+
+### `pixelroot32::math::Scalar getRestitution() const`
+
+**Description:**
+
+Gets the restitution (bounciness) of the actor.
+
+**Returns:** Restitution as Scalar.
+
+### `void setFriction(pixelroot32::math::Scalar f)`
+
+**Description:**
+
+Sets the friction coefficient.
+
+**Parameters:**
+
+- `f`: Friction value (0.0 means no friction).
 
 ### `CollisionShape getShape() const`
 
@@ -140,6 +257,24 @@ Sets the collision shape type.
 **Parameters:**
 
 - `s`: The new CollisionShape.
+
+### `pixelroot32::math::Scalar getRadius() const`
+
+**Description:**
+
+Gets the radius (only for Shape::CIRCLE).
+
+**Returns:** Radius as Scalar.
+
+### `void setRadius(pixelroot32::math::Scalar r)`
+
+**Description:**
+
+Sets the radius and updates width/height to match diameter.
+
+**Parameters:**
+
+- `r`: Radius value.
 
 ### `void setUserData(void* data)`
 
@@ -212,6 +347,24 @@ Returns true if this body bounces on collision.
 **Description:**
 
 Updates the previous position to the current position.
+
+### `pixelroot32::math::Vector2 getPreviousPosition() const`
+
+**Description:**
+
+Gets the previous frame position.
+
+**Returns:** The position from the previous physics frame.
+
+### `void setPosition(pixelroot32::math::Vector2 pos)`
+
+**Description:**
+
+Sets the position and syncs previous position.
+
+**Parameters:**
+
+- `pos`: The new position.
 
 ### `virtual void onWorldCollision()`
 

--- a/docs/api/generated/core/Scene.md
+++ b/docs/api/generated/core/Scene.md
@@ -33,7 +33,34 @@ Update the UI system.
 
 - `deltaTime`: Time elapsed in ms.
 
-### `* Execution order(deterministic)`
+### `pixelroot32::graphics::ui::UIManager& getUIManager()`
+
+**Description:**
+
+Get the UI manager for this scene.
+
+**Returns:** Reference to the UIManager
+
+### `virtual void processTouchEvents(pixelroot32::input::TouchEvent* events, uint8_t count)`
+
+**Description:**
+
+Central touch pipeline entry point (call once per frame).
+
+**Parameters:**
+
+- `events`: Mutable buffer — consumed flags are set in-place.
+- `count`: Number of events in the buffer.
+
+### `virtual void onUnconsumedTouchEvent(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Hook for scene-specific handling of unconsumed touch events.
+
+**Parameters:**
+
+- `event`: The touch event (not consumed by UI).
 
 ### `virtual void update(unsigned long deltaTime)`
 
@@ -44,6 +71,30 @@ Updates all entities in the scene and handles collisions.
 **Parameters:**
 
 - `deltaTime`: Time elapsed in ms.
+
+### `virtual void draw(pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Draws all visible entities in the scene.
+
+**Parameters:**
+
+- `renderer`: The renderer to use.
+
+### `virtual void adviseFramebufferBeforeBeginFrame(pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Advises the scene that the framebuffer is about to be drawn.
+
+**Parameters:**
+
+- `renderer`: The renderer to use.
+
+Optional hook: run immediately before Renderer::beginFrame().
+Scenes using StaticTilemapLayerCache should call adviseFramebufferBeforeBeginFrame with the same
+layers/camera sampling as StaticTilemapLayerCache::draw so dirty-region clears align with framebuffer memcpy restores.
 
 ### `virtual bool shouldRedrawFramebuffer() const`
 

--- a/docs/api/generated/core/SceneManager.md
+++ b/docs/api/generated/core/SceneManager.md
@@ -49,6 +49,30 @@ Updates the currently active scene.
 
 - `dt`: Delta time in ms.
 
+### `void draw(pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Draws the currently active scene.
+
+**Parameters:**
+
+- `renderer`: The renderer to use.
+
+### `void adviseFramebufferBeforeBeginFrame(pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Lets stacked scenes advertise framebuffer prep (runs before Renderer::beginFrame).
+
+### `std::optional<Scene*> getCurrentScene() const`
+
+**Description:**
+
+Gets the currently active scene.
+
+**Returns:** Optional pointer to the top scene on the stack.
+
 ### `bool aggregateShouldRedrawFramebuffer() const`
 
 **Description:**

--- a/docs/api/generated/drivers/ESP32AudioScheduler.md
+++ b/docs/api/generated/drivers/ESP32AudioScheduler.md
@@ -21,6 +21,14 @@ Constructor arguments are reserved for API stability.
 
 ## Methods
 
+### `bool isIndependent() const`
+
+### `bool isMusicPlaying() const`
+
+### `bool isMusicPaused() const`
+
+### `ApuCore& getApuCore()`
+
 ### `const ApuCore& core() const`
 
 ### `ApuCore& core()`

--- a/docs/api/generated/drivers/ESP32_DAC_AudioBackend.md
+++ b/docs/api/generated/drivers/ESP32_DAC_AudioBackend.md
@@ -23,4 +23,6 @@ Target: ESP32 (original), ESP32-S2. The DAC does not exist on S3/C3.
 
 ## Methods
 
+### `int getSampleRate() const`
+
 ### `void audioTaskLoop()`

--- a/docs/api/generated/drivers/ESP32_I2S_AudioBackend.md
+++ b/docs/api/generated/drivers/ESP32_I2S_AudioBackend.md
@@ -19,4 +19,6 @@ to ensure smooth playback independent of the game loop frame rate.
 
 ## Methods
 
+### `int getSampleRate() const`
+
 ### `void audioTaskLoop()`

--- a/docs/api/generated/drivers/NativeAudioScheduler.md
+++ b/docs/api/generated/drivers/NativeAudioScheduler.md
@@ -23,6 +23,14 @@ threading and the ring buffer.
 
 ### `explicit NativeAudioScheduler(size_t ringBufferSize = 4096)`
 
+### `bool isIndependent() const`
+
+### `bool isMusicPlaying() const`
+
+### `bool isMusicPaused() const`
+
+### `ApuCore& getApuCore()`
+
 ### `const ApuCore& core() const`
 
 ### `ApuCore& core()`

--- a/docs/api/generated/drivers/SDL2_AudioBackend.md
+++ b/docs/api/generated/drivers/SDL2_AudioBackend.md
@@ -16,4 +16,6 @@ Audio backend implementation for SDL2 (Windows/Linux/Mac).
 
 ## Methods
 
+### `int getSampleRate() const`
+
 ### `void audioCallback(uint8_t* stream, int len)`

--- a/docs/api/generated/drivers/SDL2_Drawer.md
+++ b/docs/api/generated/drivers/SDL2_Drawer.md
@@ -13,3 +13,36 @@ SDL2-backed draw surface for native desktop builds.
 ## Inheritance
 
 [BaseDrawSurface](../graphics/BaseDrawSurface.md) → `SDL2_Drawer`
+
+## Methods
+
+### `uint8_t* getSpriteBuffer()`
+
+**Description:**
+
+Get pointer to sprite buffer (not supported in SDL2).
+
+### `void setTouchDispatcher(pixelroot32::input::TouchEventDispatcher* touchDispatcher)`
+
+**Description:**
+
+Set the TouchEventDispatcher to receive mouse events.
+
+**Parameters:**
+
+- `touchDispatcher`: Pointer to the Engine's TouchEventDispatcher.
+
+This is the preferred method when PIXELROOT32_ENABLE_TOUCH is enabled.
+Mouse events are mapped directly to touch events.
+
+### `void setInputManager(pixelroot32::input::InputManager* inputManager)`
+
+**Description:**
+
+Set the InputManager for backwards compatibility.
+
+**Parameters:**
+
+- `inputManager`: Pointer to the InputManager instance.
+
+Deprecated: Use setTouchDispatcher() instead.

--- a/docs/api/generated/drivers/U8G2_Drawer.md
+++ b/docs/api/generated/drivers/U8G2_Drawer.md
@@ -18,6 +18,10 @@ Implementation of DrawSurface using the U8G2 library for monochromatic OLED disp
 
 ### `U8G2* getU8g2() const`
 
+### `void drawTileDirect(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t* data)`
+
+### `uint8_t* getSpriteBuffer()`
+
 ### `bool needsScaling() const`
 
 **Description:**

--- a/docs/api/generated/graphics/BaseDrawSurface.md
+++ b/docs/api/generated/graphics/BaseDrawSurface.md
@@ -8,15 +8,208 @@
 
 ## Description
 
-Optional base class for DrawSurface implementations that provides default primitive rendering.
+Optional base class for DrawSurface implementations providing default primitive rendering.
 
 Users can inherit from this class to avoid implementing every single primitive.
-At minimum, a subclass should implement:
-- init()
-- drawPixel()
-- sendBuffer()
-- clearBuffer()
+At minimum, a subclass must implement:
+- init() — initialize the hardware or window
+- drawPixel() — draw a single pixel (all other primitives delegate here)
+- sendBuffer() — transfer framebuffer to physical display
+- clearBuffer() — fill framebuffer with background color
+
+The default implementations use Bresenham-style algorithms for lines,
+rectangles, circles, and bitmaps, all building on drawPixel().
+These are slow but correct; override in performance-critical drivers.
 
 ## Inheritance
 
 [DrawSurface](./DrawSurface.md) → `BaseDrawSurface`
+
+## Methods
+
+### `void setTextColor(uint16_t color)`
+
+**Description:**
+
+Sets the text color.
+
+**Parameters:**
+
+- `color`: 16-bit RGB565 text color.
+
+### `void setTextSize(uint8_t size)`
+
+**Description:**
+
+Sets the text size multiplier.
+
+**Parameters:**
+
+- `size`: Size multiplier (1 = normal, 2 = double, etc.).
+
+### `void setCursor(int16_t x, int16_t y)`
+
+**Description:**
+
+Sets the text cursor position.
+
+**Parameters:**
+
+- `x`: X coordinate in pixels.
+- `y`: Y coordinate in pixels.
+
+### `void setContrast(uint8_t level)`
+
+**Description:**
+
+Sets the display brightness.
+
+**Parameters:**
+
+- `level`: Contrast level (0–255).
+
+### `void setRotation(uint16_t rot)`
+
+**Description:**
+
+Sets the display rotation.
+
+**Parameters:**
+
+- `rot`: Rotation index (0, 1, 2, 3) or degrees (0, 90, 180, 270).
+
+### `void setDisplaySize(int w, int h)`
+
+**Description:**
+
+Sets the logical rendering resolution.
+
+**Parameters:**
+
+- `w`: Logical width in pixels.
+- `h`: Logical height in pixels.
+
+### `void setPhysicalSize(int w, int h)`
+
+**Description:**
+
+Sets the physical display resolution.
+
+**Parameters:**
+
+- `w`: Physical width in pixels.
+- `h`: Physical height in pixels.
+
+### `void setOffset(int x, int y)`
+
+**Description:**
+
+Sets the display origin offset.
+
+**Parameters:**
+
+- `x`: Horizontal offset in pixels.
+- `y`: Vertical offset in pixels.
+
+### `void present()`
+
+**Description:**
+
+Transfers the framebuffer to the physical display.
+
+### `uint16_t color565(uint8_t r, uint8_t g, uint8_t b)`
+
+**Description:**
+
+Converts 24-bit RGB to RGB565.
+
+**Parameters:**
+
+- `r`: Red component (0-255).
+- `g`: Green component (0-255).
+- `b`: Blue component (0-255).
+
+**Returns:** 16-bit RGB565 color.
+
+### `void drawLine(int x1, int y1, int x2, int y2, uint16_t color)`
+
+**Description:**
+
+Draws a line between two points (Bresenham algorithm).
+
+**Parameters:**
+
+- `x1`: Start X coordinate.
+- `y1`: Start Y coordinate.
+- `x2`: End X coordinate.
+- `y2`: End Y coordinate.
+- `color`: 16-bit RGB565 line color.
+
+### `void drawRectangle(int x, int y, int w, int h, uint16_t color)`
+
+**Description:**
+
+Draws a rectangle outline.
+
+**Parameters:**
+
+- `x`: Top-left X coordinate.
+- `y`: Top-left Y coordinate.
+- `w`: Width in pixels.
+- `h`: Height in pixels.
+- `color`: 16-bit RGB565 outline color.
+
+### `void drawFilledRectangle(int x, int y, int w, int h, uint16_t color)`
+
+**Description:**
+
+Draws a filled rectangle.
+
+**Parameters:**
+
+- `x`: Top-left X coordinate.
+- `y`: Top-left Y coordinate.
+- `w`: Width in pixels.
+- `h`: Height in pixels.
+- `color`: 16-bit RGB565 fill color.
+
+### `void drawCircle(int x0, int y0, int r, uint16_t color)`
+
+**Description:**
+
+Draws a circle outline (midpoint algorithm).
+
+**Parameters:**
+
+- `x0`: Center X coordinate.
+- `y0`: Center Y coordinate.
+- `r`: Radius in pixels.
+- `color`: 16-bit RGB565 outline color.
+
+### `void drawFilledCircle(int x0, int y0, int r, uint16_t color)`
+
+**Description:**
+
+Draws a filled circle (midpoint algorithm).
+
+**Parameters:**
+
+- `x0`: Center X coordinate.
+- `y0`: Center Y coordinate.
+- `r`: Radius in pixels.
+- `color`: 16-bit RGB565 fill color.
+
+### `void drawBitmap(int x, int y, int w, int h, const uint8_t *bitmap, uint16_t color)`
+
+**Description:**
+
+Draws a 1bpp bitmap, rendering only non-zero pixels.
+
+**Parameters:**
+
+- `x`: Top-left X coordinate.
+- `y`: Top-left Y coordinate.
+- `w`: Width in pixels.
+- `h`: Height in pixels.
+- `bitmap`: Pointer to packed 1bpp row data (byte per row, MSB left).
+- `color`: 16-bit RGB565 color for "on" pixels.

--- a/docs/api/generated/graphics/Camera2D.md
+++ b/docs/api/generated/graphics/Camera2D.md
@@ -6,27 +6,47 @@
 
 ## Description
 
-2D camera system for managing viewports and scrolling.
+2D camera for viewport management and smooth scrolling.
+
+Manages the viewable area of a scene, providing bounds clamping and
+smooth follow-target behavior. The camera sits at a fixed position
+until instructed to follow a target; its X/Y coordinates are negated
+to become the Renderer's X/Y offset (so content scrolls "under" the camera).
+
+Bounds are enforced per-axis; if no bounds are set the camera is unclamped
+on that axis. A target X or Y position outside bounds is clamped before
+the camera moves.
+
+Camera2D does not own a Renderer. Call apply(renderer) to push the
+      camera transform after updating.
+
+::: tip
+Camera2D does not own a Renderer. Call apply(renderer) to push the
+      camera transform after updating.
+:::
 
 ## Methods
+
+### `void setBounds(pixelroot32::math::Scalar minX, pixelroot32::math::Scalar maxX)`
+
+### `void setVerticalBounds(pixelroot32::math::Scalar minY, pixelroot32::math::Scalar maxY)`
+
+### `void setPosition(pixelroot32::math::Vector2 position)`
+
+### `void followTarget(pixelroot32::math::Scalar targetX)`
+
+### `void followTarget(pixelroot32::math::Vector2 target)`
+
+### `pixelroot32::math::Scalar getX() const`
+
+### `pixelroot32::math::Scalar getY() const`
+
+### `pixelroot32::math::Vector2 getPosition() const`
 
 ### `void apply(Renderer& renderer) const`
 
 **Description:**
 
-Applies the camera transformation to a renderer.
-
-**Parameters:**
-
-- `renderer`: The renderer to apply the camera to.
+Pushes the camera transform into the renderer (sets display offset).
 
 ### `void setViewportSize(int width, int height)`
-
-**Description:**
-
-Sets the viewport size (usually logical resolution).
-
-**Parameters:**
-
-- `width`: Viewport width.
-- `height`: Viewport height.

--- a/docs/api/generated/graphics/DirtyGrid.md
+++ b/docs/api/generated/graphics/DirtyGrid.md
@@ -13,17 +13,6 @@ Bit-packed storage: one bit per cell. `curr` accumulates marks for the current f
 
 ## Methods
 
-### `void init(int screenW, int screenH)`
-
-**Description:**
-
-Initializes the dirty grid dimensions based on screen size.
-
-**Parameters:**
-
-- `screenW`: Width of the screen in pixels.
-- `screenH`: Height of the screen in pixels.
-
 ### `void markCell(uint8_t cx, uint8_t cy)`
 
 **Description:**

--- a/docs/api/generated/graphics/DisplayType.md
+++ b/docs/api/generated/graphics/DisplayType.md
@@ -76,3 +76,11 @@ Gets the underlying DrawSurface implementation.
 **Description:**
 
 Initializes the underlying draw surface.
+
+### `std::unique_ptr<DrawSurface> releaseDrawSurface()`
+
+**Description:**
+
+Transfers ownership of the DrawSurface to the caller.
+
+**Returns:** A unique_ptr containing the DrawSurface.

--- a/docs/api/generated/graphics/FontManager.md
+++ b/docs/api/generated/graphics/FontManager.md
@@ -51,6 +51,20 @@ Calculates the width in pixels of a text string when rendered.
 
 **Returns:** Width in pixels, or 0 if font is invalid or text is empty.
 
+### `static int16_t textWidth(const Font* font, std::string_view text, uint8_t size = 1)`
+
+**Description:**
+
+Calculates the width in pixels of a text string when rendered.
+
+**Parameters:**
+
+- `font`: Pointer to the font to use. If nullptr, uses the default font.
+- `text`: The text string to measure.
+- `size`: Text size multiplier (1 = normal, 2 = double size, etc.).
+
+**Returns:** Width in pixels, or 0 if font is invalid or text is empty.
+
 ### `static uint8_t getGlyphIndex(char c, const Font* font = nullptr)`
 
 **Description:**

--- a/docs/api/generated/graphics/ParticleEmitter.md
+++ b/docs/api/generated/graphics/ParticleEmitter.md
@@ -16,3 +16,30 @@ Uses a fixed-size array for particles to avoid dynamic allocation during runtime
 ## Inheritance
 
 [Entity](../core/Entity.md) → `ParticleEmitter`
+
+## Methods
+
+### `void burst(pixelroot32::math::Vector2 position, int count)`
+
+**Description:**
+
+Emits a burst of particles from a specific location.
+
+**Parameters:**
+
+- `position`: Emission origin.
+- `count`: Number of particles to spawn.
+
+### `inline uint16_t lerpColor(uint16_t c1, uint16_t c2, pixelroot32::math::Scalar t)`
+
+**Description:**
+
+Linear interpolation between two 16-bit RGB565 colors.
+
+**Parameters:**
+
+- `c1`: Start color.
+- `c2`: End color.
+- `t`: Interpolation factor (0.0 - 1.0).
+
+**Returns:** Interpolated RGB565 color.

--- a/docs/api/generated/graphics/Renderer.md
+++ b/docs/api/generated/graphics/Renderer.md
@@ -36,6 +36,14 @@ Forces a full clear on the next beginFrame when `PIXELROOT32_ENABLE_DIRTY_REGION
 
 ### `void accumulateFramebufferClearSuppressionAdvice(bool skipClearDueToMemcpyRestore)`
 
+**Description:**
+
+Accumulate framebuffer clear suppression advice from a scene.
+
+**Parameters:**
+
+- `skipClearDueToMemcpyRestore`: True if the scene will restore framebuffer via memcpy
+
 ### `void endFrame()`
 
 **Description:**
@@ -49,6 +57,62 @@ Finalizes the frame and sends the buffer to the display.
 Gets the underlying DrawSurface implementation.
 
 **Returns:** Reference to the DrawSurface.
+
+### `void drawText(std::string_view text, int16_t x, int16_t y, Color color, uint8_t size)`
+
+**Description:**
+
+Draws a string of text using the default font.
+
+**Parameters:**
+
+- `text`: The text to draw.
+- `x`: X coordinate.
+- `y`: Y coordinate.
+- `color`: Text color.
+- `size`: Text size multiplier.
+
+### `void drawText(std::string_view text, int16_t x, int16_t y, Color color, uint8_t size, const Font* font)`
+
+**Description:**
+
+Draws a string of text using a specific font.
+
+**Parameters:**
+
+- `text`: The text to draw.
+- `x`: X coordinate.
+- `y`: Y coordinate.
+- `color`: Text color.
+- `size`: Text size multiplier.
+- `font`: Pointer to the font to use. If nullptr, uses the default font.
+
+### `void drawTextCentered(std::string_view text, int16_t y, Color color, uint8_t size)`
+
+**Description:**
+
+Draws text centered horizontally at a given Y coordinate using the default font.
+
+**Parameters:**
+
+- `text`: The text to draw.
+- `y`: Y coordinate.
+- `color`: Text color.
+- `size`: Text size.
+
+### `void drawTextCentered(std::string_view text, int16_t y, Color color, uint8_t size, const Font* font)`
+
+**Description:**
+
+Draws text centered horizontally at a given Y coordinate using a specific font.
+
+**Parameters:**
+
+- `text`: The text to draw.
+- `y`: Y coordinate.
+- `color`: Text color.
+- `size`: Text size.
+- `font`: Pointer to the font to use. If nullptr, uses the default font.
 
 ### `void drawFilledCircle(int x, int y, int radius, Color color)`
 
@@ -169,6 +233,8 @@ Sets the logical display size (rendering resolution).
 
 - `w`: Logical width.
 - `h`: Logical height.
+
+### `if constexpr(pixelroot32::platforms::config::EnableDirtyRegions)`
 
 ### `int getLogicalWidth() const`
 

--- a/docs/api/generated/graphics/ResolutionPreset.md
+++ b/docs/api/generated/graphics/ResolutionPreset.md
@@ -1,0 +1,12 @@
+# ResolutionPreset
+
+<Badge type="info" text="Enum" />
+
+**Source:** `ResolutionPresets.h`
+
+## Description
+
+Logical resolution choices for memory-constrained targets.
+
+Use create() to turn a preset into a DisplayConfig with the correct
+logical and physical dimensions already set.

--- a/docs/api/generated/graphics/ResolutionPresets.md
+++ b/docs/api/generated/graphics/ResolutionPresets.md
@@ -1,0 +1,13 @@
+# ResolutionPresets
+
+<Badge type="info" text="Class" />
+
+**Source:** `ResolutionPresets.h`
+
+## Description
+
+Factory for creating DisplayConfig from resolution presets.
+
+Simplifies display setup on memory-constrained targets by providing
+a single create() call that sets logical dimensions, physical dimensions,
+and rotation together.

--- a/docs/api/generated/graphics/TileAnimationManager.md
+++ b/docs/api/generated/graphics/TileAnimationManager.md
@@ -30,6 +30,8 @@ Resolve tile index to current animated frame.
 
 PERFORMANCE: O(1) array lookup, IRAM-friendly, no branches in hot path
 
+### `* Complexity: O(animations × frameCount) when at least one tick elapses; else O(1)`
+
 ### `void step(unsigned long deltaTimeMs)`
 
 **Description:**

--- a/docs/api/generated/graphics/TouchConfig.md
+++ b/docs/api/generated/graphics/TouchConfig.md
@@ -6,16 +6,17 @@
 
 ## Description
 
-Configuration for touch controller
+Configuration for a touch controller (XPT2046 or GT911).
 
-Add to DisplayConfig or use standalone.
-Define one of TOUCH_DRIVER_XPT2046 or TOUCH_DRIVER_GT911 in build flags.
+Set controller, communication parameters, and calibration transform.
+Coordinate mapping: screenX = rawX * scaleX + offsetX (and same for Y).
+Raw coordinates outside display bounds are clamped before mapping.
 
 ## Properties
 
 | Name | Type | Description |
 |------|------|-------------|
-| `controller` | `TouchController` | Active controller |
+| `controller` | `TouchController` | Active controller type. |
 
 ## Methods
 
@@ -23,10 +24,23 @@ Define one of TOUCH_DRIVER_XPT2046 or TOUCH_DRIVER_GT911 in build flags.
 
 **Description:**
 
-Constructor for XPT2046
+Factory: XPT2046 SPI configuration.
+
+**Parameters:**
+
+- `cs`: SPI chip-select pin.
+- `irq`: Interrupt pin (255 = unused).
+
+**Returns:** Configured TouchConfig.
 
 ### `static TouchConfig createGT911(uint8_t irq = 4)`
 
 **Description:**
 
-Constructor for GT911
+Factory: GT911 I2C configuration.
+
+**Parameters:**
+
+- `irq`: Interrupt pin (default 4).
+
+**Returns:** Configured TouchConfig.

--- a/docs/api/generated/graphics/TouchController.md
+++ b/docs/api/generated/graphics/TouchController.md
@@ -6,4 +6,4 @@
 
 ## Description
 
-Supported touch controller types
+Supported touch controller types.

--- a/docs/api/generated/graphics/UIAnchorLayout.md
+++ b/docs/api/generated/graphics/UIAnchorLayout.md
@@ -41,3 +41,32 @@ Sets the screen size for anchor calculations.
 
 - `screenWidth`: Screen width in pixels.
 - `screenHeight`: Screen height in pixels.
+
+### `pixelroot32::math::Scalar getScreenWidth() const`
+
+**Description:**
+
+Gets the screen width.
+
+**Returns:** Screen width in pixels.
+
+### `pixelroot32::math::Scalar getScreenHeight() const`
+
+**Description:**
+
+Gets the screen height.
+
+**Returns:** Screen height in pixels.
+
+### `void calculateAnchorPosition(UIElement* element, Anchor anchor, pixelroot32::math::Scalar& outX, pixelroot32::math::Scalar& outY) const`
+
+**Description:**
+
+Calculates position for an element based on its anchor.
+
+**Parameters:**
+
+- `element`: The element to position.
+- `anchor`: The anchor point.
+- `outX`: Output parameter for calculated X position.
+- `outY`: Output parameter for calculated Y position.

--- a/docs/api/generated/graphics/UIButton.md
+++ b/docs/api/generated/graphics/UIButton.md
@@ -49,6 +49,25 @@ Checks if the button is currently selected.
 
 **Returns:** true if selected.
 
+### `bool isFocusable() const`
+
+**Description:**
+
+Checks if the element is focusable.
+
+**Returns:** true (Buttons are always focusable).
+
+### `void handleInput(const pixelroot32::input::InputManager& input)`
+
+**Description:**
+
+Handles input events.
+Checks for touch events within bounds or confirmation buttons if selected.
+
+**Parameters:**
+
+- `input`: The input manager instance.
+
 ### `void press()`
 
 **Description:**

--- a/docs/api/generated/graphics/UICheckBox.md
+++ b/docs/api/generated/graphics/UICheckBox.md
@@ -80,6 +80,25 @@ Checks if the checkbox is currently selected.
 
 **Returns:** true if selected.
 
+### `bool isFocusable() const`
+
+**Description:**
+
+Checks if the element is focusable.
+
+**Returns:** true (Checkboxes are always focusable).
+
+### `void handleInput(const pixelroot32::input::InputManager& input)`
+
+**Description:**
+
+Handles input events.
+Checks for touch events within bounds or confirmation buttons if selected.
+
+**Parameters:**
+
+- `input`: The input manager instance.
+
 ### `void toggle()`
 
 **Description:**

--- a/docs/api/generated/graphics/UIElement.md
+++ b/docs/api/generated/graphics/UIElement.md
@@ -52,3 +52,26 @@ Sets whether the element is in a fixed position (HUD/Overlay).
 Checks if the element is in a fixed position.
 
 **Returns:** True if fixed position is enabled.
+
+### `virtual void setPosition(pixelroot32::math::Scalar newX, pixelroot32::math::Scalar newY)`
+
+**Description:**
+
+Sets the position of the element.
+
+**Parameters:**
+
+- `newX`: New X coordinate.
+- `newY`: New Y coordinate.
+
+### `virtual void getPreferredSize(pixelroot32::math::Scalar& preferredWidth, pixelroot32::math::Scalar& preferredHeight) const`
+
+**Description:**
+
+Gets the preferred size of the element.
+Used by layouts to determine how much space the element needs.
+
+**Parameters:**
+
+- `preferredWidth`: Output parameter for preferred width (or -1 if flexible).
+- `preferredHeight`: Output parameter for preferred height (or -1 if flexible).

--- a/docs/api/generated/graphics/UIHorizontalLayout.md
+++ b/docs/api/generated/graphics/UIHorizontalLayout.md
@@ -40,6 +40,42 @@ Enables or disables scrolling (alias for setScrollEnabled).
 
 - `enable`: True to enable scrolling.
 
+### `void setViewportWidth(pixelroot32::math::Scalar w)`
+
+**Description:**
+
+Sets the viewport width (visible area).
+
+**Parameters:**
+
+- `w`: Viewport width in pixels.
+
+### `pixelroot32::math::Scalar getScrollOffset() const`
+
+**Description:**
+
+Gets the current scroll offset.
+
+**Returns:** Scroll offset in pixels.
+
+### `void setScrollOffset(pixelroot32::math::Scalar offset)`
+
+**Description:**
+
+Sets the scroll offset directly.
+
+**Parameters:**
+
+- `offset`: Scroll offset in pixels.
+
+### `pixelroot32::math::Scalar getContentWidth() const`
+
+**Description:**
+
+Gets the total content width.
+
+**Returns:** Content width in pixels.
+
 ### `int getSelectedIndex() const`
 
 **Description:**
@@ -65,6 +101,16 @@ Sets the selected element index.
 Gets the selected element.
 
 **Returns:** Pointer to selected element, or nullptr if none selected.
+
+### `void setScrollSpeed(pixelroot32::math::Scalar speed)`
+
+**Description:**
+
+Sets the scroll speed for smooth scrolling.
+
+**Parameters:**
+
+- `speed`: Pixels per millisecond.
 
 ### `void setNavigationButtons(uint8_t leftButton, uint8_t rightButton)`
 

--- a/docs/api/generated/graphics/UILabel.md
+++ b/docs/api/generated/graphics/UILabel.md
@@ -18,6 +18,17 @@ Displays a string of text on the screen. Auto-calculates its bounds based on tex
 
 ## Methods
 
+### `void setText(std::string_view t)`
+
+**Description:**
+
+Updates the label's text.
+Recalculates dimensions if text changes.
+
+**Parameters:**
+
+- `t`: New text.
+
 ### `void setVisible(bool v)`
 
 **Description:**

--- a/docs/api/generated/graphics/UILayout.md
+++ b/docs/api/generated/graphics/UILayout.md
@@ -20,6 +20,31 @@ that can be added to scenes.
 
 ## Methods
 
+### `: UIElement(x, y, w, h, UIElementType::LAYOUT)`
+
+**Description:**
+
+Constructs a new UILayout.
+
+**Parameters:**
+
+- `x`: X position of the layout container.
+- `y`: Y position of the layout container.
+- `w`: Width of the layout container.
+- `h`: Height of the layout container.
+
+### `: UIElement(position, w, h, UIElementType::LAYOUT)`
+
+**Description:**
+
+Constructs a new UILayout.
+
+**Parameters:**
+
+- `position`: Position of the layout container.
+- `w`: Width of the layout container.
+- `h`: Height of the layout container.
+
 ### `virtual void addElement(UIElement* element)`
 
 **Description:**
@@ -46,6 +71,52 @@ Removes a UI element from the layout.
 
 Recalculates positions of all elements in the layout.
 Should be called automatically when elements are added/removed.
+
+### `virtual void handleInput(const pixelroot32::input::InputManager& input)`
+
+**Description:**
+
+Handles input for layout navigation (scroll, selection, etc.).
+
+**Parameters:**
+
+- `input`: Reference to the InputManager.
+
+### `void setPadding(pixelroot32::math::Scalar p)`
+
+**Description:**
+
+Sets the padding (internal spacing) of the layout.
+
+**Parameters:**
+
+- `p`: Padding value in pixels.
+
+### `pixelroot32::math::Scalar getPadding() const`
+
+**Description:**
+
+Gets the current padding.
+
+**Returns:** Padding value in pixels.
+
+### `void setSpacing(pixelroot32::math::Scalar s)`
+
+**Description:**
+
+Sets the spacing between elements.
+
+**Parameters:**
+
+- `s`: Spacing value in pixels.
+
+### `pixelroot32::math::Scalar getSpacing() const`
+
+**Description:**
+
+Gets the current spacing.
+
+**Returns:** Spacing value in pixels.
 
 ### `size_t getElementCount() const`
 

--- a/docs/api/generated/graphics/UIManager.md
+++ b/docs/api/generated/graphics/UIManager.md
@@ -64,6 +64,10 @@ Register an element for touch hit-testing and processEvents.
 
 ### `void clear()`
 
+### `uint8_t processEvents(pixelroot32::input::TouchEvent* events, uint8_t count)`
+
+### `bool processEvent(pixelroot32::input::TouchEvent& event)`
+
 ### `UITouchWidget* getActiveWidget() const`
 
 ### `UITouchWidget* getHoverWidget() const`
@@ -82,4 +86,4 @@ Register an element for touch hit-testing and processEvents.
 
 ### `void update(unsigned long deltaTime)`
 
-### `int8_t findFreeSlot() const`
+### `void draw(pixelroot32::graphics::Renderer& renderer)`

--- a/docs/api/generated/graphics/UIPaddingContainer.md
+++ b/docs/api/generated/graphics/UIPaddingContainer.md
@@ -38,6 +38,61 @@ Gets the child element.
 
 **Returns:** Pointer to the child element, or nullptr if none set.
 
+### `void setPadding(pixelroot32::math::Scalar p)`
+
+**Description:**
+
+Sets uniform padding on all sides.
+
+**Parameters:**
+
+- `p`: Padding value in pixels.
+
+### `void setPadding(pixelroot32::math::Scalar left, pixelroot32::math::Scalar right, pixelroot32::math::Scalar top, pixelroot32::math::Scalar bottom)`
+
+**Description:**
+
+Sets asymmetric padding.
+
+**Parameters:**
+
+- `left`: Left padding in pixels.
+- `right`: Right padding in pixels.
+- `top`: Top padding in pixels.
+- `bottom`: Bottom padding in pixels.
+
+### `pixelroot32::math::Scalar getPaddingLeft() const`
+
+**Description:**
+
+Gets the left padding.
+
+**Returns:** Left padding in pixels.
+
+### `pixelroot32::math::Scalar getPaddingRight() const`
+
+**Description:**
+
+Gets the right padding.
+
+**Returns:** Right padding in pixels.
+
+### `pixelroot32::math::Scalar getPaddingTop() const`
+
+**Description:**
+
+Gets the top padding.
+
+**Returns:** Top padding in pixels.
+
+### `pixelroot32::math::Scalar getPaddingBottom() const`
+
+**Description:**
+
+Gets the bottom padding.
+
+**Returns:** Bottom padding in pixels.
+
 ### `void updateChildPosition()`
 
 **Description:**

--- a/docs/api/generated/graphics/UIPanel.md
+++ b/docs/api/generated/graphics/UIPanel.md
@@ -38,6 +38,42 @@ Gets the child element.
 
 **Returns:** Pointer to the child element, or nullptr if none set.
 
+### `void setBackgroundColor(pixelroot32::graphics::Color color)`
+
+**Description:**
+
+Sets the background color.
+
+**Parameters:**
+
+- `color`: Background color.
+
+### `pixelroot32::graphics::Color getBackgroundColor() const`
+
+**Description:**
+
+Gets the background color.
+
+**Returns:** Background color.
+
+### `void setBorderColor(pixelroot32::graphics::Color color)`
+
+**Description:**
+
+Sets the border color.
+
+**Parameters:**
+
+- `color`: Border color.
+
+### `pixelroot32::graphics::Color getBorderColor() const`
+
+**Description:**
+
+Gets the border color.
+
+**Returns:** Border color.
+
 ### `void setBorderWidth(uint8_t width)`
 
 **Description:**

--- a/docs/api/generated/graphics/UITouchButton.md
+++ b/docs/api/generated/graphics/UITouchButton.md
@@ -21,6 +21,24 @@ Events: OnDown, OnUp, OnClick
 
 ## Methods
 
+### `void setLabel(std::string_view label)`
+
+**Description:**
+
+Set the button label
+
+**Parameters:**
+
+- `label`: String view to the label (no allocation)
+
+### `std::string_view getLabel() const`
+
+**Description:**
+
+Get the current label
+
+**Returns:** String view to the label (no allocation)
+
 ### `void setColors(Color normal, Color pressed, Color disabled)`
 
 **Description:**
@@ -178,6 +196,24 @@ Auto-size button width to fit the current label
 **Parameters:**
 
 - `padding`: Extra pixels to add around text (default: 4)
+
+### `void handleTouchDown(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch down event
+
+### `void handleTouchUp(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch up event
+
+### `void handleClick(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle click event
 
 ### `void setActive()`
 

--- a/docs/api/generated/graphics/UITouchCheckbox.md
+++ b/docs/api/generated/graphics/UITouchCheckbox.md
@@ -39,6 +39,24 @@ Get current font size
 
 **Returns:** Font size multiplier
 
+### `void setLabel(std::string_view label)`
+
+**Description:**
+
+Set the checkbox label
+
+**Parameters:**
+
+- `label`: String view to the label (no allocation)
+
+### `std::string_view getLabel() const`
+
+**Description:**
+
+Get the current label
+
+**Returns:** String view to the label (no allocation)
+
 ### `void setChecked(bool checked)`
 
 **Description:**
@@ -138,6 +156,18 @@ Get the OnChanged callback
 **Description:**
 
 Reset checkbox state
+
+### `void handleTouchDown(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch down event
+
+### `void handleTouchUp(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch up event (triggers toggle if within bounds)
 
 ### `void setActive()`
 

--- a/docs/api/generated/graphics/UITouchElement.md
+++ b/docs/api/generated/graphics/UITouchElement.md
@@ -22,6 +22,14 @@ Memory: Owns widget data inline - no external allocation needed.
 
 ## Methods
 
+### `virtual bool processEvent(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Process a touch event (polymorphic dispatch from UIManager).
+
+**Returns:** true if this element handled the event for UI consumption semantics
+
 ### `virtual uint8_t getWidgetState() const`
 
 **Description:**
@@ -73,6 +81,17 @@ Set widget enabled state
 **Parameters:**
 
 - `enabled`: True to enable
+
+### `void setPosition(pixelroot32::math::Scalar newX, pixelroot32::math::Scalar newY)`
+
+**Description:**
+
+Override setPosition to sync widgetData_ with Entity position
+
+**Parameters:**
+
+- `newX`: New X coordinate
+- `newY`: New Y coordinate
 
 ### `int16_t getX() const`
 

--- a/docs/api/generated/graphics/UITouchSlider.md
+++ b/docs/api/generated/graphics/UITouchSlider.md
@@ -165,6 +165,30 @@ Check if value changed since last frame
 
 Reset slider state
 
+### `bool handleTouchDown(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch down event
+
+**Returns:** true if handled
+
+### `bool handleDragMove(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle drag move event
+
+**Returns:** true if handled
+
+### `bool handleTouchUp(const pixelroot32::input::TouchEvent& event)`
+
+**Description:**
+
+Handle touch up event
+
+**Returns:** true if handled
+
 ### `void updateValueFromPosition(int16_t xPos)`
 
 **Description:**

--- a/docs/api/generated/graphics/UITouchWidget.md
+++ b/docs/api/generated/graphics/UITouchWidget.md
@@ -23,6 +23,16 @@ Base touch widget structure
 
 ## Methods
 
+### `: type(UIWidgetType::Generic)`
+
+**Description:**
+
+Default constructor - creates empty widget
+
+### `, state(UIWidgetState::Idle)`
+
+### `, flags(UIWidgetFlags::None)`
+
 ### `, id(0)`
 
 ### `, x(0)`
@@ -32,6 +42,12 @@ Base touch widget structure
 ### `, width(0)`
 
 ### `, height(0)`
+
+### `: type(widgetType)`
+
+**Description:**
+
+Construct touch widget with all fields
 
 ### `, id(widgetId)`
 

--- a/docs/api/generated/graphics/UIVerticalLayout.md
+++ b/docs/api/generated/graphics/UIVerticalLayout.md
@@ -40,6 +40,42 @@ Enables or disables scrolling (alias for setScrollEnabled).
 
 - `enable`: True to enable scrolling.
 
+### `void setViewportHeight(pixelroot32::math::Scalar h)`
+
+**Description:**
+
+Sets the viewport height (visible area).
+
+**Parameters:**
+
+- `h`: Viewport height in pixels.
+
+### `pixelroot32::math::Scalar getScrollOffset() const`
+
+**Description:**
+
+Gets the current scroll offset.
+
+**Returns:** Scroll offset in pixels.
+
+### `void setScrollOffset(pixelroot32::math::Scalar offset)`
+
+**Description:**
+
+Sets the scroll offset directly.
+
+**Parameters:**
+
+- `offset`: Scroll offset in pixels.
+
+### `pixelroot32::math::Scalar getContentHeight() const`
+
+**Description:**
+
+Gets the total content height.
+
+**Returns:** Content height in pixels.
+
 ### `int getSelectedIndex() const`
 
 **Description:**
@@ -65,6 +101,16 @@ Sets the selected element index.
 Gets the selected element.
 
 **Returns:** Pointer to selected element, or nullptr if none selected.
+
+### `void setScrollSpeed(pixelroot32::math::Scalar speed)`
+
+**Description:**
+
+Sets the scroll speed for smooth scrolling.
+
+**Parameters:**
+
+- `speed`: Pixels per millisecond.
 
 ### `void setNavigationButtons(uint8_t upButton, uint8_t downButton)`
 

--- a/docs/api/generated/index.md
+++ b/docs/api/generated/index.md
@@ -8,16 +8,17 @@ Auto-generated API documentation from C++ header files.
 - [AudioBackend](./audio/AudioBackend.md) — Abstract interface for platform-specific audio drivers.
 - [AudioChannel](./audio/AudioChannel.md) — Represents the internal state of a single audio channel.
 - [AudioCommand](./audio/AudioCommand.md) — Internal command to communicate between game and audio threads.
-- [AudioCommandQueue](./audio/AudioCommandQueue.md) — Multi-Producer Single-Consumer lock-free ring buffer for AudioCommands.
+- [AudioCommandQueue](./audio/AudioCommandQueue.md) — Multi-Producer Single-Consumer (MPSC) lock-free ring buffer for AudioCommands.
 - [AudioConfig](./audio/AudioConfig.md) — Configuration for the Audio subsystem.
-- [AudioEngine](./audio/AudioEngine.md) — Core class for the NES-like audio subsystem.
+- [AudioEngine](./audio/AudioEngine.md) — Facade class for the NES-style audio subsystem.
 - [AudioEvent](./audio/AudioEvent.md) — A fire-and-forget sound event triggered by the game.
 - [AudioScheduler](./audio/AudioScheduler.md) — Abstract interface for the audio execution context.
-- [DefaultAudioScheduler](./audio/DefaultAudioScheduler.md) — Backend-driven scheduler used on platforms without a dedicated
-       audio task.
+- [DefaultAudioScheduler](./audio/DefaultAudioScheduler.md) — Backend-driven scheduler used on platforms without a dedicated audio task.
+- [EnvelopeState](./audio/EnvelopeState.md) — Holds ADSR envelope state for a single voice.
 - [InstrumentPreset](./audio/InstrumentPreset.md) — Defines instrument characteristics for playback.
+- [LfoState](./audio/LfoState.md) — Holds LFO (Low-Frequency Oscillator) state for pitch or volume modulation.
 - [MusicNote](./audio/MusicNote.md) — Represents a single note in a melody.
-- [MusicPlayer](./audio/MusicPlayer.md) — Simple sequencer to play MusicTracks.
+- [MusicPlayer](./audio/MusicPlayer.md) — Simple sequencer to play MusicTracks using the AudioEngine.
 
 ## Core
 
@@ -49,8 +50,8 @@ Auto-generated API documentation from C++ header files.
 ## Graphics
 
 - [Anchor](./graphics/Anchor.md) — Defines anchor points for positioning UI elements.
-- [BaseDrawSurface](./graphics/BaseDrawSurface.md) — Optional base class for DrawSurface implementations that provides default primitive rendering.
-- [Camera2D](./graphics/Camera2D.md) — 2D camera system for managing viewports and scrolling.
+- [BaseDrawSurface](./graphics/BaseDrawSurface.md) — Optional base class for DrawSurface implementations providing default primitive rendering.
+- [Camera2D](./graphics/Camera2D.md) — 2D camera for viewport management and smooth scrolling.
 - [DirtyGrid](./graphics/DirtyGrid.md) — Two-buffer dirty cell grid (8×8 px cells) for selective framebuffer clears.
 - [DisplayType](./graphics/DisplayType.md) — Identifies the type of display driver to use.
 - [DrawSurface](./graphics/DrawSurface.md) — Abstract interface for platform-specific drawing operations.
@@ -63,6 +64,8 @@ Auto-generated API documentation from C++ header files.
 - [ParticleConfig](./graphics/ParticleConfig.md) — Configuration parameters for a particle emitter.
 - [ParticleEmitter](./graphics/ParticleEmitter.md) — Manages a pool of particles to create visual effects.
 - [Renderer](./graphics/Renderer.md) — High-level graphics rendering system.
+- [ResolutionPreset](./graphics/ResolutionPreset.md) — Logical resolution choices for memory-constrained targets.
+- [ResolutionPresets](./graphics/ResolutionPresets.md) — Factory for creating DisplayConfig from resolution presets.
 - [ScrollBehavior](./graphics/ScrollBehavior.md) — Defines how scrolling behaves in layouts.
 - [Sprite](./graphics/Sprite.md) — Compact sprite descriptor for monochrome bitmapped sprites.
 - [Sprite2bpp](./graphics/Sprite2bpp.md) — Sprite descriptor for 2bpp (4-color) multi-color sprites.
@@ -76,8 +79,8 @@ Auto-generated API documentation from C++ header files.
 - [TileAttributeEntry](./graphics/TileAttributeEntry.md) — All attributes for a single tile at a specific position.
 - [TileMapGeneric](./graphics/TileMapGeneric.md) — Generic tilemap structure supporting 1bpp, 2bpp, or 4bpp tile graphics.
 - [TilemapSpriteDirtyMode](./graphics/TilemapSpriteDirtyMode.md) — Suppress per-sprite dirty marks while drawing tilemaps (static layer or selective animated marking).
-- [TouchConfig](./graphics/TouchConfig.md) — Configuration for touch controller
-- [TouchController](./graphics/TouchController.md) — Supported touch controller types
+- [TouchConfig](./graphics/TouchConfig.md) — Configuration for a touch controller (XPT2046 or GT911).
+- [TouchController](./graphics/TouchController.md) — Supported touch controller types.
 - [UIAnchorLayout](./graphics/UIAnchorLayout.md) — Layout that positions elements at fixed anchor points on the screen.
 - [UIButton](./graphics/UIButton.md) — A clickable button UI element.
 - [UICheckBox](./graphics/UICheckBox.md) — A clickable checkbox UI element.

--- a/docs/api/generated/input/ActorTouchController.md
+++ b/docs/api/generated/input/ActorTouchController.md
@@ -34,6 +34,21 @@ for (uint8_t i = 0; i < count; i++) {
 
 Clear registered actors and drag state (e.g. scene reset / arena recycle).
 
+### `bool registerActor(pixelroot32::core::Actor* actor)`
+
+**Description:**
+
+Register an actor to the drag pool
+
+**Parameters:**
+
+- `actor`: Pointer to the actor to register
+
+**Returns:** true if registration succeeded, false if pool is full
+
+Note: Does not check for duplicates - caller should ensure
+the actor is not already registered.
+
 ### `void setTouchHitSlop(int16_t expandPixels)`
 
 **Description:**
@@ -46,6 +61,18 @@ Expand hit-test rectangles by this many pixels on each side (0 = exact hitbox on
 **Description:**
 
 Current hit slop in pixels (per side).
+
+### `bool unregisterActor(pixelroot32::core::Actor* actor)`
+
+**Description:**
+
+Unregister an actor from the drag pool
+
+**Parameters:**
+
+- `actor`: Pointer to the actor to unregister
+
+**Returns:** true if actor was found and removed, false if not found
 
 ### `void handleTouch(const TouchEvent& event)`
 
@@ -69,6 +96,33 @@ Routes events based on type:
 Check if currently dragging an actor
 
 **Returns:** true if a drag operation is in progress
+
+### `pixelroot32::core::Actor* getDraggedActor() const`
+
+**Description:**
+
+Get the currently dragged actor
+
+**Returns:** Pointer to the dragged actor, nullptr if not dragging
+
+### `pixelroot32::core::Actor* hitTest(int16_t x, int16_t y)`
+
+**Description:**
+
+Perform hit test to find actor at touch position
+
+**Parameters:**
+
+- `x`: X coordinate
+- `y`: Y coordinate
+
+**Returns:** Pointer to hit actor, nullptr if none hit
+
+### `bool pointInRect(int16_t px, int16_t py, const pixelroot32::core::Rect& rect, int16_t slop = 0)`
+
+**Description:**
+
+Check if a point is inside a rectangle, optionally expanded by @a slop pixels per side.
 
 ### `void onTouchDown(const TouchEvent& event)`
 

--- a/docs/api/generated/input/InputConfig.md
+++ b/docs/api/generated/input/InputConfig.md
@@ -8,15 +8,21 @@
 
 Configuration structure for the InputManager.
 
-Defines the mapping between logical inputs and physical pins (ESP32) 
-or keyboard keys (Native/SDL2).
+Maps logical inputs to physical GPIO pins (ESP32) or keyboard scancodes (Native/SDL2).
+Uses fixed-size std::array instead of std::vector for zero-allocation and
+deterministic memory usage on ESP32.
 
-Uses variadic arguments to allow flexible configuration of input count.
+Usage:
+// ESP32
+pr32::input::InputConfig config(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT);
 
-## Properties
+// Native (SDL2)
+pr32::input::InputConfig config(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN);
 
-| Name | Type | Description |
-|------|------|-------------|
-| `buttonNames` | `std::vector<uint8_t>` | Array of button mappings (scancodes) for Native. |
-| `inputPins` | `std::vector<int>` | Array of GPIO pin numbers for ESP32. |
-| `count` | `int` | Total number of configured inputs. |
+// Empty
+pr32::input::InputConfig config{};
+InputManager
+
+## Methods
+
+### `if constexpr(sizeof...(args) > 0)`

--- a/docs/api/generated/input/TouchEvent.md
+++ b/docs/api/generated/input/TouchEvent.md
@@ -37,11 +37,13 @@ Invariants:
 
 ## Methods
 
-### `, x(0)`
+### `: timestamp(0)`
 
 **Description:**
 
 Default constructor - creates empty event
+
+### `, x(0)`
 
 ### `, y(0)`
 
@@ -53,7 +55,7 @@ Default constructor - creates empty event
 
 ### `, _padding(0)`
 
-### `, x(xPos)`
+### `: timestamp(ts)`
 
 **Description:**
 
@@ -67,6 +69,8 @@ Construct touch event with all fields
 - `yPos`: Y coordinate
 - `ts`: Timestamp in ms
 - `eventFlags`: Event flags
+
+### `, x(xPos)`
 
 ### `, y(yPos)`
 

--- a/docs/api/generated/input/TouchPoint.md
+++ b/docs/api/generated/input/TouchPoint.md
@@ -29,6 +29,26 @@ Invariants:
 
 ## Methods
 
+### `: x(0), y(0), pressed(false), id(0), ts(0)`
+
+**Description:**
+
+Default constructor - creates empty/invalid touch point
+
+### `: x(xPos), y(yPos), pressed(isPressed), id(touchId), ts(timestamp)`
+
+**Description:**
+
+Construct a touch point with all fields
+
+**Parameters:**
+
+- `xPos`: X coordinate
+- `yPos`: Y coordinate
+- `isPressed`: Touch state
+- `touchId`: Touch identifier
+- `timestamp`: Timestamp in ms
+
 ### `bool isValid(int16_t maxX, int16_t maxY) const`
 
 **Description:**

--- a/docs/api/generated/input/TouchStateData.md
+++ b/docs/api/generated/input/TouchStateData.md
@@ -23,6 +23,8 @@ Per-touch-ID state tracking
 
 ## Methods
 
+### `: state(TouchState::Idle)`
+
 ### `, pressTime(0)`
 
 ### `, pressX(0)`

--- a/docs/api/generated/math/Fixed16.md
+++ b/docs/api/generated/math/Fixed16.md
@@ -13,13 +13,13 @@ Designed for platforms without FPU (ESP32-C3, C2, C6).
 
 ## Methods
 
-### `constexpr Fixed16()`
+### `constexpr Fixed16() : raw(0)`
 
 **Description:**
 
 Default constructor (initializes to 0).
 
-### `constexpr explicit Fixed16(int32_t rawValue, bool /*isRaw*/)`
+### `constexpr explicit Fixed16(int32_t rawValue, bool /*isRaw*/) : raw(rawValue)`
 
 **Description:**
 
@@ -30,7 +30,7 @@ Raw value constructor.
 - `rawValue`: The raw 32-bit representation.
 - `isRaw`: Dummy parameter to distinguish from integer constructor.
 
-### `constexpr Fixed16(int v)`
+### `constexpr Fixed16(int v) : raw(v << FRACTIONAL_BITS)`
 
 **Description:**
 
@@ -40,7 +40,7 @@ Construct from integer.
 
 - `v`: The integer value.
 
-### `constexpr Fixed16(float v)`
+### `constexpr Fixed16(float v) : raw(static_cast<int32_t>(v * ONE + (v >= 0 ? 0.5f : -0.5f)))`
 
 **Description:**
 
@@ -50,7 +50,7 @@ Construct from float.
 
 - `v`: The float value.
 
-### `constexpr Fixed16(double v)`
+### `constexpr Fixed16(double v) : raw(static_cast<int32_t>(v * ONE + (v >= 0 ? 0.5 : -0.5)))`
 
 **Description:**
 

--- a/docs/api/generated/math/Vector2.md
+++ b/docs/api/generated/math/Vector2.md
@@ -12,13 +12,13 @@ Automatically adapts to the architecture's FPU availability.
 
 ## Methods
 
-### `constexpr Vector2()`
+### `constexpr Vector2() : x(toScalar(0)), y(toScalar(0))`
 
 **Description:**
 
 Default constructor, initializes to (0, 0).
 
-### `constexpr Vector2(Scalar _x, Scalar _y)`
+### `constexpr Vector2(Scalar _x, Scalar _y) : x(_x), y(_y)`
 
 **Description:**
 
@@ -29,7 +29,7 @@ Constructor with given x and y components.
 - `_x`: X component.
 - `_y`: Y component.
 
-### `constexpr Vector2(const Vector2& other)`
+### `constexpr Vector2(const Vector2& other) : x(other.x), y(other.y)`
 
 **Description:**
 
@@ -39,7 +39,7 @@ Copy constructor.
 
 - `other`: The other vector to copy from.
 
-### `constexpr Vector2(int _x, int _y)`
+### `constexpr Vector2(int _x, int _y) : x(toScalar(_x)), y(toScalar(_y))`
 
 **Description:**
 

--- a/docs/api/generated/physics/CollisionSystem.md
+++ b/docs/api/generated/physics/CollisionSystem.md
@@ -10,6 +10,26 @@ Manages physics simulation and collision detection for all actors.
 
 ## Methods
 
+### `void addEntity(pixelroot32::core::Entity* e)`
+
+**Description:**
+
+Adds an entity to the collision system.
+
+**Parameters:**
+
+- `e`: Pointer to the entity to add.
+
+### `void removeEntity(pixelroot32::core::Entity* e)`
+
+**Description:**
+
+Removes an entity from the collision system.
+
+**Parameters:**
+
+- `e`: Pointer to the entity to remove.
+
 ### `void update()`
 
 **Description:**
@@ -59,3 +79,15 @@ Gets the total number of registered entities.
 **Description:**
 
 Clears the collision system state.
+
+### `bool needsCCD(pixelroot32::core::PhysicsActor* body) const`
+
+**Description:**
+
+Checks if a body requires continuous collision detection (CCD).
+
+**Parameters:**
+
+- `body`: The physics actor to check.
+
+**Returns:** True if CCD is required.

--- a/docs/api/generated/physics/RigidActor.md
+++ b/docs/api/generated/physics/RigidActor.md
@@ -16,3 +16,25 @@ dynamic objects that should behave naturally, like falling crates or debris.
 ## Inheritance
 
 [PhysicsActor](../core/PhysicsActor.md) → `RigidActor`
+
+## Methods
+
+### `void applyForce(const pixelroot32::math::Vector2& f)`
+
+**Description:**
+
+Applies a force to the center of mass.
+
+**Parameters:**
+
+- `f`: Force vector.
+
+### `void applyImpulse(const pixelroot32::math::Vector2& j)`
+
+**Description:**
+
+Applies an instantaneous impulse (velocity change).
+
+**Parameters:**
+
+- `j`: Impulse vector.

--- a/docs/api/generated/physics/Segment.md
+++ b/docs/api/generated/physics/Segment.md
@@ -31,3 +31,29 @@ Checks intersection between two circles.
 - `b`: Second circle.
 
 **Returns:** True if circles intersect.
+
+### `bool intersects(const Circle& c, const pixelroot32::core::Rect& r)`
+
+**Description:**
+
+Checks intersection between a circle and a rectangle.
+
+**Parameters:**
+
+- `c`: The circle.
+- `r`: The rectangle.
+
+**Returns:** True if they intersect.
+
+### `bool intersects(const Segment& s, const pixelroot32::core::Rect& r)`
+
+**Description:**
+
+Checks intersection between a line segment and a rectangle.
+
+**Parameters:**
+
+- `s`: The line segment.
+- `r`: The rectangle.
+
+**Returns:** True if they intersect.

--- a/docs/api/generated/physics/SpatialGrid.md
+++ b/docs/api/generated/physics/SpatialGrid.md
@@ -31,3 +31,37 @@ Clears all entities (static and dynamic) from the grid.
 **Description:**
 
 Marks the static layer as dirty, requiring a rebuild.
+
+### `void rebuildStaticIfNeeded(pixelroot32::core::Entity* const* entities, uint16_t entityCount)`
+
+**Description:**
+
+Rebuilds the static layer if marked dirty.
+
+**Parameters:**
+
+- `entities`: Pointer to array of entities.
+- `entityCount`: Total number of entities.
+
+### `void insertDynamic(pixelroot32::core::Actor* actor)`
+
+**Description:**
+
+Inserts a dynamic actor into the grid.
+
+**Parameters:**
+
+- `actor`: The actor to insert.
+
+### `void getPotentialColliders(pixelroot32::core::Actor* actor, pixelroot32::core::Actor** outArray, int& count, int maxCount)`
+
+**Description:**
+
+Gets potential colliders for a given actor from the grid.
+
+**Parameters:**
+
+- `actor`: The actor to query for.
+- `outArray`: Output array to store potential colliders.
+- `count`: Reference to store the number of colliders found.
+- `maxCount`: Maximum number of colliders to return.

--- a/docs/api/generated/physics/TileCollisionBuilder.md
+++ b/docs/api/generated/physics/TileCollisionBuilder.md
@@ -50,3 +50,41 @@ Gets the number of entities created by this builder.
 **Description:**
 
 Resets the entity counter.
+
+### `pixelroot32::core::PhysicsActor* createTileBody(uint16_t x, uint16_t y, TileFlags flags)`
+
+**Description:**
+
+Creates a single tile physics body.
+
+**Parameters:**
+
+- `x`: Tile X coordinate
+- `y`: Tile Y coordinate
+- `flags`: TileFlags for this tile
+
+**Returns:** Pointer to created actor, or nullptr if entity limit reached
+
+### `void configureTileBody(pixelroot32::core::PhysicsActor* body, TileFlags flags)`
+
+**Description:**
+
+Configures a tile body based on its flags.
+
+**Parameters:**
+
+- `body`: The physics actor to configure
+- `flags`: TileFlags for configuration
+
+### `pixelroot32::math::Vector2 tileToWorldPosition(uint16_t x, uint16_t y) const`
+
+**Description:**
+
+Converts tile coordinates to world position.
+
+**Parameters:**
+
+- `x`: Tile X coordinate
+- `y`: Tile Y coordinate
+
+**Returns:** World position vector

--- a/docs/api/generated/physics/TileCollisionBuilderConfig.md
+++ b/docs/api/generated/physics/TileCollisionBuilderConfig.md
@@ -15,3 +15,7 @@ Configuration for tile collision building.
 | `tileWidth` | `uint8_t` | Width of each tile in world units |
 | `tileHeight` | `uint8_t` | Height of each tile in world units |
 | `maxEntities` | `uint16_t` | Maximum entities to create (safety limit) |
+
+## Methods
+
+### `: tileWidth(w), tileHeight(h), maxEntities(pixelroot32::platforms::config::MaxEntities / 2)`

--- a/docs/api/generated/physics/TileConsumptionHelper.md
+++ b/docs/api/generated/physics/TileConsumptionHelper.md
@@ -21,6 +21,33 @@ bool consumed = helper.consumeTile(tileActor, tileX, tileY);
 
 ## Methods
 
+### `bool consumeTile(pixelroot32::core::Actor* tileActor, uint16_t tileX, uint16_t tileY)`
+
+**Description:**
+
+Consumes a tile by removing its physics body and updating visuals.
+
+**Parameters:**
+
+- `tileActor`: Pointer to the tile physics actor to consume
+- `tileX`: Tile X coordinate (from unpacked userData)
+- `tileY`: Tile Y coordinate (from unpacked userData)
+
+**Returns:** true if tile was successfully consumed, false if already consumed or invalid
+
+### `bool consumeTileFromUserData(pixelroot32::core::Actor* tileActor, uintptr_t packedUserData)`
+
+**Description:**
+
+Consumes a tile using packed userData from collision callback.
+
+**Parameters:**
+
+- `tileActor`: Pointer to the tile physics actor
+- `packedUserData`: Packed userData from tileActor->getUserData()
+
+**Returns:** true if tile was successfully consumed, false otherwise
+
 ### `bool isTileConsumed(uint16_t tileX, uint16_t tileY) const`
 
 **Description:**

--- a/docs/api/generated/platforms/MockAudioBackend.md
+++ b/docs/api/generated/platforms/MockAudioBackend.md
@@ -19,8 +19,14 @@ for verifying AudioScheduler and AudioEngine interactions.
 
 ## Methods
 
+### `void init(AudioEngine* engine, const platforms::PlatformCapabilities& caps)`
+
+### `int getSampleRate() const`
+
 ### `bool wasInitCalled() const`
 
 ### `AudioEngine* getEngine() const`
+
+### `const platforms::PlatformCapabilities& getCaps() const`
 
 ### `void reset()`

--- a/docs/guide/audio.md
+++ b/docs/guide/audio.md
@@ -1,6 +1,6 @@
 # Audio System
 
-PixelRoot32 provides a **NES-like** audio subsystem: **four fixed channels** (two pulse, one triangle, one noise), **mono** 16-bit output, **event-driven** playback (`AudioEvent`), and **sample-accurate** timing decoupled from the game frame rate. There is **no DMC/sample channel** in the current engine.
+PixelRoot32 provides a **NES-like** audio subsystem: a **dynamic 8-voice pooling system** (supporting Pulse, Triangle, Noise, Sine, and Saw waveforms), **mono** 16-bit output, **event-driven** playback (`AudioEvent`), and **sample-accurate** timing decoupled from the game frame rate. There is **no DMC/sample channel** in the current engine.
 
 For implementation details, see [Audio subsystem](../architecture/audio-subsystem.md) (authoritative).
 
@@ -20,7 +20,7 @@ flowchart TB
 
     subgraph Audio["Audio consumer context"]
         D -->|dequeue| E[AudioScheduler thin wrapper]
-        E -->|ApuCore::generateSamples| F[Pulse x2 + Triangle + Noise + music]
+        E -->|ApuCore::generateSamples| F[Dynamic 8-Voice Pool + music]
         F --> G[Non-linear mixer FPU or LUT + optional HPF]
     end
 
@@ -30,14 +30,14 @@ flowchart TB
     end
 ```
 
-- **`AudioEngine`** forwards commands and **`generateSamples`** to the active **`AudioScheduler`**, which delegates to **`ApuCore`**: SPSC queue, four channels, music sequencer, mixing, and (on the FPU path) a one-pole output HPF. Synthesis is not duplicated across three scheduler copies.
+- **`AudioEngine`** forwards commands and **`generateSamples`** to the active **`AudioScheduler`**, which delegates to **`ApuCore`**: SPSC queue, dynamic 8-voice pool, music sequencer, mixing, and (on the FPU path) a one-pole output HPF. Synthesis is not duplicated across three scheduler copies.
 - On **ESP32**, core affinity and task priority are applied when the **backend** creates its FreeRTOS task (`PlatformCapabilities`), not inside `ESP32AudioScheduler` construction arguments (those parameters are reserved for API stability).
 
 ## Key Features
 
 | Feature | Description |
 |--------|-------------|
-| **4 channels** | 2× pulse (duty configurable), 1× triangle, 1× noise |
+| **8 voices** | Dynamic voice pooling with stealing logic. Supports Pulse, Triangle, Noise, Sine, and Saw. |
 | **Sample-accurate** | Channel lifetime in samples; independent of FPS |
 | **Schedulers** | `NativeAudioScheduler` (PC), `ESP32AudioScheduler` (firmware), `DefaultAudioScheduler` (tests / callback-driven) |
 | **Command path** | Lock-free **SPSC** ring buffer, **128** entries; one producer / one consumer |
@@ -146,6 +146,7 @@ pr32::drivers::esp32::ESP32_I2S_AudioBackend audioBackend(26, 25, 22, 22050);
 pr32::audio::AudioConfig audioConfig;
 audioConfig.backend = &audioBackend;
 audioConfig.sampleRate = 22050;
+audioConfig.blockSize = 128; // Optional: tune for platform latency (e.g., 128 for ESP32-C3, 256 for FPU)
 
 pr32::core::Engine engine(displayConfig, inputConfig, audioConfig);
 ```
@@ -157,7 +158,7 @@ See **[AudioEngine](../api/audio.md)** for **`AudioConfig`** fields and architec
 | Platform | Mixer | Noise (typical) | Audio execution |
 |----------|--------|-----------------|-----------------|
 | **ESP32 (FPU)** | Float + soft clip + HPF | Clocked LFSR | Backend task; core from `PlatformCapabilities` |
-| **ESP32-C3 (no FPU)** | LUT + Fixed-Point HPF | Clocked LFSR + Integer LFO | Same; integer path with LFO and HPF |
+| **ESP32-C3 (no FPU)** | LUT + Q15 Fixed-Point HPF | Clocked LFSR + Q15 LFO | Same; integer path with Q15 LFO and HPF, static function pointer dispatch for wave generation |
 | **PC (native)** | Float + soft clip + HPF | Same LFSR as firmware | `std::thread` + ring buffer → SDL2 callback |
 
 ## Best practices

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,15 +8,18 @@ PixelRoot32 follows a **scene-based architecture inspired by Godot Engine**, mak
 
 **Key features**
 
-- **Cross-platform** — Develop on PC (Windows/Linux/macOS) and deploy on ESP32
-- **Scene–entity system** — Scenes, entities, and actors
-- **High performance** — DMA transfers and IRAM-friendly paths on ESP32
-- **Sprites** — 1bpp/2bpp/4bpp, palettes, animation
-- **Tilemaps** — Viewport culling, multi-palette, tile animations
-- **NES-style audio** — 4-channel subsystem
-- **AABB physics** — Kinematic / rigid / static / sensor actors
-- **UI** — Labels, buttons, layouts; optional touch widgets
-- **Modular builds** — `PIXELROOT32_ENABLE_*` compile-time flags
+- **Cross-Platform**: Develop on PC (Windows/Linux/macOS) and deploy on ESP32.
+- **Scene-Entity System**: Intuitive management of Scenes, Entities, and Actors.
+- **High Performance**: Optimized for ESP32 with DMA transfers, IRAM-cached rendering, and a Dirty Regions pipeline.
+- **Sprite System**: Support for 1bpp/2bpp/4bpp sprites with multi-palette selection, flipping, rotation, and animation.
+- **Tilemap Support**: Optimized rendering with viewport culling, static layer caching, multi-palette, and tile animations.
+- **Tile Animation System**: Frame-based animations (water, lava) with O(1) frame resolution and zero-allocation policy.
+- **Independent Resolution Scaling**: Render at low logical resolutions (e.g., 128x128) and scale to physical displays (e.g., 240x240).
+- **NES-Style Audio**: Built-in dynamic 8-voice audio subsystem with fixed-point No-FPU optimizations (Pulse, Triangle, Noise, Sine, Saw).
+- **Lightweight UI**: Label, Button, and Checkbox with automatic layouts.
+- **AABB Physics**: Godot-style physics with Kinematic/Rigid actors, sensors, and one-way platforms.
+- **Indexed Color Palettes**: Optimized palettes (PR32, NES, GameBoy, PICO-8) with multi-palette support.
+- **Modular Architecture**: Compile only needed subsystems via `PIXELROOT32_ENABLE_*` flags to reduce firmware size.
 
 ## Prerequisites
 

--- a/docs/guide/input.md
+++ b/docs/guide/input.md
@@ -74,21 +74,24 @@ You choose the meaning of each index in your game (jump, fire, menu, …). Keep 
 
 ### Configuration
 
-`InputConfig` stores parallel arrays of pins (ESP32) or scancodes (native). Use the variadic constructor: first argument is **count**, then one value per button.
+`InputConfig` stores parallel arrays of pins (ESP32) or scancodes (native). The number of inputs is automatically deduced from the template variadic arguments—no explicit `count` parameter needed.
 
 ```cpp
 #include <input/InputConfig.h>
 
 #if defined(PLATFORM_NATIVE)
 // Example: 4 keyboard keys (SDL scancodes)
-input::InputConfig inputConfig(4, 80, 79, 81, 82); // arbitrary example keys
+// Count is auto-deduced: 4 buttons = indices 0, 1, 2, 3
+input::InputConfig inputConfig(80, 79, 81, 82); // arbitrary example keys
 #else
-// ESP32: count + GPIO pin numbers
-input::InputConfig inputConfig(4, 0, 32, 33, 25);
+// ESP32: GPIO pin numbers - count inferred automatically
+input::InputConfig inputConfig(0, 32, 33, 25);
 #endif
 
 core::Engine engine(std::move(displayConfig), inputConfig);
 ```
+
+> **Note:** The `count` parameter was removed in v1.5.0. The number of buttons is now deduced from the number of arguments passed.
 
 ### Button state patterns
 
@@ -229,7 +232,7 @@ flowchart LR
 
 ### Default PC mappings (illustrative)
 
-Your `InputConfig` on native builds lists **SDL scancodes** in the order of logical indices `0…n-1`. A typical layout might map arrow keys to indices `2–5` and action keys to `0–1`, but the exact table is entirely project-specific—mirror the order you passed into `InputConfig(count, …)`.
+Your `InputConfig` on native builds lists **SDL scancodes** in the order of logical indices `0…n-1`. A typical layout might map arrow keys to indices `2–5` and action keys to `0–1`, but the exact table is entirely project-specific—mirror the order you passed into `InputConfig(...)` (the count is now automatic since v1.5.0).
 
 ## Input patterns
 
@@ -288,9 +291,11 @@ Store recent **logical indices** (`uint8_t`) in a ring buffer if you need fighti
 void setup() {
     pixelroot32::graphics::DisplayConfig display(240, 240);
 #if defined(PLATFORM_NATIVE)
-    pixelroot32::input::InputConfig input(4, /* scancodes */ 0, 0, 0, 0);
+    // Count is auto-deduced - no explicit count needed
+    pixelroot32::input::InputConfig input(0, 0, 0, 0); // 4 scancodes
 #else
-    pixelroot32::input::InputConfig input(4, 0, 32, 33, 25);
+    // ESP32: 4 GPIO pins - count inferred from arguments
+    pixelroot32::input::InputConfig input(0, 32, 33, 25);
 #endif
     pixelroot32::core::Engine engine(std::move(display), input);
     // GameScene scene(engine); engine.setScene(&scene);

--- a/docs/guide/performance/esp32-performance.md
+++ b/docs/guide/performance/esp32-performance.md
@@ -37,9 +37,9 @@
 
 ### Dirty Region Selective Clear
 
-Reduces framebuffer clearing overhead by tracking which 8×8 pixel cells were actually drawn to in the previous frame:
+Reduces framebuffer clearing overhead by tracking which 8×8 pixel cells were actually drawn to in the previous frame, utilizing a **double dirty grid** pipeline.
 
-- **Benefit**: Replaces full-screen `memset` with targeted clears for only touched cells.
+- **Benefit**: Replaces full-screen `memset` with targeted **selective row-run 8bpp clearing**. It skips untouched rows entirely and uses `__builtin_popcount` optimizations to quickly identify blocks of dirty cells.
 - **RAM cost**: 64–226 bytes (depends on resolution and cell size).
 - **When it pays off**: Games with mostly static backgrounds and small moving sprites.
 - **Profiling flag**: `PIXELROOT32_ENABLE_DIRTY_REGION_PROFILING=1`
@@ -60,7 +60,7 @@ Single-core architectures (like the ESP32-C3) run the game logic, display transf
 
 - **Priority Inversion**: Heavy display transfers (like full-screen U8G2 refreshes) can block the audio task, causing buffer underruns and audio glitches. The engine dynamically detects single-core platforms and elevates the audio task priority (e.g., to `18`) to protect audio streams.
 - **Context Thrashing**: An audio priority that is *too* high (e.g., `24`) will preempt the display transfer constantly to synthesize audio, fragmenting the hardware SPI transaction and ballooning draw times (up to 4x). The engine mitigates this by balancing priority, reducing audio buffer block sizes to `128` samples, and using `taskYIELD()` for cooperative multitasking.
-- **Float Operations**: Soft-float emulation on the ESP32-C3 is extremely slow. The engine provides integer Q15 implementations for performance-critical inner loops (like `tickEnvelopeQ15` and audio mixer LUTs). Avoid introducing new float-based calculations inside per-sample audio loops or per-pixel drawing loops.
+- **Float Operations**: Soft-float emulation on the ESP32-C3 is extremely slow. The engine provides fixed-point Q15 implementations for performance-critical inner loops (like `tickEnvelopeQ15`, LFO generation for vibrato/tremolo, HPF filtering, and audio mixer LUTs). Avoid introducing new float-based calculations inside per-sample audio loops or per-pixel drawing loops.
 
 ---
 

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -484,7 +484,12 @@ build_flags =
     -DPIXELROOT32_DEBUG_MODE=1                       ; Required for debug overlay
 ```
 
-### Using LayerType
+### Using LayerType (Static vs. Dynamic)
+
+When using the Dirty Region pipeline, you must classify elements via the `LayerType` enum when drawing to optimize tracking:
+
+- **`LayerType::Static`**: For backgrounds or static HUD elements. They are drawn to the framebuffer but do **not** mark their corresponding cells as dirty, minimizing tracking overhead.
+- **`LayerType::Dynamic`**: For moving sprites or animations. Their bounding boxes automatically mark intersecting 8x8 cells as dirty, ensuring they are redrawn next frame.
 
 Classify tilemaps when drawing to optimize tracking:
 
@@ -555,7 +560,11 @@ renderer.setDebugDirtyCellOverlay(true);
 
 This draws a colored overlay showing dirty cells in real-time. When `forceFullRedraw()` has been called, all cells are highlighted.
 
-### Scene Stacking Contract
+### StaticTilemapLayerCache Integration
+
+The Dirty Region system integrates tightly with `StaticTilemapLayerCache` to provide an ultra-fast rendering path on ESP32. Instead of redrawing the background tilemap pixel-by-pixel, the cache takes a snapshot of the logical framebuffer containing only `LayerType::Static` elements. On subsequent frames, `renderer.beginFrame()` uses a fast `memcpy` to restore the background, and only the cells marked by `LayerType::Dynamic` elements are selectively cleared and redrawn.
+
+#### Scene Stacking Contract
 
 When using `StaticTilemapLayerCache` with stacked scenes:
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -81,6 +81,8 @@ test/
 │   ├── test_rect/                   # Rect type
 │   ├── test_scene/                  # Scene
 │   ├── test_scene_manager/           # Scene manager
+│   ├── test_tile_animation_manager/ # Tile animations
+│   ├── test_touch_state_machine/    # Touch gesture state machine
 │   ├── test_ui/                     # UI elements and layouts
 │   └── ...
 ├── test_engine_integration/         # Engine integration tests
@@ -195,6 +197,31 @@ void test_audio_engine_play_event(void) {
     // Assert
     TEST_ASSERT_EQUAL(1, backend.getEventCount());
     TEST_ASSERT_EQUAL_FLOAT(440.0f, backend.getLastEvent().frequency);
+}
+```
+
+### Testing Collision Systems
+
+The engine includes comprehensive unit tests for the collision system, ensuring physical interactions behave accurately. These tests cover:
+
+- **Velocity Integration**: Verifying actors move correctly based on velocity and `deltaTime`.
+- **Penetration Correction**: Ensuring intersecting actors are pushed apart cleanly without overshooting.
+- **Sensor Contacts**: Checking that `isSensor` actors trigger `onCollision` callbacks but do not block physical movement.
+- **Boundary Scenarios**: Verifying behavior at the edges of the simulation or with one-way platforms.
+
+```cpp
+void test_physics_actor_penetration_correction(void) {
+    // Arrange: two overlapping actors
+    PhysicsActor p1(0, 0, 10, 10);
+    PhysicsActor p2(5, 0, 10, 10);
+    p1.setBodyType(PhysicsActor::BodyType::KINEMATIC);
+    p2.setBodyType(PhysicsActor::BodyType::STATIC);
+    
+    // Act
+    // (Internal resolution logic invoked during step)
+    
+    // Assert: p1 should be pushed left
+    TEST_ASSERT_FLOAT_EQUAL(-5.0f, toFloat(p1.position.x));
 }
 ```
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -6,7 +6,8 @@ Version upgrade guides for PixelRoot32 Game Engine.
 
 - [v1.0.0 Migration](./migration-v1-0-0.md) - Initial stable release migration
 - [v1.1.0 Migration](./migration-v1-1-0.md) - Point release updates
-- [v1.2.0 Migration](./migration-v1-2-0.md) - Latest feature additions
+- [v1.2.0 Migration](./migration-v1-2-0.md) - Physics actor flags, UI callbacks refactor
+- [v1.5.0 Migration](./migration-v1-5-0.md) - InputConfig API simplification (std::vector to std::array)
 
 ## Migration Policy
 

--- a/docs/migration/migration-v1-5-0.md
+++ b/docs/migration/migration-v1-5-0.md
@@ -1,0 +1,247 @@
+# Migration Guide: v1.4.0 → v1.5.0
+
+## InputConfig API Simplification
+
+Version 1.5.0 simplifies the `InputConfig` constructor by eliminating the redundant `count` parameter. The number of inputs is now automatically deduced from the template arguments, making the API cleaner and less error-prone.
+
+---
+
+## Breaking Change: `count` Parameter Removed
+
+### What Changed
+
+The `InputConfig` constructor no longer requires the explicit `count` argument. The number of inputs is automatically deduced from the template variadic arguments.
+
+### Before
+
+```cpp
+pr32::input::InputConfig inputConfig(
+    6,              // count - now auto-deduced
+    BTN_UP,
+    BTN_DOWN,
+    BTN_LEFT,
+    BTN_RIGHT,
+    BTN_A,
+    BTN_B
+);
+```
+
+### After
+
+```cpp
+pr32::input::InputConfig inputConfig(
+    BTN_UP,
+    BTN_DOWN,
+    BTN_LEFT,
+    BTN_RIGHT,
+    BTN_A,
+    BTN_B
+);
+```
+
+---
+
+## Memory Optimization: `std::vector` → `std::array`
+
+### Why This Change
+
+Version 1.5.0 replaces `std::vector` with `std::array` in `InputConfig`:
+
+| Aspect | Before (`std::vector`) | After (`std::array`) |
+|--------|------------------------|----------------------|
+| Heap allocation | Yes (dynamic) | No (stack/global) |
+| Fragmentation | Possible | None |
+| Determinism | Non-deterministic | O(1) access |
+| Max inputs | Dynamic (runtime) | Fixed (16) |
+| Zero-init | Required manually | Automatic via `{}` |
+
+### Memory Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| `InputConfig` size | ~24 bytes (heap) | 72 bytes (stack, fixed) |
+| ESP32 heap usage | Variable | 0 bytes |
+| Allocation at runtime | Yes | None |
+
+---
+
+## API Changes
+
+### Constructor Signature
+
+**Before:**
+
+```cpp
+InputConfig(int count, ...);  // variadic with explicit count
+```
+
+**After:**
+
+```cpp
+template<typename... Args>
+InputConfig(Args... args);  // count auto-deduced
+```
+
+### Empty Configuration
+
+**Before:**
+
+```cpp
+InputConfig config(0);  // empty with count
+```
+
+**After:**
+
+```cpp
+InputConfig config{};  // default constructor or empty init list
+InputConfig config();  // also valid
+```
+
+---
+
+## Migration Patterns
+
+### Pattern 1: Remove the Count Parameter
+
+```cpp
+// Before
+pr32::input::InputConfig config(4, PIN_1, PIN_2, PIN_3, PIN_4);
+
+// After
+pr32::input::InputConfig config(PIN_1, PIN_2, PIN_3, PIN_4);
+```
+
+### Pattern 2: Empty Configuration
+
+```cpp
+// Before
+pr32::input::InputConfig config(0);
+
+// After
+pr32::input::InputConfig config{};
+// or
+pr32::input::InputConfig config;
+```
+
+### Pattern 3: Single Input
+
+```cpp
+// Before
+pr32::input::InputConfig config(1, BTN_UP);
+
+// After
+pr32::input::InputConfig config(BTN_UP);
+```
+
+### Pattern 4: Native Platform (SDL2)
+
+```cpp
+// Before
+pr32::input::InputConfig config(2, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN);
+
+// After
+pr32::input::InputConfig config(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN);
+```
+
+---
+
+## Compile-Time Validation
+
+The new implementation includes compile-time validation:
+
+### Overflow Detection
+
+```cpp
+// If more than 16 arguments are passed, compilation fails:
+InputConfig config(1, 2, 3, ..., 17);  // static_assert error at compile time
+```
+
+### Error Message
+
+```
+error: static_assert failed due to requirement 'sizeof...(Args) <= MAX_INPUT_COUNT'
+"Too many arguments for InputConfig"
+```
+
+---
+
+## Runtime Validation
+
+Invalid configurations are handled at runtime:
+
+| Scenario | Behavior |
+|----------|----------|
+| Empty config | `count = 0`, arrays zero-initialized |
+| 1-16 inputs | `count = N`, valid |
+| >16 inputs | `count = 16` (clamped) |
+
+---
+
+## Migration Checklist
+
+- [ ] **Search for `InputConfig(` calls**: Find all usages with explicit count
+- [ ] **Remove the first integer argument**: The count is now automatic
+- [ ] **Verify count deduction**: Ensure the new count matches expected
+- [ ] **Check empty configurations**: Replace `InputConfig(0)` with `InputConfig{}`
+- [ ] **Build and test**: Ensure all scenes compile and run correctly
+
+### Search Patterns
+
+```bash
+# Find all InputConfig usages
+grep -rn "InputConfig(" --include="*.cpp" --include="*.h"
+
+# Specific pattern for explicit count (regex)
+InputConfig\([0-9]+,
+```
+
+---
+
+## Backward Compatibility
+
+**This is a breaking change.** The old constructor signature `InputConfig(int count, ...)` no longer works.
+
+If you have code like this:
+
+```cpp
+InputConfig config(3, A, B, C);  // OLD API - WILL NOT COMPILE
+```
+
+You must update to:
+
+```cpp
+InputConfig config(A, B, C);  // NEW API
+```
+
+---
+
+## Verification
+
+After migration, verify:
+
+- [ ] All `InputConfig` calls compile without errors
+- [ ] Input count matches the number of arguments provided
+- [ ] ESP32 builds succeed with no heap allocation warnings
+- [ ] Native (SDL2) builds work correctly
+- [ ] All unit tests pass (`pio test -e native_test`)
+
+---
+
+## File Changes
+
+This change affects the following files:
+
+| File | Change |
+|------|--------|
+| `include/input/InputConfig.h` | `std::vector` → `std::array`, template variadic constructor |
+| `src/core/Engine.cpp` | Updated `InputConfig(0)` → `InputConfig{}` |
+| All game scenes | Remove `count` parameter from `InputConfig` calls |
+
+---
+
+## References
+
+- [Input System Guide](../guide/input.md)
+- [Memory Optimization](../guide/memory.md)
+- [ESP32 Performance](../guide/performance/esp32-performance.md)
+- [API Reference: Input](../api/input.md)

--- a/examples/2048/src/platforms/native.h
+++ b/examples/2048/src/platforms/native.h
@@ -25,7 +25,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ The engine revision for each example is defined in **`lib_deps`** inside that ex
 | [music_demo](music_demo/) | **`MusicPlayer`** **multi-track** (main + sub-tracks), **tick / BPM** timing, **`InstrumentPreset`** melodies + **percussion** presets; UI-based sound testing | `native`, `esp32dev` |
 | [space_invaders](space_invaders/) | Classic Space Invaders: alien formation, shooting, bunkers, score system, `AudioEngine` | `native`, `esp32dev` |
 | [physics](physics/) | `RigidActor` / `KinematicActor` / `StaticActor`, touch, optional touch UI (CYD) | `native`, `esp32dev`, `esp32cyd` |
-| [metroidvania](metroidvania/) | 4bpp tilemaps, `StaticTilemapLayerCache`, platformer player | `native`, `esp32dev` |
+| [metroidvania](metroidvania/) | 4bpp tilemaps, `StaticTilemapLayerCache`, dirty regions, platformer player with gravity + climbing | `native`, `esp32dev` |
 | [animated_tilemap](animated_tilemap/) | Tile animation, palettes, static tilemap framebuffer cache (reference depth) | `native`, `esp32dev`, `esp32cyd` |
 | [tic_tac_toe](tic_tac_toe/) | UI, GPIO vs touch, minimax AI, vector-drawn board, **`MusicPlayer`** / melody data | `native`, `esp32dev`, `esp32cyd` |
 | [2048](2048/) | 2048 puzzle game: grid rendering, touch swipes, D-pad controls, score tracking, **AI auto-play** (expectimax algorithm), audio SFX | `native`, `esp32cyd` |

--- a/examples/animated_tilemap/src/platforms/esp32_dev.h
+++ b/examples/animated_tilemap/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/animated_tilemap/src/platforms/native.h
+++ b/examples/animated_tilemap/src/platforms/native.h
@@ -22,7 +22,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/brick_breaker/src/platforms/esp32_dev.h
+++ b/examples/brick_breaker/src/platforms/esp32_dev.h
@@ -47,7 +47,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/brick_breaker/src/platforms/native.h
+++ b/examples/brick_breaker/src/platforms/native.h
@@ -24,7 +24,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
 

--- a/examples/camera/src/platforms/esp32_dev.h
+++ b/examples/camera/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/camera/src/platforms/native.h
+++ b/examples/camera/src/platforms/native.h
@@ -21,7 +21,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/dual_palette/src/platforms/esp32_dev.h
+++ b/examples/dual_palette/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/dual_palette/src/platforms/native.h
+++ b/examples/dual_palette/src/platforms/native.h
@@ -21,7 +21,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/flappy_bird/src/platforms/esp32_c3.h
+++ b/examples/flappy_bird/src/platforms/esp32_c3.h
@@ -30,7 +30,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(1, BTN_PIN_UP); // 1 button: Up
+pr32::input::InputConfig inputConfig(BTN_PIN_UP); // 1 button: Up
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/flappy_bird/src/platforms/native.h
+++ b/examples/flappy_bird/src/platforms/native.h
@@ -21,7 +21,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/hello_world/src/platforms/esp32_dev.h
+++ b/examples/hello_world/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/hello_world/src/platforms/esp32_s3.h
+++ b/examples/hello_world/src/platforms/esp32_s3.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/hello_world/src/platforms/native.h
+++ b/examples/hello_world/src/platforms/native.h
@@ -21,7 +21,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/metroidvania/README.md
+++ b/examples/metroidvania/README.md
@@ -1,14 +1,15 @@
 # Metroidvania-Style Example
 
-A compact **platformer** sample with **4bpp tilemap layers** (background, platforms, decorative tiles), **`StaticTilemapLayerCache`** for the ESP32 fast path when available, and a **`KinematicActor`**-based player with climbing and jump rules tailored to the sample map.
+A compact **platformer** sample with **4bpp tilemap layers**, **`StaticTilemapLayerCache`** for the ESP32 fast path when available, and a **`KinematicActor`**-based player with gravity, climbing, and jump rules tailored to the sample map.
 
 **Requires `PIXELROOT32_ENABLE_4BPP_SPRITES`** — the scene is guarded in [`src/MetroidvaniaScene.h`](src/MetroidvaniaScene.h).
 
 ## Requirements (build flags)
 
 - **`PIXELROOT32_ENABLE_4BPP_SPRITES`**
-- **`PIXELROOT32_ENABLE_2BPP_SPRITES`** (enabled alongside 4bpp in this example’s `platformio.ini`)
+- **`PIXELROOT32_ENABLE_2BPP_SPRITES`** (enabled alongside 4bpp in this example's `platformio.ini`)
 - **`PIXELROOT32_ENABLE_SCENE_ARENA`**
+- **`PIXELROOT32_ENABLE_DIRTY_REGIONS`**
 
 See **`platformio.ini`** for **`native`** and **`esp32dev`** presets (no `esp32cyd` environment in this project).
 
@@ -18,27 +19,44 @@ See **`platformio.ini`** for **`native`** and **`esp32dev`** presets (no `esp32c
 
 | Environment | Display |
 |-------------|---------|
-| **`native`** | SDL2, 240×240 |
-| **`esp32dev`** | **ST7789** 240×240 |
+| **`native`** | SDL2, 240x240 |
+| **`esp32dev`** | **ST7789** 240x240 |
 
 ## Controls
 
-Uses **`GameConstants.h`** button IDs: **Up / Down / Left / Right** and **Jump** (`BTN_UP` … `BTN_JUMP`). Map these to your `InputManager` / GPIO / keyboard mapping for the platform file you use.
+Uses **`GameConstants.h`** button IDs: **Up / Down / Left / Right** and **Jump** (`BTN_UP` ... `BTN_JUMP`). Map these to your `InputManager` / GPIO / keyboard mapping for the platform file you use.
+
+## Player Actor
+
+The **`PlayerActor`** extends **`KinematicActor`** and implements:
+
+- **Gravity + horizontal movement** with configurable `PLAYER_GRAVITY`, `PLAYER_MOVE_SPEED`, `PLAYER_JUMP_VELOCITY`
+- **Ladder climbing** via `setStairs()` / `buildStairsCache()` — a bitmask RAM cache of climbable tiles
+- **State machine**: `IDLE`, `RUN`, `JUMP`, `CLIMBING` with sprite animation per state
+- **Collision layers**: `PLAYER`, `PLATFORM`, `GROUND`, `ENEMY` (for future extension)
 
 ## How this scene uses the tilemap cache
 
-Like the animated tilemap sample, drawing goes through **`StaticTilemapLayerCache`**: allocate for the renderer when layers are ready, draw static groups with camera offsets, and **`invalidate()`** when static tile data or relevant animators change. See [Animated Tilemap README](../animated_tilemap/README.md) for the detailed invalidation table and [Architecture — static tilemap cache](../../docs/ARCHITECTURE.md).
+Drawing goes through **`StaticTilemapLayerCache`**: allocate for the renderer when layers are ready, draw static groups with camera offsets, and **`invalidate()`** when static tile data or relevant animators change. See [Animated Tilemap README](../animated_tilemap/README.md) for the detailed invalidation table and [Architecture — static tilemap cache](../../docs/architecture/architecture-index.md#static-tilemap-layer-cache-engine--scenes).
+
+## Dirty Regions
+
+This example enables **`PIXELROOT32_ENABLE_DIRTY_REGIONS`** for targeted clearing on ESP32. The rendering pipeline uses a dirty-grid approach to selectively clear only the regions that changed between frames, reducing SPI transfer overhead on the display.
 
 ## Features
 
-- **4bpp tilemaps** and layered level data
+- **4bpp tilemaps** and layered level data (background, platforms, stairs)
 - **`StaticTilemapLayerCache`** snapshot path when the driver exposes a logical framebuffer
-- **Player actor** with gravity, stairs/climb behavior, and map collision
+- **Dirty Regions** — targeted clearing via dirty-grid pipeline on ESP32
+- **Player actor** with gravity, stairs/climb behavior, and manual tilemap collision
+- **Stairs mask cache** — bitmask RAM cache built once from tile indices for fast overlap checks
+- **State-driven sprite animation** — `IDLE`, `RUN`, `JUMP`, `CLIMBING` states
 - **Scene arena** + owned layer entities
 
 ## Documentation links
 
 - [Graphics — tilemaps & `StaticTilemapLayerCache`](../../docs/api/graphics.md#multi-layer-4bpp-tilemap-framebuffer-snapshot-statictilemaplayercache)
+- [Architecture — static tilemap layer cache](../../docs/architecture/architecture-index.md#static-tilemap-layer-cache-engine--scenes)
 - [Architecture — ESP32 rendering / tilemap caching](../../docs/architecture/architecture-index.md#esp32-rendering-pipeline-and-tilemap-caching)
 - [Physics API](../../docs/api/physics.md)
 - [Core API](../../docs/api/core.md)

--- a/examples/metroidvania/src/platforms/esp32_dev.h
+++ b/examples/metroidvania/src/platforms/esp32_dev.h
@@ -35,7 +35,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/metroidvania/src/platforms/native.h
+++ b/examples/metroidvania/src/platforms/native.h
@@ -22,7 +22,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/music_demo/src/platforms/esp32_c3.h
+++ b/examples/music_demo/src/platforms/esp32_c3.h
@@ -41,7 +41,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(1, BTN_PIN_UP); // 1 button: Up
+pr32::input::InputConfig inputConfig(BTN_PIN_UP); // 1 button: Up
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/music_demo/src/platforms/esp32_dev.h
+++ b/examples/music_demo/src/platforms/esp32_dev.h
@@ -47,7 +47,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/music_demo/src/platforms/native.h
+++ b/examples/music_demo/src/platforms/native.h
@@ -24,7 +24,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
 

--- a/examples/physics/src/platforms/esp32_dev.h
+++ b/examples/physics/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/physics/src/platforms/native.h
+++ b/examples/physics/src/platforms/native.h
@@ -22,7 +22,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/snake/src/platforms/esp32_dev.h
+++ b/examples/snake/src/platforms/esp32_dev.h
@@ -47,7 +47,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/snake/src/platforms/native.h
+++ b/examples/snake/src/platforms/native.h
@@ -24,7 +24,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/space_invaders/src/platforms/esp32_dev.h
+++ b/examples/space_invaders/src/platforms/esp32_dev.h
@@ -47,7 +47,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/space_invaders/src/platforms/native.h
+++ b/examples/space_invaders/src/platforms/native.h
@@ -24,7 +24,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
 

--- a/examples/sprites/src/platforms/esp32_dev.h
+++ b/examples/sprites/src/platforms/esp32_dev.h
@@ -29,7 +29,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/sprites/src/platforms/native.h
+++ b/examples/sprites/src/platforms/native.h
@@ -21,7 +21,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::core::Engine engine(config, inputConfig);
 

--- a/examples/tic_tac_toe/src/platforms/esp32_dev.h
+++ b/examples/tic_tac_toe/src/platforms/esp32_dev.h
@@ -47,7 +47,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B); // 6 buttons: Up, Down, Left, Right, A, B
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
 

--- a/examples/tic_tac_toe/src/platforms/native.h
+++ b/examples/tic_tac_toe/src/platforms/native.h
@@ -25,7 +25,7 @@ pr32::graphics::DisplayConfig config(
     Y_OFF_SET
 );
 
-pr32::input::InputConfig inputConfig(6, SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN); // 6 buttons: Up, Down, Left, Right, Space(A), Enter (B)
 
 pr32::audio::AudioConfig audioConfig(&audioBackend, 22050);
 

--- a/include/audio/ApuCore.h
+++ b/include/audio/ApuCore.h
@@ -13,39 +13,46 @@
 
 namespace pixelroot32::audio {
 
-    /**
-     * @class ApuCore
-     * @brief Shared NES-style APU core used by every AudioScheduler.
-     *
-     * Owns the 4 channels (2x PULSE, 1x TRIANGLE, 1x NOISE), the SPSC command
-     * queue and the music sequencer. Platform-specific schedulers
-     * (DefaultAudioScheduler, ESP32AudioScheduler, NativeAudioScheduler) are
-     * thin orchestrators that decide *when* generateSamples() runs; all
-     * synthesis, mixing and sequencing lives here to eliminate the three-way
-     * duplication that existed before.
-     *
-     * Mixing curve:
-     *   per channel: s_c = wave_c(phase) * volume_c * MIXER_SCALE
-     *   sum:         S   = Σ s_c                         (bounded to [-1.6, 1.6])
-     *   compressor:  y   = S / (1 + |S| * MIXER_K)
-     *   output:      y * masterVolume * 32767, passed through a single-pole
-     *                DC-blocker to remove offset + transient clicks.
-     *
-     * On cores without an FPU (ESP32-C3) the integer-optimised path uses
-     * `audio_mixer_lut` which is pre-fitted to the same curve.
-     */
-    class ApuCore {
+/**
+      * @class ApuCore
+      * @brief Shared NES-style APU core used by every AudioScheduler.
+      *
+      * Owns the 4 channels (2x PULSE, 1x TRIANGLE, 1x NOISE), the SPSC command
+      * queue and the music sequencer. Platform-specific schedulers
+      * (DefaultAudioScheduler, ESP32AudioScheduler, NativeAudioScheduler) are
+      * thin orchestrators that decide *when* generateSamples() runs; all
+      * synthesis, mixing and sequencing lives here to eliminate the three-way
+      * duplication that existed before.
+      *
+      * Mixing curve:
+      *   per channel: s_c = wave_c(phase) * volume_c * MIXER_SCALE
+      *   sum:         S   = Σ s_c                         (bounded to [-1.6, 1.6])
+      *   compressor:  y   = S / (1 + |S| * MIXER_K)
+      *   output:      y * masterVolume * 32767, passed through a single-pole
+      *                DC-blocker to remove offset + transient clicks.
+      *
+      * On cores without an FPU (ESP32-C3) the integer-optimised path uses
+      * `audio_mixer_lut` which is pre-fitted to the same curve.
+      */
+     class ApuCore {
     public:
+        /** @brief Maximum number of voices (dynamic pool size). */
         static constexpr int MAX_VOICES = 8;
         // Backward-compatible alias used in some tests/diagnostics.
+        /** @brief Alias for MAX_VOICES for backward compatibility. */
         static constexpr int NUM_CHANNELS = MAX_VOICES;
+        /** @brief Maximum simultaneous music tracks. */
         static constexpr size_t MAX_MUSIC_TRACKS = 4;
+        /** @brief Default ticks (subdivisions) per beat. */
         static constexpr int TICKS_PER_BEAT = 4;
+        /** @brief Default tempo in BPM. */
         static constexpr float DEFAULT_BPM = 150.0f;
 
         // Sequencer note limit: max notes processed per frame to prevent unbounded catch-up
+        /** @brief Default max notes per frame for the music sequencer. */
         static constexpr size_t DEFAULT_MAX_NOTES_PER_FRAME = 32;
         #ifndef AUDIO_SEQUENCER_MAX_NOTES
+        /** @brief User-configurable max notes per frame. */
         static constexpr size_t MAX_NOTES_PER_FRAME = DEFAULT_MAX_NOTES_PER_FRAME;
         #else
         static_assert(AUDIO_SEQUENCER_MAX_NOTES >= 1 && AUDIO_SEQUENCER_MAX_NOTES <= 1024,
@@ -54,57 +61,99 @@ namespace pixelroot32::audio {
         #endif
 
         // Mixing constants exposed for diagnostics / tests.
+        /** @brief Per-channel scaling factor before summation. */
         static constexpr float MIXER_SCALE = 0.4f;
+        /** @brief Compressor nonlinearity constant. */
         static constexpr float MIXER_K     = 0.5f;
 
+        /** @brief Default constructor. Initializes state but does not set sample rate. */
         ApuCore();
 
-        /** Configure the output sample rate. Safe to call before start. */
+        /**
+         * @brief Configures the output sample rate.
+         * @param sampleRate Sample rate in Hz (e.g., 22050, 44100).
+         * 
+         * Safe to call before start(). Pre-calculates internal timing values.
+         */
         void init(int sampleRate);
 
-        /** Enqueue a command. @return false if the SPSC queue was full. */
+        /**
+         * @brief Enqueues a command for processing.
+         * @param cmd The audio command to enqueue.
+         * @return true if the command was enqueued, false if the queue was full.
+         */
         bool submitCommand(const AudioCommand& cmd);
 
-        /** Generate `length` mono int16 samples into `stream`. */
+        /**
+         * @brief Generates audio samples.
+         * @param stream Output buffer (mono, int16 samples).
+         * @param length Number of samples to generate.
+         * 
+         * Processes all pending commands, updates music sequencer, and synthesizes
+         * voices into the output buffer. Applies master volume, bitcrush, and DC blocking.
+         */
         void generateSamples(int16_t* stream, int length);
 
-        /** Total commands dropped since boot (monotonic). */
+        /** @brief Returns the total number of commands dropped since construction. @return Monotonic count. */
         uint32_t getDroppedCommands() const {
             return droppedCommands.load(std::memory_order_relaxed);
         }
 
         // Sequencer note limit API
-        /** Set max notes processed per audio frame (1-1000, clamped internally). */
+        /**
+         * @brief Sets the maximum notes processed per audio frame.
+         * @param limit Max notes [1-1000], clamped to safe bounds internally.
+         * 
+         * Bounded processing prevents audio starvation when many notes queue up.
+         */
         void setSequencerNoteLimit(size_t limit);
 
-        /** Get current max notes per frame setting. */
+        /** @brief Gets current max notes per frame setting. @return Current limit. */
         size_t getSequencerNoteLimit() const { return sequencerNoteLimit.load(std::memory_order_acquire); }
 
-        /** Get count of notes deferred to next frame due to limit. */
+        /** @brief Returns notes deferred to next frame due to note limit. @return Deferred count. */
         size_t getDeferredNotes() const { return deferredNotes.load(std::memory_order_relaxed); }
 
-        /** Music transport reflected to the game thread (atomic). */
+        /** @brief Reports if music is currently playing. @return true if playing. */
         bool isMusicPlaying() const { return musicPlayingFlag.load(std::memory_order_acquire); }
+        /** @brief Reports if music is paused. @return true if paused. */
         bool isMusicPaused()  const { return musicPausedFlag.load(std::memory_order_acquire); }
 
+        /** @brief Gets the configured sample rate. @return Sample rate in Hz. */
         int getSampleRate() const { return sampleRate; }
 
-        /** Reset all state. Intended for unit tests. */
+        /**
+         * @brief Resets all state to initial values.
+         * 
+         * Intended for unit tests. Stops all voices, clears sequencer, resets counters.
+         */
         void reset();
 
         /**
-         * Optional post-mix callback (RT-safe): runs on final int16 buffer after bitcrush.
-         * Typically set once from AudioEngine using AudioConfig.
+         * @brief Sets an optional post-mix callback.
+         * @param fn Function pointer: void(int16_t* mono, int length, void* user).
+         * @param user User data passed to the callback.
+         * 
+         * Called after bitcrush on the final mono buffer. Runs in audio thread context.
          */
         void setPostMixMono(void (*fn)(int16_t* mono, int length, void* user), void* user);
 
         // -- Profiling API (public for Engine access) -------------
+        /** @brief Ring buffer size for profile entries. */
         static constexpr int PROFILE_RING_SIZE = 64;
+        /**
+         * @brief A single profile snapshot.
+         */
         struct ProfileEntry {
-            uint64_t audioTimeSamples;
-            float peak;
-            bool clipped;
+            uint64_t audioTimeSamples; ///< Global sample counter at capture.
+            float peak;                ///< Peak sample magnitude [0.0 - 1.0].
+            bool clipped;              ///< Whether any sample exceeded ±32767.
         };
+        /**
+         * @brief Reads and clears all profile entries.
+         * @param out Array of ProfileEntry to fill.
+         * @param count On input: max entries. On output: actual count written.
+         */
         void getAndResetProfileStats(ProfileEntry* out, uint8_t& count);
 
 #if defined(UNIT_TEST)

--- a/include/audio/AudioBackend.h
+++ b/include/audio/AudioBackend.h
@@ -9,28 +9,38 @@ namespace pixelroot32::audio {
 
     class AudioEngine;
 
-    /**
-     * @class AudioBackend
-     * @brief Abstract interface for platform-specific audio drivers.
-     * 
-     * This class abstracts the underlying audio hardware or API (e.g., SDL2, I2S).
-     * It is responsible for requesting audio samples from the AudioEngine and
-     * pushing them to the output device.
-     */
+/**
+      * @class AudioBackend
+      * @brief Abstract interface for platform-specific audio drivers.
+      * 
+      * This class abstracts the underlying audio hardware or API (e.g., SDL2 on native,
+      * I2S on ESP32). It is responsible for requesting audio samples from the AudioEngine
+      * and pushing them to the output device. Platforms implement this interface to
+      * bridge between the engine's sample generation and the actual hardware.
+      * 
+      * Typical lifecycle:
+      * 1. init() is called with an AudioEngine pointer.
+      * 2. The backend sets up the audio output (I2S, SDL audio, etc.).
+      * 3. In its output callback, the backend calls engine->generateSamples().
+      * 4. On destruction, resources are cleaned up.
+      */
     class AudioBackend {
     public:
+        /** @brief Virtual destructor for proper cleanup in derived classes. */
         virtual ~AudioBackend() = default;
 
         /**
          * @brief Initializes the audio backend.
          * @param engine Pointer to the AudioEngine instance to request samples from.
-         * @param caps Platform capabilities to guide backend initialization (e.g., core pinning).
+         *        Must not be nullptr.
+         * @param caps Platform capabilities to guide backend initialization
+         *        (e.g., core pinning on ESP32, thread priorities).
          */
         virtual void init(AudioEngine* engine, const pixelroot32::platforms::PlatformCapabilities& caps = pixelroot32::platforms::PlatformCapabilities()) = 0;
 
         /**
          * @brief Returns the configured sample rate of the backend.
-         * @return Sample rate in Hz (e.g., 22050, 44100).
+         * @return Sample rate in Hz (e.g., 22050, 44100, 48000).
          */
         virtual int getSampleRate() const = 0;
     };

--- a/include/audio/AudioCommandQueue.h
+++ b/include/audio/AudioCommandQueue.h
@@ -13,24 +13,34 @@ namespace pixelroot32::audio {
 
     /**
      * @class AudioCommandQueue
-     * @brief Multi-Producer Single-Consumer lock-free ring buffer for AudioCommands.
+     * @brief Multi-Producer Single-Consumer (MPSC) lock-free ring buffer for AudioCommands.
      * 
-     * Fixed size, no allocation. Supports multiple concurrent producer threads.
-     * If the queue is full, the newest command is dropped and droppedCommands is incremented.
-     * Uses compare-and-swap (CAS) for atomic ring index advancement.
+     * Fixed-size, zero-allocation queue designed for real-time audio thread communication.
+     * Supports multiple concurrent producer threads (e.g., game logic, music sequencer)
+     * and a single consumer thread (the audio thread).
+     * 
+     * Drop policy: When the queue is full, the newest command is silently dropped and
+     * the droppedCommands counter is incremented. Callers can monitor this via
+     * getDroppedCommands() for diagnostics.
+     * 
+     * Thread-safety: Uses compare-and-swap (CAS) for atomic ring index advancement.
+     * The producer path is wait-free; the consumer path is lock-free.
      */
     class AudioCommandQueue {
     public:
         // Configurable capacity: 128-1024. Default 128 for memory efficiency.
         // Can be increased for high-throughput use cases at compile time.
         #ifndef AUDIO_COMMAND_QUEUE_CAPACITY
+        /** @brief Default queue capacity in commands. */
         static constexpr size_t CAPACITY = 128;
         #else
         static_assert(AUDIO_COMMAND_QUEUE_CAPACITY >= 128 && AUDIO_COMMAND_QUEUE_CAPACITY <= 1024,
             "AUDIO_COMMAND_QUEUE_CAPACITY must be between 128 and 1024");
+        /** @brief User-configured queue capacity in commands. */
         static constexpr size_t CAPACITY = AUDIO_COMMAND_QUEUE_CAPACITY;
         #endif
 
+        /** @brief Default constructor. Initializes head, tail, and dropped counters to zero. */
         AudioCommandQueue() : head(0), tail(0), droppedCommands(0) {}
 
         /**

--- a/include/audio/AudioConfig.h
+++ b/include/audio/AudioConfig.h
@@ -25,10 +25,11 @@ namespace pixelroot32::audio {
         void* postMixUser = nullptr;
 
         /**
-         * @brief Default constructor.
-         * @param backend Pointer to the audio backend implementation.
-         * @param sampleRate Desired sample rate (default 22050Hz for retro feel).
-         * @param blockSize Audio block size (128 without FPU, 256 with FPU).
+         * @brief Constructs an AudioConfig with platform-adaptive block size.
+         * @param backend Pointer to the audio backend implementation. May be nullptr for headless configs.
+         * @param sampleRate Desired sample rate in Hz (default 22050 for retro feel).
+         * @param blockSize Audio block size in samples. Defaults to 256 on FPU platforms, 128 on no-FPU platforms.
+         *        Must be a multiple of 128 for I2S DMA alignment.
          */
         AudioConfig(AudioBackend* backend = nullptr, int sampleRate = 22050,
                   int blockSize = platforms::config::HasFPU ? 256 : 128)

--- a/include/audio/AudioEngine.h
+++ b/include/audio/AudioEngine.h
@@ -16,27 +16,63 @@ namespace pixelroot32::audio {
 
     /**
      * @class AudioEngine
-     * @brief Core class for the NES-like audio subsystem.
+     * @brief Facade class for the NES-style audio subsystem.
      * 
-     * In Phase 2, this class becomes a facade for the AudioScheduler.
+     * Provides a high-level API for playing sound events, controlling volume,
+     * and managing music playback. Internally delegates to an AudioScheduler
+     * (typically DefaultAudioScheduler) which owns the ApuCore for synthesis.
+     * 
+     * Usage:
+     * 1. Construct with an AudioConfig and PlatformCapabilities.
+     * 2. Call init() to set up the scheduler and backend.
+     * 3. Call playEvent() to trigger one-shot sounds.
+     * 4. Use MusicPlayer for music track sequencing.
      */
     class AudioEngine {
     public:
+        /**
+         * @brief Constructs the AudioEngine.
+         * @param config Audio configuration including backend pointer and sample rate.
+         * @param caps Platform capabilities (e.g., FPU presence, core count).
+         */
         AudioEngine(const AudioConfig& config, const pixelroot32::platforms::PlatformCapabilities& caps = pixelroot32::platforms::PlatformCapabilities());
         
+        /** @brief Initializes the engine and its internal scheduler. */
         void init();
 
+        /**
+         * @brief Generates audio samples into the output buffer.
+         * @param stream Output buffer (mono, int16 samples).
+         * @param length Number of samples to generate.
+         */
         void generateSamples(int16_t* stream, int length);
 
+        /**
+         * @brief Triggers a one-shot sound event.
+         * @param event The event to play (type, frequency, duration, volume).
+         */
         void playEvent(const AudioEvent& event);
 
+        /**
+         * @brief Sets the master volume for all audio output.
+         * @param volume Volume level [0.0 = silent, 1.0 = full].
+         */
         void setMasterVolume(float volume);
+        /** @brief Gets the current master volume. @return Volume [0.0 - 1.0]. */
         float getMasterVolume() const;
 
-        /** 0 = off; 1–15 = master bus bit depth reduction (post-mixer). */
+        /**
+         * @brief Sets the master bitcrusher effect on the final output.
+         * @param bits Bit depth reduction [0 = off, 1-15 = re-quantize to N bits].
+         */
         void setMasterBitcrush(uint8_t bits);
+        /** @brief Gets the current master bitcrush setting. @return Bit depth (0 = off). */
         uint8_t getMasterBitcrush() const;
 
+        /**
+         * @brief Submits a raw audio command to the scheduler.
+         * @param cmd The command to execute.
+         */
         void submitCommand(const AudioCommand& cmd);
 
         /**
@@ -50,13 +86,14 @@ namespace pixelroot32::audio {
         bool isMusicPaused() const;
 
         /**
-         * @brief Sets a custom scheduler.
-         * @param scheduler The scheduler to use.
+         * @brief Replaces the scheduler with a custom implementation.
+         * @param scheduler Unique pointer to the new scheduler. Takes ownership.
          */
         void setScheduler(std::unique_ptr<AudioScheduler> scheduler);
 
         /**
-         * @brief Gets the underlying scheduler for diagnostics/profiling.
+         * @brief Gets the current scheduler for diagnostics or profiling.
+         * @return Pointer to the current AudioScheduler, or nullptr if not set.
          */
         AudioScheduler* getScheduler() const { return scheduler.get(); }
 

--- a/include/audio/AudioMusicTypes.h
+++ b/include/audio/AudioMusicTypes.h
@@ -333,14 +333,34 @@ constexpr InstrumentPreset INSTR_HIHAT{
     0.0f      // dutySweep
 };
 
+/**
+ * @brief Constructs a MusicNote using the preset's default octave.
+ * @param preset The instrument preset defining default volume and octave.
+ * @param note The musical note to play.
+ * @param duration Note duration in seconds.
+ * @return A MusicNote with the preset's base volume and default octave.
+ */
 inline MusicNote makeNote(const InstrumentPreset& preset, Note note, float duration) {
     return MusicNote{note, preset.defaultOctave, duration, preset.baseVolume, &preset};
 }
 
+/**
+ * @brief Constructs a MusicNote with a specific octave override.
+ * @param preset The instrument preset defining default volume and other parameters.
+ * @param note The musical note to play.
+ * @param octave The octave for this note (overrides preset default).
+ * @param duration Note duration in seconds.
+ * @return A MusicNote with the preset's base volume and specified octave.
+ */
 inline MusicNote makeNote(const InstrumentPreset& preset, Note note, uint8_t octave, float duration) {
     return MusicNote{note, octave, duration, preset.baseVolume, &preset};
 }
 
+/**
+ * @brief Constructs a rest (silence) note.
+ * @param duration Duration of the rest in seconds.
+ * @return A MusicNote representing silence.
+ */
 inline MusicNote makeRest(float duration) {
     return MusicNote{Note::Rest, 0, duration, 0.0f, nullptr};
 }

--- a/include/audio/AudioOscLUT.h
+++ b/include/audio/AudioOscLUT.h
@@ -8,8 +8,19 @@
 
 namespace pixelroot32::audio {
 
-    /** One period of sin(2*pi*i/256) in Q15-like int16 (max ≈ 32767). */
-    inline constexpr int16_t SINE_LUT_Q15[256] = {
+/**
+ * @file AudioOscLUT.h
+ * @brief Precomputed sine wave look-up table for band-limited oscillator synthesis.
+ * 
+ * Contains one full period of sin(2*pi*i/256) quantized to int16 in Q15 format.
+ * Used by the SINE wave type in AudioChannel to avoid runtime sine computation.
+ * The 256-entry table provides good quality with minimal memory footprint (~512 bytes).
+ * 
+ * The values range from -32767 to +32767, representing sin(0) to sin(2*pi) at 256 steps.
+ */
+
+/** @brief One period of sin(2*pi*i/256) in Q15 int16 (max ≈ 32767). */
+inline constexpr int16_t SINE_LUT_Q15[256] = {
         0,     804,   1608,  2410,  3212,  4011,  4808,  5602,  6393,  7179,  7962,  8739,  9512,  10278, 11039, 11793,
         12539, 13279, 14010, 14732, 15446, 16151, 16846, 17530, 18204, 18868, 19519, 20159, 20787, 21403, 22005, 22594,
         23170, 23731, 24279, 24811, 25329, 25832, 26319, 26790, 27245, 27683, 28105, 28510, 28898, 29268, 29621, 29956,

--- a/include/audio/AudioScheduler.h
+++ b/include/audio/AudioScheduler.h
@@ -25,36 +25,39 @@ namespace pixelroot32::audio {
 
         /**
          * @brief Initializes the scheduler.
-         * @param backend The audio backend to use.
-         * @param sampleRate The output sample rate.
-         * @param caps Platform capabilities to guide core pinning or threading.
-         * @param blockSize Audio block size (samples) for I2S DMA and ring buffer operations.
+         * @param backend The audio backend to use for output.
+         * @param sampleRate The output sample rate in Hz.
+         * @param caps Platform capabilities to guide core pinning or threading decisions.
+         * @param blockSize Audio block size in samples for I2S DMA and ring buffer operations.
+         *        Must be a multiple of 128.
          */
         virtual void init(AudioBackend* backend, int sampleRate, const pixelroot32::platforms::PlatformCapabilities& caps = pixelroot32::platforms::PlatformCapabilities(), int blockSize = 256) = 0;
 
         /**
-         * @brief Submits a command to the scheduler.
-         * @param cmd The command to execute.
+         * @brief Submits a command to the scheduler for execution.
+         * @param cmd The command to enqueue (PLAY_EVENT, STOP_CHANNEL, etc.).
          */
         virtual void submitCommand(const AudioCommand& cmd) = 0;
 
-        /**
-         * @brief Starts the scheduler execution.
-         */
+        /** @brief Starts the scheduler execution. Enables audio generation. */
         virtual void start() = 0;
 
-        /**
-         * @brief Stops the scheduler execution.
-         */
+        /** @brief Stops the scheduler execution. Silences all voices. */
         virtual void stop() = 0;
 
         /**
          * @brief Checks if the scheduler runs in an independent thread.
+         * @return true if the scheduler owns a dedicated audio thread, false if it
+         *        runs synchronously with the backend's callback.
          */
         virtual bool isIndependent() const = 0;
 
         /**
-         * @brief Generates samples. Should be called by the backend or scheduler thread.
+         * @brief Generates samples into the provided buffer.
+         * @param stream Pointer to the output buffer (mono, int16 samples).
+         * @param length Number of samples to generate (must match blockSize).
+         * 
+         * Called by the backend (or scheduler thread) to fill the audio buffer.
          */
         virtual void generateSamples(int16_t* stream, int length) = 0;
 

--- a/include/audio/AudioTypes.h
+++ b/include/audio/AudioTypes.h
@@ -53,31 +53,44 @@ namespace pixelroot32::audio {
         }
     }
 
+    /**
+     * @struct EnvelopeState
+     * @brief Holds ADSR envelope state for a single voice.
+     * 
+     * Tracks the attack/decay/sustain/release stages and provides both
+     * floating-point and Q15 fixed-point variants to support platforms
+     * without an FPU (e.g., ESP32-C3 RISC-V).
+     */
     struct EnvelopeState {
+        /** ADSR stage: ATTACK, DECAY, SUSTAIN, RELEASE, or OFF. */
         enum class Stage : uint8_t { ATTACK, DECAY, SUSTAIN, RELEASE, OFF };
+        /** Current ADSR stage. */
         Stage stage = Stage::OFF;
         
         // Timing (in samples, pre-calculated from seconds * sampleRate)
-        uint32_t attackSamples = 0;
-        uint32_t decaySamples = 0;
-        float    sustainLevel = 1.0f;
-        uint32_t releaseSamples = 0;
+        uint32_t attackSamples = 0;   ///< Samples for attack phase (0 = instantaneous).
+        uint32_t decaySamples = 0;    ///< Samples for decay phase.
+        float    sustainLevel = 1.0f; ///< Target volume at sustain phase [0.0 - 1.0].
+        uint32_t releaseSamples = 0;  ///< Samples for release phase.
         
         // Runtime state
-        uint32_t sampleCounter = 0;
-        float    currentLevel = 0.0f;
+        uint32_t sampleCounter = 0;    ///< Counter within current stage.
+        float    currentLevel = 0.0f;  ///< Current envelope amplitude [0.0 - 1.0].
 
-        float attackDelta = 0.0f;    // 1.0 / attackSamples
-        float decayDelta = 0.0f;     // (1.0 - sustainLevel) / decaySamples
-        float releaseDelta = 0.0f;   // sustainLevel / releaseSamples
+        float attackDelta = 0.0f;    ///< Volume increment per sample during attack: 1.0 / attackSamples.
+        float decayDelta = 0.0f;     ///< Volume decrement per sample during decay: (1.0 - sustainLevel) / decaySamples.
+        float releaseDelta = 0.0f;   ///< Volume decrement per sample during release: sustainLevel / releaseSamples.
 
         // --- Fixed-point additions for no-FPU path ---
-        int32_t currentLevelQ15 = 0;
-        int32_t attackDeltaQ15 = 0;    // 32768 / attackSamples
-        int32_t decayDeltaQ15 = 0;     // (32768 - sustainLevelQ15) / decaySamples
-        int32_t sustainLevelQ15 = 32768;
-        int32_t releaseDeltaQ15 = 0;   // sustainLevelQ15 / releaseSamples
+        int32_t currentLevelQ15 = 0;    ///< Q15 mirror of currentLevel (-32768 to +32768).
+        int32_t attackDeltaQ15 = 0;     ///< Q15 attack delta: 32768 / attackSamples.
+        int32_t decayDeltaQ15 = 0;      ///< Q15 decay delta: (32768 - sustainLevelQ15) / decaySamples.
+        int32_t sustainLevelQ15 = 32768;///< Q15 sustain level.
+        int32_t releaseDeltaQ15 = 0;    ///< Q15 release delta: sustainLevelQ15 / releaseSamples.
 
+        /**
+         * @brief Resets all envelope state to OFF.
+         */
         void reset() {
             stage = Stage::OFF;
             attackSamples = 0;
@@ -97,23 +110,34 @@ namespace pixelroot32::audio {
     // --- LFO Types ---
     enum class LfoTarget : uint8_t { NONE, PITCH, VOLUME };
 
+    /**
+     * @struct LfoState
+     * @brief Holds LFO (Low-Frequency Oscillator) state for pitch or volume modulation.
+     * 
+     * Supports both floating-point and Q15 fixed-point variants for no-FPU platforms.
+     * The LFO produces a sine-like waveform that can modulate pitch (vibrato) or
+     * volume (tremolo) of a voice.
+     */
     struct LfoState {
-        bool enabled = false;
-        LfoTarget target = LfoTarget::NONE;
+        bool enabled = false;            ///< Whether the LFO is active.
+        LfoTarget target = LfoTarget::NONE;///< What the LFO modulates: PITCH or VOLUME.
         
-        float depth = 0.0f;
-        uint32_t periodSamples = 0;
+        float depth = 0.0f;             ///< Modulation depth (pitch: ratio e.g. 0.05; volume: 0.0-1.0).
+        uint32_t periodSamples = 0;     ///< LFO period in samples (derived from lfoFrequency).
         
-        uint32_t sampleCounter = 0;
-        float currentValue = 0.0f;
+        uint32_t sampleCounter = 0;      ///< Current sample position within the period.
+        float currentValue = 0.0f;       ///< Current LFO output value [-1.0 to +1.0].
 
         // Q15 fixed-point fields for no-FPU path
-        int32_t depthQ15 = 0;           // 0-32768 maps to 0.0-1.0
-        int32_t currentValueQ15 = 0;     // -32768 to +32768 maps to -1.0 to +1.0
+        int32_t depthQ15 = 0;            ///< Q15 depth: 0-32768 maps to 0.0-1.0.
+        int32_t currentValueQ15 = 0;      ///< Q15 output: -32768 to +32768 maps to -1.0 to +1.0.
 
-        uint16_t delaySamples = 0;
-        uint16_t delayCounter = 0;
+        uint16_t delaySamples = 0;      ///< Samples to wait before LFO starts (in seconds * sampleRate).
+        uint16_t delayCounter = 0;       ///< Countdown for delay phase.
         
+        /**
+         * @brief Resets all LFO state to disabled.
+         */
         void reset() {
             enabled = false;
             target = LfoTarget::NONE;
@@ -179,13 +203,16 @@ namespace pixelroot32::audio {
         uint64_t remainingSamples = 0;
 
         // Optional linear frequency sweep (PULSE / TRIANGLE only; see AudioEvent::sweep*)
-        uint32_t sweepSamplesTotal = 0;
-        uint32_t sweepSamplesRemaining = 0;
-        float sweepStartHz = 0.0f;
-        float sweepEndHz = 0.0f;
-        uint32_t sweepStartIncQ32 = 0;
-        uint32_t sweepEndIncQ32 = 0;
+        uint32_t sweepSamplesTotal = 0;   ///< Total samples for the sweep.
+        uint32_t sweepSamplesRemaining = 0;///< Samples remaining in the sweep.
+        float sweepStartHz = 0.0f;        ///< Starting frequency in Hz.
+        float sweepEndHz = 0.0f;          ///< Ending frequency in Hz.
+        uint32_t sweepStartIncQ32 = 0;    ///< Q32 phase increment at sweep start.
+        uint32_t sweepEndIncQ32 = 0;      ///< Q32 phase increment at sweep end.
 
+        /**
+         * @brief Resets the channel to a clean disabled state.
+         */
         void reset() {
             enabled = false;
             type = WaveType::PULSE;

--- a/include/audio/DefaultAudioScheduler.h
+++ b/include/audio/DefaultAudioScheduler.h
@@ -11,17 +11,22 @@ namespace pixelroot32::audio {
 
     /**
      * @class DefaultAudioScheduler
-     * @brief Backend-driven scheduler used on platforms without a dedicated
-     *        audio task.
-     *
-     * Inherits from AudioScheduler.
+     * @brief Backend-driven scheduler used on platforms without a dedicated audio task.
      *
      * Delegates all synthesis to ApuCore; generateSamples() runs in whichever
-     * context the backend invokes it (tests, simulators without a thread,
-     * etc.).
+     * context the backend invokes it (tests, simulators without a thread, etc.).
+     * Does not own a thread — audio generation is driven by the backend's callback.
+     *
+     * @note For platforms with a dedicated audio task (e.g., FreeRTOS on ESP32),
+     *       use a scheduler that spawns its own thread instead.
      */
     class DefaultAudioScheduler : public AudioScheduler {
     public:
+        /**
+         * @brief Default constructor. Initializes ApuCore with default sample rate.
+         * 
+         * Ensures ApuCore is properly set up even if init() is never called explicitly.
+         */
         DefaultAudioScheduler() : apu() {
             // Initialize with default sample rate to ensure ApuCore is properly set up
             // This prevents issues where init() is never called
@@ -30,22 +35,29 @@ namespace pixelroot32::audio {
 
         void init(AudioBackend* backend, int sampleRate,
                   const pixelroot32::platforms::PlatformCapabilities& caps, int blockSize = 256) override;
+        /** @brief Enqueues a command to the ApuCore. @param cmd The command to submit. */
         void submitCommand(const AudioCommand& cmd) override;
+        /** @brief Marks scheduler as running. Starts audio generation context. */
         void start() override;
+        /** @brief Marks scheduler as stopped. Silences all voices. */
         void stop() override;
+        /** @brief Returns false (no dedicated audio thread). @return false. */
         bool isIndependent() const override;
+        /** @brief Generates samples via ApuCore. @param stream Output buffer. @param length Sample count. */
         void generateSamples(int16_t* stream, int length) override;
         bool isMusicPlaying() const override { return apu.isMusicPlaying(); }
         bool isMusicPaused()  const override { return apu.isMusicPaused(); }
+        /** @brief Returns reference to the ApuCore for diagnostics. @return ApuCore reference. */
         ApuCore& getApuCore() override { return apu; }
 
-        /** Exposes the underlying core for tests or higher-level queries. */
+        /** @brief Exposes the underlying core for tests or higher-level queries. @return Const ApuCore reference. */
         const ApuCore& core() const { return apu; }
+        /** @brief Exposes the underlying core for tests or higher-level queries. @return ApuCore reference. */
         ApuCore& core() { return apu; }
 
     private:
-        ApuCore apu;
-        bool running = false;
+        ApuCore apu;     ///< The shared APU core handling all synthesis.
+        bool running = false; ///< Whether the scheduler is active.
     };
 
 } // namespace pixelroot32::audio

--- a/include/audio/MusicPlayer.h
+++ b/include/audio/MusicPlayer.h
@@ -13,7 +13,11 @@ namespace pixelroot32::audio {
 
 /**
  * @class MusicPlayer
- * @brief Simple sequencer to play MusicTracks.
+ * @brief Simple sequencer to play MusicTracks using the AudioEngine.
+ * 
+ * Provides a high-level interface for music playback with tempo control,
+ * pause/resume, and master volume management. Wraps audio commands to the
+ * engine's scheduler.
  */
 class MusicPlayer {
 public:
@@ -25,23 +29,17 @@ public:
 
     /**
      * @brief Starts playing a track.
-     * @param track The track to play.
+     * @param track The MusicTrack to play. Must remain in scope for duration.
      */
     void play(const MusicTrack& track);
 
-    /**
-     * @brief Stops playback and silences the channel.
-     */
+    /** @brief Stops playback and silences all voices. */
     void stop();
 
-    /**
-     * @brief Pauses playback.
-     */
+    /** @brief Pauses playback at the current position. */
     void pause();
 
-    /**
-     * @brief Resumes playback.
-     */
+    /** @brief Resumes playback from the paused position. */
     void resume();
 
     /**
@@ -52,7 +50,7 @@ public:
 
     /**
      * @brief Sets the global tempo scaling factor.
-     * @param factor 1.0f is normal speed, 2.0f is double speed.
+     * @param factor 1.0f is normal speed, 2.0f is double speed, 0.5f is half speed.
      */
     void setTempoFactor(float factor);
 
@@ -64,7 +62,7 @@ public:
 
     /**
      * @brief Sets the tempo in BPM (beats per minute).
-     * @param bpm Beats per minute (default 150).
+     * @param bpm Beats per minute (affects note timing resolution).
      */
     void setBPM(float bpm);
 
@@ -81,24 +79,24 @@ public:
     size_t getActiveTrackCount() const;
 
     /**
-     * @brief Sets the master volume level.
-     * @param volume Volume level (0.0f = silent, 1.0f = full volume).
+     * @brief Sets the master volume level for music playback.
+     * @param volume Volume level [0.0f = silent, 1.0f = full volume].
      */
     void setMasterVolume(float volume);
 
     /**
      * @brief Gets the current master volume level.
-     * @return Current volume (0.0f - 1.0f).
+     * @return Current volume [0.0f - 1.0f].
      */
     float getMasterVolume() const;
 
 private:
-    AudioEngine& engine;
-    const MusicTrack* currentTrack;
-    float tempoFactor; // Global speed multiplier (1.0 = normal)
-    float bpm;         // Beats per minute (default 150)
-    bool playing;
-    bool paused;
+    AudioEngine& engine;             ///< Reference to the audio engine.
+    const MusicTrack* currentTrack; ///< Currently playing track (nullptr if stopped).
+    float tempoFactor;              ///< Global speed multiplier (1.0 = normal).
+    float bpm;                     ///< Beats per minute (default 150).
+    bool playing;                  ///< True if playback is active.
+    bool paused;                   ///< True if playback is paused.
 };
 
 } // namespace pixelroot32::audio

--- a/include/graphics/BaseDrawSurface.h
+++ b/include/graphics/BaseDrawSurface.h
@@ -11,101 +11,105 @@ namespace pixelroot32::graphics {
 
 /**
  * @class BaseDrawSurface
- * @brief Optional base class for DrawSurface implementations that provides default primitive rendering.
+ * @brief Optional base class for DrawSurface implementations providing default primitive rendering.
  *
  * Inherits from DrawSurface.
  *
  * Users can inherit from this class to avoid implementing every single primitive.
- * At minimum, a subclass should implement:
- * - init()
- * - drawPixel()
- * - sendBuffer()
- * - clearBuffer()
+ * At minimum, a subclass must implement:
+ * - init() — initialize the hardware or window
+ * - drawPixel() — draw a single pixel (all other primitives delegate here)
+ * - sendBuffer() — transfer framebuffer to physical display
+ * - clearBuffer() — fill framebuffer with background color
+ *
+ * The default implementations use Bresenham-style algorithms for lines,
+ * rectangles, circles, and bitmaps, all building on drawPixel().
+ * These are slow but correct; override in performance-critical drivers.
  */
 class BaseDrawSurface : public DrawSurface {
 public:
     virtual ~BaseDrawSurface() = default;
 
-    // State management defaults
-    // State management defaults
     /**
      * @brief Sets the text color.
-     * @param color The 16-bit text color.
+     * @param color 16-bit RGB565 text color.
      */
     void setTextColor(uint16_t color) override { textColor = color; }
 
     /**
-     * @brief Sets the text size.
-     * @param size The text size multiplier.
+     * @brief Sets the text size multiplier.
+     * @param size Size multiplier (1 = normal, 2 = double, etc.).
      */
     void setTextSize(uint8_t size) override { textSize = size; }
 
     /**
-     * @brief Sets the cursor position for text drawing.
-     * @param x The X coordinate.
-     * @param y The Y coordinate.
+     * @brief Sets the text cursor position.
+     * @param x X coordinate in pixels.
+     * @param y Y coordinate in pixels.
      */
     void setCursor(int16_t x, int16_t y) override { cursorX = x; cursorY = y; }
 
     /**
-     * @brief Sets the display contrast.
-     * @param level Contrast level (0-255).
+     * @brief Sets the display brightness.
+     * @param level Contrast level (0–255).
      */
     void setContrast(uint8_t level) override { contrast = level; }
 
     /**
      * @brief Sets the display rotation.
-     * @param rot Rotation index or degrees.
+     * @param rot Rotation index (0, 1, 2, 3) or degrees (0, 90, 180, 270).
      */
     void setRotation(uint16_t rot) override { rotation = rot; }
     
-    // Size management defaults
-    // Size management defaults
     /**
-     * @brief Sets the logical display size.
-     * @param w The logical width.
-     * @param h The logical height.
+     * @brief Sets the logical rendering resolution.
+     * @param w Logical width in pixels.
+     * @param h Logical height in pixels.
      */
     void setDisplaySize(int w, int h) override { logicalWidth = w; logicalHeight = h; }
 
     /**
-     * @brief Sets the physical display size.
-     * @param w The physical width.
-     * @param h The physical height.
+     * @brief Sets the physical display resolution.
+     * @param w Physical width in pixels.
+     * @param h Physical height in pixels.
      */
     void setPhysicalSize(int w, int h) override { physicalWidth = w; physicalHeight = h; }
 
     /**
-     * @brief Sets the display offset.
-     * @param x The X offset.
-     * @param y The Y offset.
+     * @brief Sets the display origin offset.
+     * @param x Horizontal offset in pixels.
+     * @param y Vertical offset in pixels.
      */
     void setOffset(int x, int y) override { xOffset = x; yOffset = y; }
 
     /**
-     * @brief Presents the current frame buffer.
+     * @brief Transfers the framebuffer to the physical display.
+     * 
+     * Default implementation calls sendBuffer(). Override if you need
+     * additional logic (e.g., double-buffered swap on SDL).
      */
     void present() override { sendBuffer(); }
 
     /**
-     * @brief Converts RGB888 color to RGB565 format.
+     * @brief Converts 24-bit RGB to RGB565.
      * @param r Red component (0-255).
      * @param g Green component (0-255).
      * @param b Blue component (0-255).
-     * @return The 16-bit color value.
+     * @return 16-bit RGB565 color.
      */
     uint16_t color565(uint8_t r, uint8_t g, uint8_t b) override {
         return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
     }
 
     // Default primitive implementations using drawPixel (slow but functional)
+
     /**
-     * @brief Draws a line between two points.
+     * @brief Draws a line between two points (Bresenham algorithm).
      * @param x1 Start X coordinate.
      * @param y1 Start Y coordinate.
      * @param x2 End X coordinate.
      * @param y2 End Y coordinate.
-     * @param color The line color.
+     * @param color 16-bit RGB565 line color.
      */
     void drawLine(int x1, int y1, int x2, int y2, uint16_t color) override {
         int dx = abs(x2 - x1), sx = x1 < x2 ? 1 : -1;
@@ -124,9 +128,9 @@ public:
      * @brief Draws a rectangle outline.
      * @param x Top-left X coordinate.
      * @param y Top-left Y coordinate.
-     * @param w Width of the rectangle.
-     * @param h Height of the rectangle.
-     * @param color The outline color.
+     * @param w Width in pixels.
+     * @param h Height in pixels.
+     * @param color 16-bit RGB565 outline color.
      */
     void drawRectangle(int x, int y, int w, int h, uint16_t color) override {
         for (int i = 0; i < w; i++) {
@@ -143,9 +147,9 @@ public:
      * @brief Draws a filled rectangle.
      * @param x Top-left X coordinate.
      * @param y Top-left Y coordinate.
-     * @param w Width of the rectangle.
-     * @param h Height of the rectangle.
-     * @param color The fill color.
+     * @param w Width in pixels.
+     * @param h Height in pixels.
+     * @param color 16-bit RGB565 fill color.
      */
     void drawFilledRectangle(int x, int y, int w, int h, uint16_t color) override {
         for (int j = 0; j < h; j++) {
@@ -156,11 +160,11 @@ public:
     }
 
     /**
-     * @brief Draws a circle outline.
+     * @brief Draws a circle outline (midpoint algorithm).
      * @param x0 Center X coordinate.
      * @param y0 Center Y coordinate.
-     * @param r Radius of the circle.
-     * @param color The outline color.
+     * @param r Radius in pixels.
+     * @param color 16-bit RGB565 outline color.
      */
     void drawCircle(int x0, int y0, int r, uint16_t color) override {
         int x = -r, y = 0, err = 2 - 2 * r;
@@ -176,11 +180,11 @@ public:
     }
 
     /**
-     * @brief Draws a filled circle.
+     * @brief Draws a filled circle (midpoint algorithm).
      * @param x0 Center X coordinate.
      * @param y0 Center Y coordinate.
-     * @param r Radius of the circle.
-     * @param color The fill color.
+     * @param r Radius in pixels.
+     * @param color 16-bit RGB565 fill color.
      */
     void drawFilledCircle(int x0, int y0, int r, uint16_t color) override {
         int x = -r, y = 0, err = 2 - 2 * r;
@@ -196,13 +200,13 @@ public:
     }
 
     /**
-     * @brief Draws a bitmap.
+     * @brief Draws a 1bpp bitmap, rendering only non-zero pixels.
      * @param x Top-left X coordinate.
      * @param y Top-left Y coordinate.
-     * @param w Width of the bitmap.
-     * @param h Height of the bitmap.
-     * @param bitmap Pointer to the bitmap data.
-     * @param color The color to draw.
+     * @param w Width in pixels.
+     * @param h Height in pixels.
+     * @param bitmap Pointer to packed 1bpp row data (byte per row, MSB left).
+     * @param color 16-bit RGB565 color for "on" pixels.
      */
     void drawBitmap(int x, int y, int w, int h, const uint8_t *bitmap, uint16_t color) override {
         for (int j = 0; j < h; j++) {
@@ -215,14 +219,18 @@ public:
     }
 
 protected:
-    uint16_t textColor = 0xFFFF;
-    uint8_t textSize = 1;
-    int16_t cursorX = 0, cursorY = 0;
-    uint8_t contrast = 255;
-    uint16_t rotation = 0;
-    int logicalWidth = 240, logicalHeight = 240;
-    int physicalWidth = 240, physicalHeight = 240;
-    int xOffset = 0, yOffset = 0;
+    uint16_t textColor = 0xFFFF;     ///< Current 16-bit text color (RGB565).
+    uint8_t textSize = 1;           ///< Text size multiplier (1 = normal, 2 = double, etc.).
+    int16_t cursorX = 0;            ///< Text cursor X position in pixels.
+    int16_t cursorY = 0;            ///< Text cursor Y position in pixels.
+    uint8_t contrast = 255;         ///< Display brightness (0-255).
+    uint16_t rotation = 0;          ///< Display rotation (0, 1, 2, 3 for 0°, 90°, 180°, 270°).
+    int logicalWidth = 240;         ///< Logical rendering width in pixels.
+    int logicalHeight = 240;         ///< Logical rendering height in pixels.
+    int physicalWidth = 240;        ///< Physical display width in pixels.
+    int physicalHeight = 240;       ///< Physical display height in pixels.
+    int xOffset = 0;                 ///< Horizontal offset for display positioning.
+    int yOffset = 0;                 ///< Vertical offset for display positioning.
 };
 
 } // namespace pixelroot32::graphics

--- a/include/graphics/Camera2D.h
+++ b/include/graphics/Camera2D.h
@@ -13,88 +13,44 @@ class Renderer;
 
 /**
  * @class Camera2D
- * @brief 2D camera system for managing viewports and scrolling.
+ * @brief 2D camera for viewport management and smooth scrolling.
+ *
+ * Manages the viewable area of a scene, providing bounds clamping and
+ * smooth follow-target behavior. The camera sits at a fixed position
+ * until instructed to follow a target; its X/Y coordinates are negated
+ * to become the Renderer's X/Y offset (so content scrolls "under" the camera).
+ *
+ * Bounds are enforced per-axis; if no bounds are set the camera is unclamped
+ * on that axis. A target X or Y position outside bounds is clamped before
+ * the camera moves.
+ *
+ * @note Camera2D does not own a Renderer. Call apply(renderer) to push the
+ *       camera transform after updating.
  */
 class Camera2D {
 public:
-    /**
-     * @brief Constructs a new Camera2D.
-     * @param viewportWidth Width of the viewport.
-     * @param viewportHeight Height of the viewport.
-     */
     Camera2D(int viewportWidth, int viewportHeight);
 
-    /**
-     * @brief Sets the horizontal scrolling bounds.
-     * @param minX Minimum X coordinate.
-     * @param maxX Maximum X coordinate.
-     */
     void setBounds(pixelroot32::math::Scalar minX, pixelroot32::math::Scalar maxX);
-
-    /**
-     * @brief Sets the vertical scrolling bounds.
-     * @param minY Minimum Y coordinate.
-     * @param maxY Maximum Y coordinate.
-     */
     void setVerticalBounds(pixelroot32::math::Scalar minY, pixelroot32::math::Scalar maxY);
-
-    /**
-     * @brief Sets the camera's current position.
-     * @param position The new position vector.
-     */
     void setPosition(pixelroot32::math::Vector2 position);
-
-    /**
-     * @brief Makes the camera follow a target on the X axis.
-     * @param targetX The target X coordinate to follow.
-     */
     void followTarget(pixelroot32::math::Scalar targetX);
-
-    /**
-     * @brief Makes the camera follow a target in 2D space.
-     * @param target The target position vector.
-     */
     void followTarget(pixelroot32::math::Vector2 target);
-
-    /**
-     * @brief Gets the current X position.
-     * @return The X coordinate.
-     */
     pixelroot32::math::Scalar getX() const;
-
-    /**
-     * @brief Gets the current Y position.
-     * @return The Y coordinate.
-     */
     pixelroot32::math::Scalar getY() const;
-
-    /**
-     * @brief Gets the current position vector.
-     * @return The position vector.
-     */
     pixelroot32::math::Vector2 getPosition() const;
-
-    /**
-     * @brief Applies the camera transformation to a renderer.
-     * @param renderer The renderer to apply the camera to.
-     */
+    /** @brief Pushes the camera transform into the renderer (sets display offset). */
     void apply(Renderer& renderer) const;
-
-    /**
-     * @brief Sets the viewport size (usually logical resolution).
-     * @param width Viewport width.
-     * @param height Viewport height.
-     */
     void setViewportSize(int width, int height);
 
 private:
-    pixelroot32::math::Vector2 position;
-    int viewportWidth;
-    int viewportHeight;
-    pixelroot32::math::Scalar minX;
-    pixelroot32::math::Scalar maxX;
-    pixelroot32::math::Scalar minY;
-    pixelroot32::math::Scalar maxY;
+    pixelroot32::math::Vector2 position;   ///< Camera position in world units.
+    int viewportWidth;                    ///< Viewport width in pixels.
+    int viewportHeight;                   ///< Viewport height in pixels.
+    pixelroot32::math::Scalar minX;      ///< Left boundary in world units (unbounded if > maxX).
+    pixelroot32::math::Scalar maxX;      ///< Right boundary in world units.
+    pixelroot32::math::Scalar minY;      ///< Top boundary in world units.
+    pixelroot32::math::Scalar maxY;      ///< Bottom boundary in world units.
 };
 
 } // namespace pixelroot32::graphics

--- a/include/graphics/PaletteDefs.h
+++ b/include/graphics/PaletteDefs.h
@@ -7,6 +7,35 @@
 
 namespace pixelroot32::graphics {
 
+/**
+ * @file PaletteDefs.h
+ * @brief Predefined 16-color RGB565 palettes (NES, GameBoy, PICO-8, PR32).
+ *
+ * All palettes are constexpr arrays of 16 RGB565 values (indices 0–15).
+ * The engine resolves Color enum values against these tables at render time.
+ *
+ * Palette Layout (all 16 entries):
+ * Index | Color Role
+ * ------|------------------------------
+ *  0    | Black
+ *  1    | White
+ *  2    | Navy
+ *  3    | Blue
+ *  4    | Cyan
+ *  5    | DarkGreen
+ *  6    | Green
+ *  7    | LightGreen
+ *  8    | Yellow
+ *  9    | Orange
+ * 10    | LightRed
+ * 11    | Red
+ * 12    | DarkRed
+ * 13    | Purple
+ * 14    | Magenta
+ * 15    | Gray
+ */
+
+/** 16-color NES-style palette (PICO-8 compatible). */
 static constexpr uint16_t PALETTE_NES[] = {
     0x0000, // #000000 (Black)
     0xFF9C, // #FFF1E8 (White)

--- a/include/graphics/ResolutionPresets.h
+++ b/include/graphics/ResolutionPresets.h
@@ -9,28 +9,49 @@
 namespace pixelroot32::graphics {
 
 /**
- * @brief Predefined resolution presets for different memory/performance profiles.
+ * @file ResolutionPresets.h
+ * @brief Predefined logical resolution presets with associated memory savings.
+ *
+ * Provides a convenient enum + factory for common PixelRoot32 configurations.
+ * Each preset pairs a logical resolution with automatic nearest-neighbor scaling
+ * to the physical display, trading visual fidelity for framebuffer memory.
+ *
+ * Memory is calculated as: (logicalWidth × logicalHeight) bytes for 8bpp.
+ * Savings are relative to 240×240 (57,600 bytes).
+ */
+
+/**
+ * @enum ResolutionPreset
+ * @brief Logical resolution choices for memory-constrained targets.
+ *
+ * Use create() to turn a preset into a DisplayConfig with the correct
+ * logical and physical dimensions already set.
  */
 enum ResolutionPreset {
-    RES_240x240,  ///< Full resolution (no scaling), 240x240 logical on 240x240 physical.
-    RES_160x160,  ///< 160x160 logical scaled to 240x240. ~55% memory savings.
-    RES_128x128,  ///< 128x128 logical scaled to 240x240. ~72% memory savings (Recommended).
-    RES_96x96,    ///< 96x96 logical scaled to 240x240. ~84% memory savings (Very pixelated).
+    RES_240x240,  ///< Full resolution: 240×240 logical on 240×240 physical (57,600 bytes).
+    RES_160x160,  ///< 160×160 logical scaled to 240×240 (~55% memory savings, ~25,600 bytes).
+    RES_128x128,  ///< 128×128 logical scaled to 240×240 (~72% memory savings — recommended, ~16,384 bytes).
+    RES_96x96,    ///< 96×96 logical scaled to 240×240 (~84% memory savings, very pixelated, ~9,216 bytes).
     RES_CUSTOM    ///< User-defined resolution.
 };
 
 /**
- * @brief Helper class to create DisplayConfigs from presets.
+ * @class ResolutionPresets
+ * @brief Factory for creating DisplayConfig from resolution presets.
+ *
+ * Simplifies display setup on memory-constrained targets by providing
+ * a single create() call that sets logical dimensions, physical dimensions,
+ * and rotation together.
  */
 class ResolutionPresets {
 public:
     /**
-     * @brief Creates a DisplayConfig based on a preset and hardware target.
-     * @param preset The desired resolution preset.
-     * @param type The physical display type (default ST7789).
-     * @param physicalW Physical width (default 240).
-     * @param physicalH Physical height (default 240).
-     * @return A configured DisplayConfig object.
+     * @brief Creates a DisplayConfig from a preset and hardware target.
+     * @param preset Desired resolution preset.
+     * @param type Physical display type (default ST7789).
+     * @param physicalW Physical width in pixels (default 240).
+     * @param physicalH Physical height in pixels (default 240).
+     * @return Configured DisplayConfig with correct logical/physical dimensions.
      */
     static DisplayConfig create(ResolutionPreset preset, DisplayType type = ST7789, 
                                uint16_t physicalW = 240, uint16_t physicalH = 240) {

--- a/include/graphics/TouchConfig.h
+++ b/include/graphics/TouchConfig.h
@@ -13,51 +13,77 @@
 namespace pixelroot32::graphics {
 
 /**
+ * @file TouchConfig.h
+ * @brief Touch controller configuration for XPT2046 (SPI) and GT911 (I2C).
+ *
+ * Defines TouchConfig as a simple struct with calibration, SPI/I2C settings,
+ * and coordinate transformation (scale + offset). Add to DisplayConfig
+ * or use standalone.
+ *
+ * Compile-time activation:
+ *   -DTOUCH_DRIVER_XPT2046  → XPT2046 SPI at 2.5 MHz default
+ *   -DTOUCH_DRIVER_GT911    → GT911 I2C at 400 kHz default
+ */
+
+/**
  * @enum TouchController
- * @brief Supported touch controller types
+ * @brief Supported touch controller types.
  */
 enum class TouchController {
-    None = 0,     ///< No touch controller
-    XPT2046 = 1,  ///< SPI touch controller (common on dev boards)
-    GT911 = 2     ///< I2C touch controller (Goodix)
+    None = 0,    ///< No touch hardware.
+    XPT2046 = 1, ///< SPI resistive controller (common on ESP32 dev boards).
+    GT911 = 2    ///< I2C capacitive controller (Goodix, up to 5-point touch).
 };
 
 /**
  * @struct TouchConfig
- * @brief Configuration for touch controller
+ * @brief Configuration for a touch controller (XPT2046 or GT911).
  *
- * Add to DisplayConfig or use standalone.
- * Define one of TOUCH_DRIVER_XPT2046 or TOUCH_DRIVER_GT911 in build flags.
+ * Set controller, communication parameters, and calibration transform.
+ * Coordinate mapping: screenX = rawX * scaleX + offsetX (and same for Y).
+ * Raw coordinates outside display bounds are clamped before mapping.
  */
 struct TouchConfig {
-    TouchController controller = TouchController::None;  ///< Active controller
-    
-    // SPI settings (for XPT2046)
-    uint32_t spiClockHz = 2500000;    // 2.5 MHz
-    uint8_t csPin = 5;               // SPI CS pin
-    uint8_t irqPin = 4;              // Interrupt pin (optional)
-    
-    // I2C settings (for GT911)
-    uint32_t i2cClockHz = 400000;     // 400 kHz
-    uint8_t i2cAddress = 0x5D;        // GT911 I2C address
-    
-    // Calibration defaults
+    TouchController controller = TouchController::None;  ///< Active controller type.
+
+    // SPI settings (XPT2046)
+    /** SPI clock frequency in Hz (default 2.5 MHz). */
+    uint32_t spiClockHz = 2500000;
+    /** SPI chip-select pin. */
+    uint8_t csPin = 5;
+    /** Touch interrupt pin (255 = unused). */
+    uint8_t irqPin = 4;
+
+    // I2C settings (GT911)
+    /** I2C clock frequency in Hz (default 400 kHz). */
+    uint32_t i2cClockHz = 400000;
+    /** GT911 I2C address (default 0x5D; alternate 0x14). */
+    uint8_t i2cAddress = 0x5D;
+
+    // Calibration transform
+    /** Horizontal scale (raw → display coordinate multiplier). */
     float scaleX = 1.0f;
+    /** Vertical scale (raw → display coordinate multiplier). */
     float scaleY = 1.0f;
+    /** Horizontal offset in display pixels after scaling. */
     int16_t offsetX = 0;
+    /** Vertical offset in display pixels after scaling. */
     int16_t offsetY = 0;
-    
+
     // Display bounds for coordinate clamping
+    /** Physical display width in pixels. */
     uint16_t displayWidth = 320;
+    /** Physical display height in pixels. */
     uint16_t displayHeight = 240;
 
-    /**
-     * @brief Default constructor - no touch
-     */
+    /** Default constructor — no controller, defaults for all fields. */
     TouchConfig() = default;
 
     /**
-     * @brief Constructor for XPT2046
+     * @brief Factory: XPT2046 SPI configuration.
+     * @param cs SPI chip-select pin.
+     * @param irq Interrupt pin (255 = unused).
+     * @return Configured TouchConfig.
      */
     static TouchConfig createXPT2046(uint8_t cs, uint8_t irq = 255) {
         TouchConfig config;
@@ -68,7 +94,9 @@ struct TouchConfig {
     }
 
     /**
-     * @brief Constructor for GT911
+     * @brief Factory: GT911 I2C configuration.
+     * @param irq Interrupt pin (default 4).
+     * @return Configured TouchConfig.
      */
     static TouchConfig createGT911(uint8_t irq = 4) {
         TouchConfig config;

--- a/include/input/InputConfig.h
+++ b/include/input/InputConfig.h
@@ -9,61 +9,84 @@
  * This file remains licensed under the MIT License.
  */
 #pragma once
-#include <cstdarg>
+#include <array>
 #include <cstdint>
-#include <vector>
+#include <type_traits>
 
 namespace pixelroot32::input {
+
+// Forward declaration for static_assert validation
+struct InputManager;
 
 /**
  * @struct InputConfig
  * @brief Configuration structure for the InputManager.
  *
- * Defines the mapping between logical inputs and physical pins (ESP32) 
- * or keyboard keys (Native/SDL2).
+ * Maps logical inputs to physical GPIO pins (ESP32) or keyboard scancodes (Native/SDL2).
+ * Uses fixed-size std::array instead of std::vector for zero-allocation and
+ * deterministic memory usage on ESP32.
  *
- * Uses variadic arguments to allow flexible configuration of input count.
+ * Usage:
+ * @code
+ * // ESP32
+ * pr32::input::InputConfig config(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT);
+ *
+ * // Native (SDL2)
+ * pr32::input::InputConfig config(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN);
+ *
+ * // Empty
+ * pr32::input::InputConfig config{};
+ * @endcode
+ *
+ * @see InputManager
  */
-struct InputConfig{
+struct InputConfig {
+    /// Maximum number of inputs supported (compile-time fixed size).
+    static constexpr size_t MAX_INPUT_COUNT = 16;
+
+    static_assert(MAX_INPUT_COUNT <= 16,
+        "MAX_INPUT_COUNT must not exceed compile-time limits");
+
 #ifdef PLATFORM_NATIVE
-    std::vector<uint8_t> buttonNames; ///< Array of button mappings (scancodes) for Native.
+    /// Array of SDL scancodes for Native platform.
+    std::array<uint8_t, MAX_INPUT_COUNT> buttonNames{};
 #else
-    std::vector<int> inputPins; ///< Array of GPIO pin numbers for ESP32.
+    /// Array of GPIO pin numbers for ESP32.
+    std::array<int, MAX_INPUT_COUNT> inputPins{};
 #endif
-    int count = 0;         ///< Total number of configured inputs.
+
+    /// Total number of configured inputs (auto-deduced from constructor arguments).
+    size_t count = 0;
 
     /**
-     * @brief Constructs a new InputConfig.
-     * @param count Number of inputs to configure.
-     * @param ... Variable arguments list of pins (int) or keys.
+     * @brief Template variadic constructor.
+     * @tparam Args Types of input arguments (int for pins/scancodes).
+     * @param args Variable number of input values.
+     *
+     * Count is auto-deduced from argument count. Exceeding MAX_INPUT_COUNT
+     * triggers a static_assert compile error.
      */
-    InputConfig(int count, ...): count(count) {
-        if (count <= 0) {
-            this->count = 0;
-            return;
+    template<typename... Args>
+    InputConfig(Args... args) : count(sizeof...(Args)) {
+        static_assert(sizeof...(Args) <= MAX_INPUT_COUNT,
+            "Too many arguments for InputConfig");
+
+        if (count > MAX_INPUT_COUNT) {
+            count = MAX_INPUT_COUNT;
         }
 
-        va_list args;
-        va_start(args, count);
-
-        #ifdef PLATFORM_NATIVE
-            buttonNames.reserve(count);
-            for (int i = 0; i < count; i++) {
-                buttonNames.push_back((uint8_t)va_arg(args, int));
-            }
-        #else
-            inputPins.reserve(count);
-            for (int i = 0; i < count; i++) {
-                inputPins.push_back(va_arg(args, int));
-            }
-        #endif
-        va_end(args);
+        if constexpr (sizeof...(args) > 0) {
+            size_t index = 0;
+#ifdef PLATFORM_NATIVE
+            ((buttonNames[index++] = static_cast<uint8_t>(args)), ...);
+#else
+            ((inputPins[index++] = static_cast<int>(args)), ...);
+#endif
+        }
     }
 
-    /**
-     * @brief Default constructor.
-     */
+    /// @brief Default constructor (empty configuration).
     InputConfig() : count(0) {}
 };
 
-}
+} // namespace pixelroot32::input

--- a/include/input/InputConfig.h
+++ b/include/input/InputConfig.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "u8g2",
     "sdl2"
   ],
-  "version": "1.4.0",
+  "version": "1.5.0",
   "build": {
     "srcDir": "src",
     "includeDir": "include"

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -199,43 +199,30 @@ def extract_method_signature(line: str) -> Optional[Tuple[str, str, bool, bool, 
         # Assignment statement like "int x = 5;" but not "operator="
         return None
     
+    # Strip inline body first so override/final are always at end for regex
+    stripped = original_line
+    sig_part = stripped
+    if '{' in stripped:
+        sig_part = stripped.split('{')[0].strip()
+
     # Check for virtual
-    is_virtual = 'virtual ' in line
-    line = line.replace('virtual ', '')
-    
+    is_virtual = 'virtual ' in sig_part
+    sig_part = sig_part.replace('virtual ', '')
+
     # Check for static
-    is_static = line.strip().startswith('static ')
-    line = line.replace('static ', '')
-    
+    is_static = sig_part.strip().startswith('static ')
+    sig_part = sig_part.replace('static ', '')
+
     # Check for explicit override/final and pure virtual
-    line = re.sub(r'\s+override\s*$', '', line)
-    line = re.sub(r'\s+final\s*$', '', line)
-    line = re.sub(r'\s*=\s*0\s*;', ';', line)  # Pure virtual
+    sig_part = re.sub(r'\s+override\s*$', '', sig_part)
+    sig_part = re.sub(r'\s+final\s*$', '', sig_part)
+    sig_part = re.sub(r'\s*=\s*0\s*;', ';', sig_part)
+
+    # For matching, use sig_part as-is
+    sig_line = sig_part
     
-    # Skip if line contains function body indicators
-    if '{' in line and ';' not in line.split('{')[0]:
-        # Likely a function definition with body, not just declaration
-        pass  # Still check if it ends with semicolon after body
-    
+    # Use sig_part (already stripped of inline body, override, final)
     # Match method signature: return_type name(params) [const];
-    # Handle templates, pointers, references, etc.
-    # Can end with semicolon OR have inline body { ... }
-    stripped = line.strip()
-    
-    # Check if this looks like an inline implementation (ends with })
-    # but has proper signature pattern before the body
-    has_inline_body = stripped.endswith('}') and '{' in stripped
-    
-    # For inline methods, we need to extract just the signature part before { or :
-    # First, try to match the signature part only (before { or :)
-    sig_line = stripped
-    if ':' in stripped and ('{' not in stripped or stripped.find(':') < stripped.find('{')):
-        # Constructor with initializer list - cut before :
-        sig_line = stripped.split(':')[0].strip()
-    elif '{' in stripped:
-        # Inline function body - cut before {
-        sig_line = stripped.split('{')[0].strip()
-    
     method_pattern = r'^(?:template\s*<[^>]+>\s*)?'  # Optional template
     method_pattern += r'([\w:<>,\s&*~]+?)'  # Return type (non-greedy), allow ~ for destructor
     method_pattern += r'\s+([\w~]+)\s*'  # Method name (allow ~ for destructor)
@@ -244,7 +231,7 @@ def extract_method_signature(line: str) -> Optional[Tuple[str, str, bool, bool, 
     method_pattern += r'(?:\s*=\s*0)?'  # Optional pure virtual = 0
     method_pattern += r'(?:\s*;)?$'  # Optional semicolon at end
     
-    match = re.match(method_pattern, sig_line)
+    match = re.match(method_pattern, sig_part)
     if not match:
         return None
     

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -72,7 +72,7 @@ namespace pixelroot32::core {
     }
 
     Engine::Engine(DisplayConfig&& displayConfig) 
-        : renderer(std::move(displayConfig)), inputManager(InputConfig(0)), capabilities(PlatformCapabilities::detect())
+        : renderer(std::move(displayConfig)), inputManager(InputConfig{}), capabilities(PlatformCapabilities::detect())
         #if PIXELROOT32_ENABLE_TOUCH
         , touchManager(nullptr), wasTouchActive(false), lastTouchX(0), lastTouchY(0)
         #endif
@@ -113,8 +113,8 @@ namespace pixelroot32::core {
     }
 
     Engine::Engine(const DisplayConfig& displayConfig) 
-        : renderer(const_cast<DisplayConfig&>(displayConfig)), 
-          inputManager(InputConfig(0)), capabilities(PlatformCapabilities::detect())
+        : renderer(const_cast<DisplayConfig&>(displayConfig)),
+          inputManager(InputConfig{}), capabilities(PlatformCapabilities::detect())
 #if PIXELROOT32_ENABLE_AUDIO
           , audioEngine(AudioConfig(), capabilities), musicPlayer(audioEngine)
 #endif

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -29,7 +29,7 @@ namespace pixelroot32::input {
 
         // Initialize button pins - arrays are pre-initialized to zero/false
         // Set all pins as INPUT_PULLUP
-        for (int i = 0; i < config.count; i++) {
+        for (size_t i = 0; i < config.count; i++) {
             #ifdef PLATFORM_NATIVE
                 buttonPins[i] = config.buttonNames[i];
             #else
@@ -42,7 +42,7 @@ namespace pixelroot32::input {
     void InputManager::update(unsigned long dt, const uint8_t* keyboardState) {
         if (config.count <= 0) return;
 
-        for (int i = 0; i < config.count; i++) {
+        for (size_t i = 0; i < config.count; i++) {
             // Reset stateChanged at the start of each update for every button
             stateChanged[i] = false;
 
@@ -69,7 +69,7 @@ namespace pixelroot32::input {
     void InputManager::update(unsigned long dt) {
         if (config.count <= 0) return;
 
-        for (int i = 0; i < config.count; i++) {
+        for (size_t i = 0; i < config.count; i++) {
             // Reset stateChanged at the start of each update for every button
             stateChanged[i] = false;
 

--- a/test/unit/test_input_config/test_input_config.cpp
+++ b/test/unit/test_input_config/test_input_config.cpp
@@ -7,17 +7,15 @@ void setUp(void) {}
 void tearDown(void) {}
 
 void test_input_config_initialization(void) {
-    InputConfig config(3, 10, 20, 30);
-    
+    InputConfig config(10, 20, 30);
+
     TEST_ASSERT_EQUAL(3, config.count);
-    
+
 #ifdef PLATFORM_NATIVE
-    TEST_ASSERT_EQUAL(3, config.buttonNames.size());
     TEST_ASSERT_EQUAL(10, config.buttonNames[0]);
     TEST_ASSERT_EQUAL(20, config.buttonNames[1]);
     TEST_ASSERT_EQUAL(30, config.buttonNames[2]);
 #else
-    TEST_ASSERT_EQUAL(3, config.inputPins.size());
     TEST_ASSERT_EQUAL(10, config.inputPins[0]);
     TEST_ASSERT_EQUAL(20, config.inputPins[1]);
     TEST_ASSERT_EQUAL(30, config.inputPins[2]);
@@ -25,18 +23,70 @@ void test_input_config_initialization(void) {
 }
 
 void test_input_config_empty(void) {
-    InputConfig config(0);
+    InputConfig config;
     TEST_ASSERT_EQUAL(0, config.count);
 #ifdef PLATFORM_NATIVE
-    TEST_ASSERT_EQUAL(0, config.buttonNames.size());
+    TEST_ASSERT_EQUAL(0, config.buttonNames[0]);
 #else
-    TEST_ASSERT_EQUAL(0, config.inputPins.size());
+    TEST_ASSERT_EQUAL(0, config.inputPins[0]);
 #endif
 }
 
 void test_input_config_negative_count(void) {
-    InputConfig config(-1);
+    InputConfig config;
     TEST_ASSERT_EQUAL(0, config.count);
+}
+
+// Phase 3: New tests for array-based InputConfig
+
+void test_input_config_default(void) {
+    // Verify default constructor initializes count=0 and all elements are zero
+    InputConfig config;
+
+    TEST_ASSERT_EQUAL(0, config.count);
+    TEST_ASSERT_EQUAL(16u, config.buttonNames.size());
+
+    // Verify all elements are zero-initialized
+    for (size_t i = 0; i < config.buttonNames.size(); i++) {
+        TEST_ASSERT_EQUAL(0, config.buttonNames[i]);
+    }
+}
+
+void test_input_config_init_list(void) {
+    // Verify variadic constructor works: InputConfig(1, 2, 3) = count 3
+    InputConfig config(1, 2, 3);
+
+    TEST_ASSERT_EQUAL(3, config.count);
+    TEST_ASSERT_EQUAL(1, config.buttonNames[0]);
+    TEST_ASSERT_EQUAL(2, config.buttonNames[1]);
+    TEST_ASSERT_EQUAL(3, config.buttonNames[2]);
+
+    // Verify unused elements are zero
+    TEST_ASSERT_EQUAL(0, config.buttonNames[3]);
+    TEST_ASSERT_EQUAL(0, config.buttonNames[15]);
+}
+
+void test_input_config_bounds(void) {
+    // Verify maximum valid count (16) works correctly
+    // static_assert prevents compile-time overflow for >16 args
+    InputConfig config(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+
+    TEST_ASSERT_EQUAL(16, config.count);
+    TEST_ASSERT_EQUAL(1, config.buttonNames[0]);
+    TEST_ASSERT_EQUAL(16, config.buttonNames[15]);
+
+    // Verify trailing elements are zero (index 15 is last valid, 0-14 should be data, 15 is last data)
+    // Actually with 16 elements: indices 0-15 contain data, so no trailing zeros to check
+}
+
+void test_input_config_overflow(void) {
+    // Test that default constructor handles zero case properly
+    InputConfig config;
+
+    TEST_ASSERT_EQUAL(0, config.count);
+
+    // Verify MAX_INPUT_COUNT constant is accessible
+    TEST_ASSERT_EQUAL(16u, InputConfig::MAX_INPUT_COUNT);
 }
 
 int main(int argc, char **argv) {
@@ -44,5 +94,9 @@ int main(int argc, char **argv) {
     RUN_TEST(test_input_config_initialization);
     RUN_TEST(test_input_config_empty);
     RUN_TEST(test_input_config_negative_count);
+    RUN_TEST(test_input_config_default);
+    RUN_TEST(test_input_config_init_list);
+    RUN_TEST(test_input_config_bounds);
+    RUN_TEST(test_input_config_overflow);
     return UNITY_END();
 }

--- a/test/unit/test_input_manager/test_input_manager.cpp
+++ b/test/unit/test_input_manager/test_input_manager.cpp
@@ -23,17 +23,17 @@ void setUp(void) {
 void tearDown(void) {}
 
 void test_input_manager_initialization(void) {
-    InputConfig config(2, 10, 20);
+    InputConfig config(10, 20);
     InputManager manager(config);
     manager.init();
-    
+
     // Initial states should be false
     TEST_ASSERT_FALSE(manager.isButtonDown(0));
     TEST_ASSERT_FALSE(manager.isButtonDown(1));
 }
 
 void test_input_manager_button_press(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -47,7 +47,7 @@ void test_input_manager_button_press(void) {
 }
 
 void test_input_manager_button_release(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -65,7 +65,7 @@ void test_input_manager_button_release(void) {
 }
 
 void test_input_manager_debouncing(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -89,7 +89,7 @@ void test_input_manager_debouncing(void) {
 }
 
 void test_input_manager_click(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -107,7 +107,7 @@ void test_input_manager_click(void) {
 }
 
 void test_input_manager_out_of_bounds(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -118,7 +118,7 @@ void test_input_manager_out_of_bounds(void) {
 }
 
 void test_input_manager_multiple_buttons(void) {
-    InputConfig config(3, 10, 11, 12);
+    InputConfig config(10, 11, 12);
     InputManager manager(config);
     manager.init();
     
@@ -132,7 +132,7 @@ void test_input_manager_multiple_buttons(void) {
 }
 
 void test_input_manager_button_state_persistence(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -149,7 +149,7 @@ void test_input_manager_button_state_persistence(void) {
 }
 
 void test_input_manager_is_button_pressed_clears_after_frame(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -162,7 +162,7 @@ void test_input_manager_is_button_pressed_clears_after_frame(void) {
 }
 
 void test_input_manager_is_button_released_clears_after_frame(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -178,7 +178,7 @@ void test_input_manager_is_button_released_clears_after_frame(void) {
 }
 
 void test_input_manager_touch_events_empty(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -190,7 +190,7 @@ void test_input_manager_touch_events_empty(void) {
 }
 
 void test_input_manager_get_touch_state_idle(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -199,7 +199,7 @@ void test_input_manager_get_touch_state_idle(void) {
 }
 
 void test_input_manager_invalid_button_index_all_methods(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -210,16 +210,16 @@ void test_input_manager_invalid_button_index_all_methods(void) {
 }
 
 void test_input_manager_zero_button_count(void) {
-    InputConfig config(0);
+    InputConfig config;
     InputManager manager(config);
     manager.init();
-    
+
     TEST_ASSERT_FALSE(manager.isButtonDown(0));
     TEST_ASSERT_FALSE(manager.isButtonPressed(0));
 }
 
 void test_input_manager_config_max_buttons(void) {
-    InputConfig config(16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    InputConfig config(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     InputManager manager(config);
     manager.init();
     
@@ -237,7 +237,7 @@ void test_input_manager_config_max_buttons(void) {
 // =============================================================================
 
 void test_input_manager_touch_event_press_release(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -260,7 +260,7 @@ void test_input_manager_touch_event_press_release(void) {
 }
 
 void test_input_manager_touch_event_move(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -275,7 +275,7 @@ void test_input_manager_touch_event_move(void) {
 }
 
 void test_input_manager_touch_event_multiple_touches(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -295,7 +295,7 @@ void test_input_manager_touch_event_multiple_touches(void) {
 }
 
 void test_input_manager_touch_event_queue_full(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -314,7 +314,7 @@ void test_input_manager_touch_event_queue_full(void) {
 }
 
 void test_input_manager_has_touch_events_after_inject(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -328,7 +328,7 @@ void test_input_manager_has_touch_events_after_inject(void) {
 }
 
 void test_input_manager_get_touch_state_pressed(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -341,7 +341,7 @@ void test_input_manager_get_touch_state_pressed(void) {
 }
 
 void test_input_manager_invalid_touch_id(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -353,7 +353,7 @@ void test_input_manager_invalid_touch_id(void) {
 // Platform-native specific tests (SDL event processing)
 #ifdef PLATFORM_NATIVE
 void test_input_manager_process_sdl_event_mouse_button_down(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -372,7 +372,7 @@ void test_input_manager_process_sdl_event_mouse_button_down(void) {
 }
 
 void test_input_manager_process_sdl_event_mouse_button_up(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -399,7 +399,7 @@ void test_input_manager_process_sdl_event_mouse_button_up(void) {
 }
 
 void test_input_manager_process_sdl_event_mouse_motion_drag(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -435,7 +435,7 @@ void test_input_manager_process_sdl_event_mouse_motion_drag(void) {
 }
 
 void test_input_manager_process_sdl_event_mouse_motion_no_drag(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -453,7 +453,7 @@ void test_input_manager_process_sdl_event_mouse_motion_no_drag(void) {
 }
 
 void test_input_manager_process_sdl_event_non_mouse_ignored(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -470,7 +470,7 @@ void test_input_manager_process_sdl_event_non_mouse_ignored(void) {
 }
 
 void test_input_manager_process_sdl_event_right_button_ignored(void) {
-    InputConfig config(1, 10);
+    InputConfig config(10);
     InputManager manager(config);
     manager.init();
     
@@ -489,25 +489,25 @@ void test_input_manager_process_sdl_event_right_button_ignored(void) {
 #endif // PLATFORM_NATIVE
 
 void test_input_manager_init_invalid_count(void) {
-    // Test initialization with invalid count (0)
-    InputConfig config(0);
+    // Test initialization with invalid count (0) - empty config
+    InputConfig config;
     InputManager manager(config);
     manager.init();
-    
+
     // Verify manager is still functional - should not crash
     // Invalid touch ID should return Idle
     TouchState state = manager.getTouchState(0);
     TEST_ASSERT_EQUAL(static_cast<uint8_t>(TouchState::Idle), static_cast<uint8_t>(state));
 }
 
-void test_input_manager_init_count_above_max(void) {
-    // Test initialization with count above MAX_BUTTONS
-    InputConfig config(20);  // Above MAX_BUTTONS (16)
+void test_input_manager_init_count_at_max(void) {
+    // Test initialization with count at MAX_BUTTONS (16)
+    // static_assert now catches overflow at compile time for >16 args
+    InputConfig config(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
     InputManager manager(config);
     manager.init();
-    
-    // Verify manager is still functional
-    // Invalid touch ID should return Idle
+
+    // Verify manager is functional with max buttons
     TouchState state = manager.getTouchState(0);
     TEST_ASSERT_EQUAL(static_cast<uint8_t>(TouchState::Idle), static_cast<uint8_t>(state));
 }
@@ -549,7 +549,7 @@ int main(int argc, char **argv) {
     #endif
     
     RUN_TEST(test_input_manager_init_invalid_count);
-    RUN_TEST(test_input_manager_init_count_above_max);
+    RUN_TEST(test_input_manager_init_count_at_max);
     
     return UNITY_END();
 }

--- a/test/unit/test_particle_emitter/test_particle_emitter.cpp
+++ b/test/unit/test_particle_emitter/test_particle_emitter.cpp
@@ -12,6 +12,8 @@
  */
 
 #include <unity.h>
+#include <vector>
+#include <tuple>
 #include "../../test_config.h"
 
 #ifdef PIXELROOT32_ENABLE_PARTICLES

--- a/test/unit/test_platforms/test_platform_input.h
+++ b/test/unit/test_platforms/test_platform_input.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unity.h>
+#include <array>
 #include "input/InputConfig.h"
 
 using namespace pixelroot32::input;
@@ -15,9 +16,10 @@ void test_input_config_default_constructor(void) {
 }
 
 void test_input_config_single_input(void) {
-    InputConfig config(1, 10);
+    // New API: InputConfig(pin1, pin2, ...) - count auto-deduced
+    InputConfig config(10);
     TEST_ASSERT_EQUAL(1, config.count);
-    
+
     #ifdef PLATFORM_NATIVE
     TEST_ASSERT_EQUAL(10, config.buttonNames[0]);
     #else
@@ -26,9 +28,10 @@ void test_input_config_single_input(void) {
 }
 
 void test_input_config_multiple_inputs(void) {
-    InputConfig config(3, 10, 20, 30);
+    // New API: 3 inputs = 3 arguments
+    InputConfig config(10, 20, 30);
     TEST_ASSERT_EQUAL(3, config.count);
-    
+
     #ifdef PLATFORM_NATIVE
     TEST_ASSERT_EQUAL(10, config.buttonNames[0]);
     TEST_ASSERT_EQUAL(20, config.buttonNames[1]);
@@ -41,14 +44,16 @@ void test_input_config_multiple_inputs(void) {
 }
 
 void test_input_config_zero_count(void) {
-    InputConfig config(0);
+    // Empty constructor
+    InputConfig config;
     TEST_ASSERT_EQUAL(0, config.count);
 }
 
 void test_input_config_negative_count(void) {
-    // Negative count should be treated as 0
+    // New API: negative values are treated as regular input values (GPIO pins can be negative in some contexts)
+    // This test verifies that negative values are stored as-is
     InputConfig config(-5, 10, 20);
-    TEST_ASSERT_EQUAL(0, config.count);
+    TEST_ASSERT_EQUAL(3, config.count);  // -5, 10, 20 = 3 inputs
 }
 
 // ============================================================================
@@ -56,18 +61,22 @@ void test_input_config_negative_count(void) {
 // ============================================================================
 
 void test_input_config_array_size_matches_count(void) {
-    InputConfig config(4, 1, 2, 3, 4);
-    
+    // New API: 4 inputs = 4 arguments
+    InputConfig config(1, 2, 3, 4);
+
+    // std::array always has MAX_INPUT_COUNT capacity, count holds the actual used count
+    TEST_ASSERT_EQUAL(4, config.count);
     #ifdef PLATFORM_NATIVE
-    TEST_ASSERT_EQUAL(4, config.buttonNames.size());
+    TEST_ASSERT_EQUAL(InputConfig::MAX_INPUT_COUNT, config.buttonNames.size());
     #else
-    TEST_ASSERT_EQUAL(4, config.inputPins.size());
+    TEST_ASSERT_EQUAL(InputConfig::MAX_INPUT_COUNT, config.inputPins.size());
     #endif
 }
 
 void test_input_config_array_values_correct(void) {
-    InputConfig config(2, 65, 66); // A and B keys
-    
+    // New API: 2 inputs = 2 arguments
+    InputConfig config(65, 66); // A and B keys
+
     #ifdef PLATFORM_NATIVE
     TEST_ASSERT_EQUAL_UINT8(65, config.buttonNames[0]);
     TEST_ASSERT_EQUAL_UINT8(66, config.buttonNames[1]);
@@ -83,17 +92,19 @@ void test_input_config_array_values_correct(void) {
 
 #ifdef PLATFORM_NATIVE
 void test_input_config_native_button_names_type(void) {
-    InputConfig config(2, 10, 20);
+    // New API: 2 inputs = 2 arguments
+    InputConfig config(10, 20);
     // Verify buttonNames is the correct type for native platform
-    static_assert(std::is_same<decltype(config.buttonNames), std::vector<uint8_t>>::value, 
-                  "buttonNames should be vector<uint8_t> on native");
+    static_assert(std::is_same<decltype(config.buttonNames), std::array<uint8_t, InputConfig::MAX_INPUT_COUNT>>::value,
+                  "buttonNames should be array<uint8_t, MAX_INPUT_COUNT> on native");
 }
 #else
 void test_input_config_esp32_pins_type(void) {
-    InputConfig config(2, 10, 20);
+    // New API: 2 inputs = 2 arguments
+    InputConfig config(10, 20);
     // Verify inputPins is the correct type for ESP32
-    static_assert(std::is_same<decltype(config.inputPins), std::vector<int>>::value, 
-                  "inputPins should be vector<int> on ESP32");
+    static_assert(std::is_same<decltype(config.inputPins), std::array<int, InputConfig::MAX_INPUT_COUNT>>::value,
+                  "inputPins should be array<int, MAX_INPUT_COUNT> on ESP32");
 }
 #endif
 
@@ -102,16 +113,16 @@ void test_input_config_esp32_pins_type(void) {
 // ============================================================================
 
 void test_input_config_large_count(void) {
-    // Test with many inputs
-    InputConfig config(10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    // Test with many inputs - new API uses 10 arguments
+    InputConfig config(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     TEST_ASSERT_EQUAL(10, config.count);
 }
 
 void test_input_config_duplicate_values(void) {
-    // Duplicate mappings should be allowed
-    InputConfig config(3, 10, 10, 10);
+    // Duplicate mappings should be allowed - new API uses 3 arguments
+    InputConfig config(10, 10, 10);
     TEST_ASSERT_EQUAL(3, config.count);
-    
+
     #ifdef PLATFORM_NATIVE
     TEST_ASSERT_EQUAL(10, config.buttonNames[0]);
     TEST_ASSERT_EQUAL(10, config.buttonNames[1]);


### PR DESCRIPTION
- Update library.json version from 1.4.0 to 1.5.0
- Remove outdated DirtyGrid::init method documentation
- Add missing parameter description for Renderer::accumulateFramebufferClearSuppressionAdvice
- Replaced `std::vector` with `std::array<T,N>{}` in `InputConfig` to eliminate heap allocation, prevent memory fragmentation, and ensure deterministic O(1) access times on ESP32.
- Update CHANGELOG.md with details for 1.5.0 release
- Remove outdated "Known Issues" section from README.md and update its changelog summary
- Improve documentation clarity and consistency