### PR TITLE
feat(camera-effect-demo): add project structure and scene interface

### DIFF
--- a/examples/camera-effect-demo/.gitignore
+++ b/examples/camera-effect-demo/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/camera-effect-demo/lib/platformio.ini
+++ b/examples/camera-effect-demo/lib/platformio.ini
@@ -1,0 +1,49 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+; TEMPLATES
+
+[base]
+build_unflags = 
+	-std=gnu++11        ; Remove C++11 standard flag (we use C++17 instead)
+build_flags =
+    -Wl,--gc-sections
+	-std=gnu++17        ; Use GNU C++17 standard
+    -fno-exceptions     ; Saves ~15KB Flash (Removes try/catch overhead)
+    -D PIXELROOT32_ENABLE_AUDIO=0
+    -D PIXELROOT32_ENABLE_PARTICLES=0
+    -D PIXELROOT32_ENABLE_PHYSICS=0
+    -D PIXELROOT32_ENABLE_UI_SYSTEM=1
+    -D PIXELROOT32_ENABLE_CAMERA_EFFECTS=1
+
+[base_esp32]
+platform = espressif32
+monitor_speed = 115200
+build_unflags = 
+	${base.build_unflags}
+build_flags =
+    ${base.build_flags}
+    -Os                  ; Optimize for binary size (useful on ESP32 with limited RAM/Flash)
+    -flto                ; Link-Time Optimization (reduces binary size by combining code)
+    -fuse-linker-plugin  ; Allows ld to use the LTO plugin; required for RISC-V toolchain
+    -ffunction-sections  ; Put each function in its own section; helps remove unused functions (-Wl,--gc-sections)
+    -fdata-sections      ; Same as above but for data; helps reduce flash usage
+    -fno-lto             ; Disable LTO for problematic objects; prevents "plugin needed to handle lto object" in mixed C/C++ code
+    -fno-rtti            ; Remove RTTI support; saves ~20 KB of Flash and RAM
+
+[base_native]
+platform = native
+build_unflags = 
+	${base.build_unflags}
+build_flags =
+    ${base.build_flags}
+    -DPLATFORM_NATIVE
+    -DSDL_MAIN_HANDLED
+    -lSDL2

--- a/examples/camera-effect-demo/platformio.ini
+++ b/examples/camera-effect-demo/platformio.ini
@@ -1,0 +1,60 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = native
+extra_configs = lib/platformio.ini
+
+[env:native]
+extends = base_native
+lib_deps = symlink://../../
+build_flags = 
+    ${base_native.build_flags}
+    -D PHYSICAL_DISPLAY_WIDTH=240
+    -D PHYSICAL_DISPLAY_HEIGHT=240
+    ; -D PIXELROOT32_ENABLE_PROFILING
+    ; -D PIXELROOT32_DEBUG_MODE
+    -Isrc
+    -Iinclude
+    -I.pio/libdeps/native/PixelRoot32-Game-Engine/include
+    -I.pio/libdeps/native/PixelRoot32-Game-Engine/src
+    -IC:/msys64/mingw64/include/SDL2
+    -LC:/msys64/mingw64/lib
+    -O2
+    -Wall
+    -Wextra
+    -mconsole
+
+[env:esp32dev]
+extends = base_esp32
+board = esp32dev
+framework = arduino
+lib_deps = symlink://../../
+build_flags = 
+    ${base_esp32.build_flags}
+    -D PHYSICAL_DISPLAY_WIDTH=240
+    -D PHYSICAL_DISPLAY_HEIGHT=240
+    ; -D PIXELROOT32_ENABLE_PROFILING
+    ; -D PIXELROOT32_DEBUG_MODE
+    -D PLATFORM_ESP32DEV
+    ; TFT config (ST7789 240x240)
+    -D USER_SETUP_LOADED=1
+    -D ST7789_DRIVER
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=240
+    -D TFT_MOSI=23
+    -D TFT_SCLK=18
+    -D TFT_DC=2
+    -D TFT_RST=4
+    -D TFT_CS=-1
+    -D TOUCH_CS=-1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=20000000
+    -Isrc
+    -O2

--- a/examples/camera-effect-demo/src/EffectDemoConstants.h
+++ b/examples/camera-effect-demo/src/EffectDemoConstants.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <platforms/PlatformDefaults.h>
+
+namespace effectdemo {
+
+// Display configuration - use different names to avoid conflicts with engine macros
+constexpr int DEMO_DISPLAY_WIDTH = PHYSICAL_DISPLAY_WIDTH;
+constexpr int DEMO_DISPLAY_HEIGHT = PHYSICAL_DISPLAY_HEIGHT;
+
+// State machine
+enum class EffectDemoState : uint8_t {
+    MAIN,
+    EFFECT_ACTIVE
+};
+
+// Effect preset durations (ms)
+constexpr unsigned long PRESET_SHAKE_DUR = 2000u;
+constexpr unsigned long PRESET_PUNCH_DUR = 1500u;
+constexpr unsigned long PRESET_OFFSET_DUR = 2000u;
+
+// Effect preset amplitudes
+constexpr int PRESET_SHAKE_AMP = 8;
+constexpr int PRESET_PUNCH_AMP = 6;
+constexpr int PRESET_OFFSET_AMP = 4;
+
+// Auto-cancel timeout (ms)
+constexpr unsigned long AUTO_CANCEL_MS = 2000u;
+
+// Menu layout
+constexpr float TITLE_Y = 10.0f;
+constexpr int TITLE_FONT_SIZE = 1;
+
+constexpr float BTN_WIDTH = 180.0f;
+constexpr float BTN_HEIGHT = 16.0f;
+constexpr float BTN_START_Y = 30.0f;
+constexpr float BTN_GAP = 2.0f;
+constexpr int BTN_FONT_SIZE = 1;
+
+constexpr float NAV_INSTR_Y_OFFSET = 35.0f;
+constexpr float SEL_INSTR_Y_OFFSET = 25.0f;
+constexpr int INSTRUCTION_FONT_SIZE = 1;
+
+// Button mappings
+constexpr uint8_t BTN_NAV_UP = 0;
+constexpr uint8_t BTN_NAV_DOWN = 1;
+constexpr uint8_t BTN_BACK = 4;
+constexpr uint8_t BTN_SELECT = 5;
+
+// Active effect label
+constexpr const char* ACTIVE_EFFECT_LABEL = "Active: ";
+
+} // namespace effectdemo

--- a/examples/camera-effect-demo/src/EffectDemoScene.h
+++ b/examples/camera-effect-demo/src/EffectDemoScene.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "EffectDemoConstants.h"
+#include "core/Scene.h"
+#include "core/Log.h"
+#include "graphics/Camera2D.h"
+#include "graphics/ui/UILabel.h"
+#include "graphics/ui/UIButton.h"
+#include "graphics/ui/UIVerticalLayout.h"
+
+#include <memory>
+#include <cstdint>
+
+namespace effectdemo {
+
+class EffectDemoScene : public pixelroot32::core::Scene {
+public:
+    void init() override;
+    void update(unsigned long deltaTime) override;
+    void draw(pixelroot32::graphics::Renderer& renderer) override;
+
+    // Public trigger methods for callbacks
+    void triggerShake();
+    void triggerPunchUp();
+    void triggerPunchDown();
+    void triggerPunchLeft();
+    void triggerPunchRight();
+    void triggerOffset();
+    void cancelAll();
+
+private:
+    EffectDemoState currentState = EffectDemoState::MAIN;
+    unsigned long effectElapsed = 0;
+    const char* activeEffectName = nullptr;
+
+    // Camera2D at dead-center
+    pixelroot32::graphics::Camera2D camera{0, 0};
+
+    // UI Elements
+    std::unique_ptr<pixelroot32::graphics::ui::UILabel> titleLabel;
+    std::unique_ptr<pixelroot32::graphics::ui::UIVerticalLayout> buttonLayout;
+
+    // Effect buttons (7 total)
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnShake;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnPunchUp;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnPunchDown;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnPunchLeft;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnPunchRight;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnOffset;
+    std::unique_ptr<pixelroot32::graphics::ui::UIButton> btnCancelAll;
+
+    // Active effect label
+    std::unique_ptr<pixelroot32::graphics::ui::UILabel> lblActiveEffect;
+
+    // Navigation labels
+    std::unique_ptr<pixelroot32::graphics::ui::UILabel> lblNavigate;
+    std::unique_ptr<pixelroot32::graphics::ui::UILabel> lblSelect;
+    std::unique_ptr<pixelroot32::graphics::ui::UILabel> lblBack;
+
+    // Helper methods
+    void setupMenu();
+    void showMenu();
+    void activateEffect(const char* name);
+};
+
+} // namespace effectdemo

--- a/examples/camera-effect-demo/src/stub_main.cpp
+++ b/examples/camera-effect-demo/src/stub_main.cpp
@@ -1,0 +1,4 @@
+// Temporary stub — replaced by Phase 4+5 platform wiring
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Phase 1+2: Foundation files for camera effect demo example.
- .gitignore: ignore .pio, .vscode artifacts
- lib/platformio.ini: shared build templates (base, base_esp32, base_native)
- platformio.ini: native + esp32dev envs with UI_SYSTEM + CAMERA_EFFECTS
- EffectDemoConstants.h: state enum, effect presets, layout constants
- EffectDemoScene.h: Scene subclass with 7 trigger methods, Camera2D member
- stub_main.cpp: temporary stub for compilation (replaced by Phase 4+5)