### PR TITLE
refactor(physics): unify moveAndSlide and moveAndSlideWithSnap APIs

### DIFF
--- a/docs/api/generated/index.md
+++ b/docs/api/generated/index.md
@@ -151,6 +151,7 @@ Auto-generated API documentation from C++ header files.
 - [RigidActor](./physics/RigidActor.md) — A physics body fully simulated by the engine.
 - [Segment](./physics/Segment.md) — Represents a 2D line segment for collision detection.
 - [SensorActor](./physics/SensorActor.md) — A static body that acts as a trigger: detects overlap but produces no physical response.
+- [SnapPolicy](./physics/SnapPolicy.md) — Controls floor snap behavior after slide resolution.
 - [SpatialGrid](./physics/SpatialGrid.md) — Optimized spatial partitioning with separate static/dynamic layers.
 - [StaticActor](./physics/StaticActor.md) — A physics body that does not move.
 - [TileBehaviorLayer](./physics/TileBehaviorLayer.md) — Runtime representation of exported behavior layer for O(1) flag lookup.

--- a/docs/api/generated/physics/KinematicActor.md
+++ b/docs/api/generated/physics/KinematicActor.md
@@ -18,6 +18,12 @@ moveAndSlide for complex character movement.
 
 [PhysicsActor](../core/PhysicsActor.md) → `KinematicActor`
 
+## Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `constexpr` | `static` | Minimum snap magnitude for SnapPolicy::Step. |
+
 ## Methods
 
 ### `bool moveAndCollide(pixelroot32::math::Vector2 motion, KinematicCollision* outCollision = nullptr, bool testOnly = false, pixelroot32::math::Scalar safeMargin = pixelroot32::math::Scalar(0.08f), bool recoveryAsCollision = false)`
@@ -35,49 +41,6 @@ Moves the body along a vector and stops at the first collision.
 - `recoveryAsCollision`: If true, depenetration is reported as collision.
 
 **Returns:** true if a collision occurred.
-
-### `void moveAndSlide(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 upDirection = {0, -1}, pixelroot32::core::PhysicsActor** outFloorBody = nullptr, pixelroot32::math::Scalar dt = pixelroot32::physics::CollisionSystem::FIXED_DT)`
-
-**Description:**
-
-Moves the body while sliding along surfaces.
-
-**Parameters:**
-
-- `velocity`: The velocity vector.
-- `upDirection`: The up vector used to differentiate floor/ceiling (optional).
-- `outFloorBody`: Optional pointer to receive the floor PhysicsActor if on a KINEMATIC floor.
-- `dt`: Delta time used to calculate the movement (default: FIXED_DT).
-
-### `pixelroot32::math::Vector2 moveAndSlideWithSnap(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 snap, pixelroot32::math::Scalar dt, pixelroot32::math::Vector2 upDirection = {0, -1})`
-
-**Description:**
-
-Moves the body while sliding along surfaces, then snaps to floor.
-
-**Parameters:**
-
-- `velocity`: The velocity vector in units/sec (NOT pre-scaled by dt).
-- `snap`: Snap vector toward floor. Pass zero to disable.
-- `dt`: Delta time. REQUIRED — same dt used by the game loop for
-          input scaling consistency. No default.
-- `upDirection`: Up direction for floor detection. Defaults to {0, -1}.
-
-**Returns:** The actual velocity after slide and snap processing.
-        Assign to your velocity variable to replace post-slide zeroing.
-
-Performs standard moveAndSlide along velocity, then pushes the AABB
-along -upDirection by |snap| to attach to the floor. Returns the
-actual velocity after collisions and snap are resolved.
-
-::: tip
-When jumping, caller MUST pass a zero snap vector explicitly.
-      The engine does NOT auto-disable snap on upward velocity.
-:::
-
-::: tip
-Snap magnitudes below MIN_SNAP (4.0) are treated as disabled.
-:::
 
 ### `inline bool is_on_ceiling() const`
 

--- a/docs/api/generated/physics/SnapPolicy.md
+++ b/docs/api/generated/physics/SnapPolicy.md
@@ -1,0 +1,13 @@
+# SnapPolicy
+
+<Badge type="info" text="Enum" />
+
+**Source:** `KinematicActor.h`
+
+## Description
+
+Controls floor snap behavior after slide resolution.
+
+- None: slide only (default).
+- Step: guarded snap post-step when wasSnapFloor was true at entry.
+- Continuous: reserved for future continuous floor adhesion; currently no-op.

--- a/examples/brick_breaker/src/actors/PaddleActor.cpp
+++ b/examples/brick_breaker/src/actors/PaddleActor.cpp
@@ -33,7 +33,7 @@ void PaddleActor::update(unsigned long dt) {
     }
 
     if (motion.x != 0 || motion.y != 0) {
-        moveAndSlide(motion);
+        (void)moveAndSlide(motion / deltaTimeSec, deltaTimeSec);
     }
 
     if (position.x < math::toScalar(0)) {

--- a/examples/camera/src/PlayerCube.cpp
+++ b/examples/camera/src/PlayerCube.cpp
@@ -48,17 +48,15 @@ void PlayerCube::update(unsigned long deltaTime) {
         setCollisionMask(Layers::GROUND | Layers::PLATFORM);
     }
 
-    // Use moveAndSlideWithSnap: snap engages when not jumping, disabled on jump frames
-    // Return value is the actual post-snap velocity; floor/ceiling collision is
-    // handled inside the method (no need for post-call velocity zeroing)
     pixelroot32::math::Vector2 snap = (jumpThisFrame)
         ? pixelroot32::math::Vector2{}
         : pixelroot32::math::Vector2(pixelroot32::math::toScalar(0), KinematicActor::MIN_SNAP);
-    velocity = moveAndSlideWithSnap(
+    velocity = moveAndSlide(
         velocity,
-        snap,
         pixelroot32::math::toScalar(dt),
-        pixelroot32::math::Vector2(0, -1)
+        pixelroot32::math::Vector2(0, -1),
+        pixelroot32::physics::SnapPolicy::Step,
+        snap
     );
 
     if (worldWidth > 0) {

--- a/examples/metroidvania/src/PlayerActor.cpp
+++ b/examples/metroidvania/src/PlayerActor.cpp
@@ -242,11 +242,9 @@ void PlayerActor::update(unsigned long deltaTime) {
         ? math::Vector2{}
         : math::Vector2(math::toScalar(0), KinematicActor::MIN_SNAP);
 
-    // Execute Move and Slide against the physics system
-    // moveAndSlideWithSnap handles floor/ceiling collision in its return value
-    velocity = moveAndSlideWithSnap(velocity, snap, dt, math::Vector2(0, -1));
+    velocity = moveAndSlide(velocity, dt, math::Vector2(0, -1), pixelroot32::physics::SnapPolicy::Step, snap);
 
-    // Keep wall-stop zeroing — moveAndSlideWithSnap doesn't handle wall velocity
+    // Keep wall-stop zeroing — moveAndSlide doesn't zero wall velocity in return
     if (is_on_wall()) {
         velocity.x = math::toScalar(0);
     }

--- a/examples/physics/src/PhysicsDemoScene.cpp
+++ b/examples/physics/src/PhysicsDemoScene.cpp
@@ -341,7 +341,7 @@ void PhysicsDemoScene::update(unsigned long deltaTime) {
     if (move.length() > toScalar(0)) {
         move.normalize();
         Scalar dt = toScalar(static_cast<float>(deltaTime) * 0.001f);
-        player->moveAndSlide(move * speed * dt);
+        (void)player->moveAndSlide(move * speed, dt);
     }
 
     Scene::update(deltaTime);

--- a/include/physics/KinematicActor.h
+++ b/include/physics/KinematicActor.h
@@ -9,6 +9,16 @@
 namespace pixelroot32::physics {
 
 /**
+ * @enum SnapPolicy
+ * @brief Controls floor snap behavior after slide resolution.
+ *
+ * - None: slide only (default).
+ * - Step: guarded snap post-step when wasSnapFloor was true at entry.
+ * - Continuous: reserved for future continuous floor adhesion; currently no-op.
+ */
+enum class SnapPolicy { None, Step, Continuous };
+
+/**
  * @class KinematicActor
  * @brief A physics body moved via script/manual velocity with collision detection.
  *
@@ -20,6 +30,8 @@ namespace pixelroot32::physics {
  */
 class KinematicActor : public pixelroot32::core::PhysicsActor {
 public:
+    static constexpr pixelroot32::math::Scalar MIN_SNAP = pixelroot32::math::toScalar(4.0f); ///< Minimum snap magnitude for SnapPolicy::Step.
+
     /**
      * @brief Constructs a new KinematicActor.
      * @param x X position.
@@ -51,33 +63,25 @@ public:
                         bool recoveryAsCollision = false);
 
     /**
-     * @brief Moves the body while sliding along surfaces.
-     * @param velocity The velocity vector.
-     * @param upDirection The up vector used to differentiate floor/ceiling (optional).
+     * @brief Moves the body while sliding along surfaces, with optional floor snap.
+     * @param velocity World velocity in units/sec (motion = velocity * dt).
+     * @param dt Delta time in seconds. Required — no default.
+     * @param upDirection Up vector for floor/ceiling/wall classification.
+     * @param snapPolicy Snap behavior after slide (default: None).
+     * @param snapVector Max snap distance toward -upDirection; zero disables snap.
      * @param outFloorBody Optional pointer to receive the floor PhysicsActor if on a KINEMATIC floor.
-     * @param dt Delta time used to calculate the movement (default: FIXED_DT).
+     * @return Resolved velocity after slide (+ snap when Step). Assign to caller velocity.
+     *
+     * @note SnapPolicy::Continuous is reserved; debug builds assert once and behave as None.
+     * @note When jumping, pass snapVector=zero explicitly — snap is not auto-disabled on upward velocity.
      */
-    void moveAndSlide(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 upDirection = {0, -1}, pixelroot32::core::PhysicsActor** outFloorBody = nullptr, pixelroot32::math::Scalar dt = pixelroot32::physics::CollisionSystem::FIXED_DT);
-
-    /**
-     * @brief Moves the body while sliding along surfaces, then snaps to floor.
-     * @param velocity The velocity vector in units/sec (NOT pre-scaled by dt).
-     * @param snap Snap vector toward floor. Pass zero to disable.
-     * @param dt Delta time. REQUIRED — same dt used by the game loop for
-     *           input scaling consistency. No default.
-     * @param upDirection Up direction for floor detection. Defaults to {0, -1}.
-     * @return The actual velocity after slide and snap processing.
-     *         Assign to your velocity variable to replace post-slide zeroing.
-     * 
-     * Performs standard moveAndSlide along velocity, then pushes the AABB
-     * along -upDirection by |snap| to attach to the floor. Returns the
-     * actual velocity after collisions and snap are resolved.
-     * 
-     * @note When jumping, caller MUST pass a zero snap vector explicitly.
-     *       The engine does NOT auto-disable snap on upward velocity.
-     * @note Snap magnitudes below MIN_SNAP (4.0) are treated as disabled.
-     */
-    pixelroot32::math::Vector2 moveAndSlideWithSnap(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 snap, pixelroot32::math::Scalar dt, pixelroot32::math::Vector2 upDirection = {0, -1});
+    [[nodiscard]] pixelroot32::math::Vector2 moveAndSlide(
+        pixelroot32::math::Vector2 velocity,
+        pixelroot32::math::Scalar dt,
+        pixelroot32::math::Vector2 upDirection = {0, -1},
+        SnapPolicy snapPolicy = SnapPolicy::None,
+        pixelroot32::math::Vector2 snapVector = {},
+        pixelroot32::core::PhysicsActor** outFloorBody = nullptr);
 
     /**
      * @brief Returns true if the body collided with the ceiling.
@@ -119,32 +123,27 @@ public:
      */
     void draw(pixelroot32::graphics::Renderer& renderer) override;
 
-protected:
-    static constexpr pixelroot32::math::Scalar MIN_SNAP = pixelroot32::math::toScalar(4.0f); ///< Minimum snap magnitude for moveAndSlideWithSnap.
-
 private:
     int maxSlides = 4; ///< Maximum number of slide iterations to prevent infinite loops.
     bool onFloor = false;
     bool onCeiling = false;
     bool onWall = false;
 
-    /// @brief Tracks whether the body was on floor at the end of the last moveAndSlide or moveAndSlideWithSnap call.
+    /// @brief Tracks whether the body was on floor at the end of the last moveAndSlide call.
     ///
-    /// Used INTERNALLY by moveAndSlideWithSnap's snap step guard: snap only fires if the body
+    /// Used INTERNALLY by SnapPolicy::Step snap guard: snap only fires if the body
     /// was on floor the previous frame. This prevents snap from re-engaging when the body
     /// has left the floor (e.g., after a jump or walking off a ledge).
-    ///
-    /// Both moveAndSlide and moveAndSlideWithSnap set this flag to the value of onFloor at
-    /// the end of their respective slide steps.
-    ///
-    /// @note This is NOT part of the is_on_floor() API contract. is_on_floor() returns only
-    ///       raw current-frame contact state. wasSnapFloor is purely internal to the snap step.
     bool wasSnapFloor = false;
 
-    // Floor state storage (v2 readiness: unused in v1, stores for platform velocity injection)
     pixelroot32::math::Vector2 floorVelocity;                 ///< Persisted floor velocity from last KINEMATIC floor contact.
     pixelroot32::core::PhysicsActor* floorBody = nullptr;     ///< Current floor body pointer.
     pixelroot32::math::Vector2 lastFloorNormal;                ///< Last floor collision normal.
+
+    void resolvePreSlideDepenetration();
+    void resolvePostSlideKinematicDepenetration();
+    void applySnapStep(pixelroot32::math::Vector2 snapVector, pixelroot32::math::Vector2 upDirection,
+                       pixelroot32::core::PhysicsActor*& localFloorBody);
 
     /**
      * @brief Internal slide loop. Iterates moveAndCollide to slide along surfaces.

--- a/src/physics/KinematicActor.cpp
+++ b/src/physics/KinematicActor.cpp
@@ -187,253 +187,186 @@ bool KinematicActor::moveAndCollide(pixelroot32::math::Vector2 motion, Kinematic
     return true;
 }
 
-void KinematicActor::moveAndSlide(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 upDirection, pixelroot32::core::PhysicsActor** outFloorBody, pixelroot32::math::Scalar dt) {
+void KinematicActor::resolvePreSlideDepenetration() {
     namespace math = pixelroot32::math;
     using math::Vector2;
     using math::Scalar;
     using math::toScalar;
 
-    // Reset collision flags
+    static pixelroot32::core::Actor* startCollisions[16];
+    int startCollisionCount = 0;
+    if (!collisionSystem || !collisionSystem->checkCollision(this, startCollisions, startCollisionCount, 16)) {
+        return;
+    }
+
+    for (int i = 0; i < startCollisionCount; ++i) {
+        auto* other = startCollisions[i];
+        if (!other->isPhysicsBody()) continue;
+
+        auto* physOther = static_cast<pixelroot32::core::PhysicsActor*>(other);
+        if (physOther->getBodyType() == pixelroot32::core::PhysicsBodyType::RIGID || physOther->isSensor()) {
+            continue;
+        }
+
+        if (physOther->isOneWay()) {
+            pixelroot32::core::Rect otherBox = physOther->getHitBox();
+            Scalar previousBottom = getPreviousPosition().y + getHitboxOffset().y + toScalar(height);
+            Scalar platformTop = otherBox.position.y;
+            if (previousBottom > platformTop + CollisionSystem::SLOP) {
+                continue;
+            }
+        }
+
+        pixelroot32::core::Rect myBox = getHitBox();
+        pixelroot32::core::Rect otherBox = physOther->getHitBox();
+        if (!myBox.intersects(otherBox)) continue;
+
+        Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
+                                    otherBox.position.x + toScalar(otherBox.width)) -
+                          math::max(myBox.position.x, otherBox.position.x);
+        Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
+                                    otherBox.position.y + toScalar(otherBox.height)) -
+                          math::max(myBox.position.y, otherBox.position.y);
+
+        Scalar depenClamp = toScalar(4.0f);
+
+        if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
+            Scalar correction = math::min(overlapX, depenClamp);
+            if (position.x + getHitboxOffset().x + toScalar(myBox.width)/2.0f < otherBox.position.x + toScalar(otherBox.width)/2.0f) {
+                position.x -= correction;
+            } else {
+                position.x += correction;
+            }
+        } else if (overlapY > CollisionSystem::SLOP) {
+            Scalar correction = math::min(overlapY, depenClamp);
+            if (position.y + getHitboxOffset().y + toScalar(myBox.height)/2.0f < otherBox.position.y + toScalar(otherBox.height)/2.0f) {
+                position.y -= correction;
+            } else {
+                position.y += correction;
+            }
+        }
+    }
+}
+
+void KinematicActor::resolvePostSlideKinematicDepenetration() {
+    namespace math = pixelroot32::math;
+    using math::Scalar;
+    using math::toScalar;
+
+    if (!floorBody || floorBody->getBodyType() != pixelroot32::core::PhysicsBodyType::KINEMATIC) {
+        return;
+    }
+
+    pixelroot32::core::Rect myBox = getHitBox();
+    pixelroot32::core::Rect floorBox = floorBody->getHitBox();
+    if (!myBox.intersects(floorBox)) return;
+
+    Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
+                                floorBox.position.x + toScalar(floorBox.width)) -
+                      math::max(myBox.position.x, floorBox.position.x);
+    Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
+                                floorBox.position.y + toScalar(floorBox.height)) -
+                      math::max(myBox.position.y, floorBox.position.y);
+    Scalar depenClamp = toScalar(2.0f);
+
+    if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
+        Scalar correction = math::min(overlapX, depenClamp);
+        if (position.x < floorBody->position.x) position.x -= correction;
+        else position.x += correction;
+    } else if (overlapY > CollisionSystem::SLOP) {
+        Scalar correction = math::min(overlapY, depenClamp);
+        if (position.y < floorBody->position.y) position.y -= correction;
+        else position.y += correction;
+    }
+}
+
+void KinematicActor::applySnapStep(pixelroot32::math::Vector2 snapVector, pixelroot32::math::Vector2 upDirection,
+                                   pixelroot32::core::PhysicsActor*& localFloorBody) {
+    namespace math = pixelroot32::math;
+    using math::Vector2;
+    using math::Scalar;
+    using math::toScalar;
+
+    if (!wasSnapFloor) return;
+
+    Scalar snapMag = snapVector.length();
+    if (snapMag < MIN_SNAP) return;
+
+    if (snapVector.dot(upDirection) >= toScalar(0)) return;
+
+    Vector2 preSnapPos = position;
+    Vector2 snapMotion = -upDirection * snapMag;
+    KinematicCollision snapCol;
+    bool hit = moveAndCollide(snapMotion, &snapCol);
+    Scalar floorThreshold = toScalar(0.70710678f);
+
+    if (hit) {
+        Scalar dot = snapCol.normal.dot(upDirection);
+        if (dot > floorThreshold) {
+            onFloor = true;
+            if (snapCol.collider && snapCol.collider->isPhysicsBody()) {
+                auto* phys = static_cast<pixelroot32::core::PhysicsActor*>(snapCol.collider);
+                if (phys->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
+                    localFloorBody = phys;
+                    lastFloorNormal = snapCol.normal;
+                }
+            }
+        } else {
+            position = preSnapPos;
+        }
+    } else {
+        position = preSnapPos;
+    }
+}
+
+pixelroot32::math::Vector2 KinematicActor::moveAndSlide(
+    pixelroot32::math::Vector2 velocity,
+    pixelroot32::math::Scalar dt,
+    pixelroot32::math::Vector2 upDirection,
+    SnapPolicy snapPolicy,
+    pixelroot32::math::Vector2 snapVector,
+    pixelroot32::core::PhysicsActor** outFloorBody) {
+
+    namespace math = pixelroot32::math;
+    using math::Vector2;
+    using math::Scalar;
+
     onFloor = false;
     onCeiling = false;
     onWall = false;
 
-    // --- Pre-slide depenetration: resolve overlaps against solid static/kinematic bodies first ---
-    static pixelroot32::core::Actor* startCollisions[16];
-    int startCollisionCount = 0;
-    if (collisionSystem && collisionSystem->checkCollision(this, startCollisions, startCollisionCount, 16)) {
-        for (int i = 0; i < startCollisionCount; ++i) {
-            auto* other = startCollisions[i];
-            if (other->isPhysicsBody()) {
-                auto* physOther = static_cast<pixelroot32::core::PhysicsActor*>(other);
-                if (physOther->getBodyType() == pixelroot32::core::PhysicsBodyType::RIGID || physOther->isSensor()) {
-                    continue;
-                }
-                
-                // One-way platform filter: only depenetrate if we are coming from above
-                if (physOther->isOneWay()) {
-                    pixelroot32::core::Rect otherBox = physOther->getHitBox();
-                    Scalar previousBottom = getPreviousPosition().y + getHitboxOffset().y + toScalar(height);
-                    Scalar platformTop = otherBox.position.y;
-                    if (previousBottom > platformTop + CollisionSystem::SLOP) {
-                        continue;
-                    }
-                }
+    resolvePreSlideDepenetration();
 
-                pixelroot32::core::Rect myBox = getHitBox();
-                pixelroot32::core::Rect otherBox = physOther->getHitBox();
-                if (myBox.intersects(otherBox)) {
-                    Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
-                                                otherBox.position.x + toScalar(otherBox.width)) -
-                                      math::max(myBox.position.x, otherBox.position.x);
-                    Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
-                                                otherBox.position.y + toScalar(otherBox.height)) -
-                                      math::max(myBox.position.y, otherBox.position.y);
-                    
-                    Scalar depenClamp = toScalar(4.0f);
-                    
-                    if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
-                        Scalar correction = math::min(overlapX, depenClamp);
-                        if (position.x + getHitboxOffset().x + toScalar(myBox.width)/2.0f < otherBox.position.x + toScalar(otherBox.width)/2.0f) {
-                            position.x -= correction;
-                        } else {
-                            position.x += correction;
-                        }
-                    } else if (overlapY > CollisionSystem::SLOP) {
-                        Scalar correction = math::min(overlapY, depenClamp);
-                        if (position.y + getHitboxOffset().y + toScalar(myBox.height)/2.0f < otherBox.position.y + toScalar(otherBox.height)/2.0f) {
-                            position.y -= correction;
-                        } else {
-                            position.y += correction;
-                        }
-                    }
-                }
-            }
-        }
-    }
+    Vector2 startPos = position;
+    Vector2 currentMotion = velocity * dt;
 
-    Vector2 currentMotion = velocity;
-
-    // Local floor body tracker for current frame
     pixelroot32::core::PhysicsActor* localFloorBody = nullptr;
-
-    // Slide along surfaces
     slide(currentMotion, upDirection, localFloorBody);
+    Vector2 afterSlidePos = position;
 
-    // --- Post-slide depenetration: push out from overlapping KINEMATIC bodies ---
-    if (floorBody && floorBody->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
-        pixelroot32::core::Rect myBox = getHitBox();
-        pixelroot32::core::Rect floorBox = floorBody->getHitBox();
-        if (myBox.intersects(floorBox)) {
-            Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
-                                        floorBox.position.x + toScalar(floorBox.width)) -
-                              math::max(myBox.position.x, floorBox.position.x);
-            Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
-                                        floorBox.position.y + toScalar(floorBox.height)) -
-                              math::max(myBox.position.y, floorBox.position.y);
-            Scalar depenClamp = toScalar(2.0f);
-            // Depenetrate along the axis with smaller overlap
-            if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
-                Scalar correction = math::min(overlapX, depenClamp);
-                if (position.x < floorBody->position.x) position.x -= correction;
-                else position.x += correction;
-            } else if (overlapY > CollisionSystem::SLOP) {
-                Scalar correction = math::min(overlapY, depenClamp);
-                if (position.y < floorBody->position.y) position.y -= correction;
-                else position.y += correction;
-            }
+    if (snapPolicy == SnapPolicy::Step) {
+        applySnapStep(snapVector, upDirection, localFloorBody);
+    } else if (snapPolicy == SnapPolicy::Continuous) {
+#if PIXELROOT32_DEBUG_MODE
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            assert(false && "SnapPolicy::Continuous not implemented");
         }
+#endif
     }
 
-    // Write the floor body pointer if caller requested it
+    resolvePostSlideKinematicDepenetration();
+
     if (outFloorBody) {
         *outFloorBody = floorBody;
     }
 
-    // Persist floor state for the next frame's snap guard (mirrors moveAndSlideWithSnap)
-    wasSnapFloor = onFloor;
-}
-
-pixelroot32::math::Vector2 KinematicActor::moveAndSlideWithSnap(pixelroot32::math::Vector2 velocity, pixelroot32::math::Vector2 snap, pixelroot32::math::Scalar dt, pixelroot32::math::Vector2 upDirection) {
-    namespace math = pixelroot32::math;
-    using math::Vector2;
-    using math::Scalar;
-    using math::toScalar;
-
-    // Reset collision flags
-    onFloor = false;
-    onCeiling = false;
-    onWall = false;
-
-    // --- Pre-slide depenetration: resolve overlaps against solid static/kinematic bodies first ---
-    static pixelroot32::core::Actor* startCollisions[16];
-    int startCollisionCount = 0;
-    if (collisionSystem && collisionSystem->checkCollision(this, startCollisions, startCollisionCount, 16)) {
-        for (int i = 0; i < startCollisionCount; ++i) {
-            auto* other = startCollisions[i];
-            if (other->isPhysicsBody()) {
-                auto* physOther = static_cast<pixelroot32::core::PhysicsActor*>(other);
-                if (physOther->getBodyType() == pixelroot32::core::PhysicsBodyType::RIGID || physOther->isSensor()) {
-                    continue;
-                }
-
-                // One-way platform filter: only depenetrate if we are coming from above
-                if (physOther->isOneWay()) {
-                    pixelroot32::core::Rect otherBox = physOther->getHitBox();
-                    Scalar previousBottom = getPreviousPosition().y + getHitboxOffset().y + toScalar(height);
-                    Scalar platformTop = otherBox.position.y;
-                    if (previousBottom > platformTop + CollisionSystem::SLOP) {
-                        continue;
-                    }
-                }
-
-                pixelroot32::core::Rect myBox = getHitBox();
-                pixelroot32::core::Rect otherBox = physOther->getHitBox();
-                if (myBox.intersects(otherBox)) {
-                    Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
-                                                otherBox.position.x + toScalar(otherBox.width)) -
-                                      math::max(myBox.position.x, otherBox.position.x);
-                    Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
-                                                otherBox.position.y + toScalar(otherBox.height)) -
-                                      math::max(myBox.position.y, otherBox.position.y);
-
-                    Scalar depenClamp = toScalar(4.0f);
-
-                    if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
-                        Scalar correction = math::min(overlapX, depenClamp);
-                        if (position.x + getHitboxOffset().x + toScalar(myBox.width)/2.0f < otherBox.position.x + toScalar(otherBox.width)/2.0f) {
-                            position.x -= correction;
-                        } else {
-                            position.x += correction;
-                        }
-                    } else if (overlapY > CollisionSystem::SLOP) {
-                        Scalar correction = math::min(overlapY, depenClamp);
-                        if (position.y + getHitboxOffset().y + toScalar(myBox.height)/2.0f < otherBox.position.y + toScalar(otherBox.height)/2.0f) {
-                            position.y -= correction;
-                        } else {
-                            position.y += correction;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Vector2 startPos = position;
-    Vector2 currentMotion = velocity * dt;
-    Scalar floorThreshold = toScalar(0.70710678f);
-
-    pixelroot32::core::PhysicsActor* localFloorBody = nullptr;
-
-    // Slide along surfaces (records displacement for return value before snap)
-    slide(currentMotion, upDirection, localFloorBody);
-    Vector2 afterSlidePos = position;
-
-    // --- Snap post-step: move body toward floor via moveAndCollide ---
-    // Guard: only snap if body was on floor last frame. This prevents snap from
-    // re-engaging when the body has left the floor (e.g., after a jump, or when
-    // walking/falling off a ledge).
-    if (wasSnapFloor) {
-        Scalar snapMag = snap.length();
-        if (snapMag >= MIN_SNAP) {
-            // Snap must point opposite to upDirection (i.e., toward floor)
-            if (snap.dot(upDirection) < toScalar(0)) {
-                Vector2 preSnapPos = position;
-                Vector2 snapMotion = -upDirection * snapMag;
-                KinematicCollision snapCol;
-                bool hit = moveAndCollide(snapMotion, &snapCol);
-                if (hit) {
-                    Scalar dot = snapCol.normal.dot(upDirection);
-                    if (dot > floorThreshold) {
-                        onFloor = true;
-                        if (snapCol.collider && snapCol.collider->isPhysicsBody()) {
-                            auto* phys = static_cast<pixelroot32::core::PhysicsActor*>(snapCol.collider);
-                            if (phys->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
-                                localFloorBody = phys;
-                                lastFloorNormal = snapCol.normal;
-                            }
-                        }
-                    } else {
-                        // Hit something but not a floor — restore pre-snap position
-                        position = preSnapPos;
-                    }
-                } else {
-                    // No hit — snap misses, restore pre-snap position
-                    position = preSnapPos;
-                }
-            }
-        }
-    } // end wasSnapFloor guard
-
-    // --- Post-slide depenetration: push out from overlapping KINEMATIC bodies ---
-    if (floorBody && floorBody->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
-        pixelroot32::core::Rect myBox = getHitBox();
-        pixelroot32::core::Rect floorBox = floorBody->getHitBox();
-        if (myBox.intersects(floorBox)) {
-            Scalar overlapX = math::min(myBox.position.x + toScalar(myBox.width),
-                                        floorBox.position.x + toScalar(floorBox.width)) -
-                              math::max(myBox.position.x, floorBox.position.x);
-            Scalar overlapY = math::min(myBox.position.y + toScalar(myBox.height),
-                                        floorBox.position.y + toScalar(floorBox.height)) -
-                              math::max(myBox.position.y, floorBox.position.y);
-            Scalar depenClamp = toScalar(2.0f);
-            // Depenetrate along the axis with smaller overlap
-            if (overlapX < overlapY && overlapX > CollisionSystem::SLOP) {
-                Scalar correction = math::min(overlapX, depenClamp);
-                if (position.x < floorBody->position.x) position.x -= correction;
-                else position.x += correction;
-            } else if (overlapY > CollisionSystem::SLOP) {
-                Scalar correction = math::min(overlapY, depenClamp);
-                if (position.y < floorBody->position.y) position.y -= correction;
-                else position.y += correction;
-            }
-        }
-    }
-
-    // Persist floor state for the next frame's snap guard
     wasSnapFloor = onFloor;
 
-    // Return velocity from slide displacement only (snap is positional, not velocity-affecting)
+    if (dt == Scalar(0)) {
+        return Vector2::ZERO();
+    }
     Vector2 displacement = afterSlidePos - startPos;
     return displacement / dt;
 }
@@ -453,7 +386,6 @@ void KinematicActor::slide(pixelroot32::math::Vector2& currentMotion, pixelroot3
 
             if (dot > floorThreshold) {
                 onFloor = true;
-                // Track the floor body if it is KINEMATIC (for velocity inheritance)
                 if (col.collider && col.collider->isPhysicsBody()) {
                     auto* phys = static_cast<pixelroot32::core::PhysicsActor*>(col.collider);
                     if (phys->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {

--- a/test/test_player_jump_integration/test_player_jump_integration.cpp
+++ b/test/test_player_jump_integration/test_player_jump_integration.cpp
@@ -4,7 +4,7 @@
  *        using real game-loop dt values (NOT synthetic FIXED_DT).
  *
  * These tests guard against the half-jump and gliding regressions by
- * verifying the full velocity -> moveAndSlideWithSnap pipeline at 30/60/120 FPS.
+ * verifying the full velocity -> moveAndSlide pipeline at 30/60/120 FPS.
  *
  * KS-INTEGRATION-TEST-SUITE
  */
@@ -83,7 +83,7 @@ static void setupOnFloor(Scalar floorTopY, Scalar dt) {
     // Player is 16 tall, so position.y = floorTopY - 16 - 1 = floorTopY - 17
     player->position.y = floorTopY - toScalar(17);
 
-    // Step 1: fall into floor via moveAndSlideWithSnap with sufficient velocity.
+    // Step 1: fall into floor via moveAndSlide with sufficient velocity.
     //         displacement = velocity * dt must exceed the 1-unit gap.
     //         Use 600/s at 120FPS: 600/120 = 5 units > 1. Well above threshold.
     //         At 30FPS: 600/30 = 20 units > 1. Also fine.
@@ -92,17 +92,17 @@ static void setupOnFloor(Scalar floorTopY, Scalar dt) {
     //         But at the end: wasSnapFloor = onFloor = true.
     Vector2 up(0, -1);
     Vector2 snap(toScalar(0), toScalar(MIN_SNAP));
-    player->moveAndSlideWithSnap(
+    (void)player->moveAndSlide(
         Vector2(toScalar(0), toScalar(600)),
-        snap, dt, up
+        dt, up, SnapPolicy::None, snap
     );
 
     // Step 2: establish wasSnapFloor via persistent floor contact.
     //         Small downward velocity + snap.
     //         wasSnapFloor=true from step 1 -> snap fires -> onFloor=true.
-    player->moveAndSlideWithSnap(
+    (void)player->moveAndSlide(
         Vector2(toScalar(0), toScalar(60)),
-        snap, dt, up
+        dt, up, SnapPolicy::Step, snap
     );
 }
 
@@ -117,7 +117,7 @@ static Scalar referenceJumpApex(Scalar v0, Scalar dt) {
     Scalar y = v * dt;  // Frame 0 displacement
     Scalar gDt = toScalar(GRAVITY) * dt;
     // Frames 1+: gravity accumulates on the velocity returned from the
-    //            previous moveAndSlideWithSnap frame (which equals the
+    //            previous moveAndSlide frame (which equals the
     //            input velocity in free space, i.e., no collisions).
     while (v < toScalar(0)) {
         v += gDt;  // gravity applied to prev frame's return velocity
@@ -158,8 +158,8 @@ static bool simulatePlayerCubeFrame(Scalar& vy, bool wantsJump, Scalar dt) {
     Vector2 snap = jumpThisFrame
         ? Vector2{}
         : Vector2(toScalar(0), toScalar(MIN_SNAP));
-    Vector2 result = player->moveAndSlideWithSnap(
-        Vector2(toScalar(0), vy), snap, dt, up
+    Vector2 result = player->moveAndSlide(
+        Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap
     );
     vy = static_cast<float>(result.y);
     return player->is_on_floor();
@@ -184,8 +184,8 @@ static bool simulatePlayerActorFrame(Scalar& vy, bool wantsJump, TestState& stat
     Vector2 snap = (state == TestState::JUMP && jumpThisFrame)
         ? Vector2{}
         : Vector2(toScalar(0), toScalar(MIN_SNAP));
-    Vector2 result = player->moveAndSlideWithSnap(
-        Vector2(toScalar(0), vy), snap, dt, up
+    Vector2 result = player->moveAndSlide(
+        Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap
     );
     vy = static_cast<float>(result.y);
     // State machine transition
@@ -326,8 +326,8 @@ void test_free_fall_trajectory_120fps(void) {
 
     for (int frame = 1; frame <= totalFrames; frame++) {
         vy += toScalar(GRAVITY) * dt;
-        Vector2 result = player->moveAndSlideWithSnap(
-            Vector2(toScalar(0), vy), snap, dt, up
+        Vector2 result = player->moveAndSlide(
+            Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap
         );
         vy = result.y;
 
@@ -368,8 +368,8 @@ void test_free_fall_trajectory_60fps(void) {
 
     for (int frame = 1; frame <= totalFrames; frame++) {
         vy += toScalar(GRAVITY) * dt;
-        Vector2 result = player->moveAndSlideWithSnap(
-            Vector2(toScalar(0), vy), snap, dt, up
+        Vector2 result = player->moveAndSlide(
+            Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap
         );
         vy = result.y;
 
@@ -399,13 +399,13 @@ void test_landing_wasSnapFloor_transition(void) {
     Scalar vy = toScalar(60);
     Vector2 up(0, -1);
     Vector2 snap(toScalar(0), toScalar(MIN_SNAP));
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), vy), snap, dt, up);
+    (void)player->moveAndSlide(Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F1: on floor via snap (wasSnapFloor=true)");
     Scalar floorY = player->position.y;
 
     // F2: Jump with zero snap -> leaves floor
     vy = toScalar(-JUMP_VEL_CUBE);
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), vy), Vector2{}, dt, up);
+    (void)player->moveAndSlide(Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, Vector2{});
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "F2: not on floor after jump");
     TEST_ASSERT_TRUE_MESSAGE(player->position.y < floorY, "F2: above floor after jump");
 
@@ -415,7 +415,7 @@ void test_landing_wasSnapFloor_transition(void) {
     int landFrame = -1;
     for (int frame = 3; frame <= 120; frame++) {
         vy += toScalar(GRAVITY) * dt;
-        player->moveAndSlideWithSnap(Vector2(toScalar(0), vy), snap, dt, up);
+        (void)player->moveAndSlide(Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap);
         if (player->is_on_floor()) {
             // Landed! Verify landing is NOT too early (would indicate
             // wasSnapFloor guard failing and snap re-engaging mid-flight).
@@ -433,7 +433,7 @@ void test_landing_wasSnapFloor_transition(void) {
 
     // F(n+1): After landing, snap can re-engage (wasSnapFloor=true again)
     vy = toScalar(60);
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), vy), snap, dt, up);
+    (void)player->moveAndSlide(Vector2(toScalar(0), vy), dt, up, SnapPolicy::Step, snap);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "After landing: on floor via snap re-engage");
 }
 

--- a/test/unit/test_kinematic_actor/test_kinematic_actor.cpp
+++ b/test/unit/test_kinematic_actor/test_kinematic_actor.cpp
@@ -15,6 +15,12 @@ StaticActor* wall = nullptr;
 SensorActor* sensor = nullptr;
 KinematicActor* platform = nullptr;
 
+static constexpr Scalar kFixedDt = CollisionSystem::FIXED_DT;
+
+static Vector2 dispVel(Scalar dx, Scalar dy) {
+    return Vector2(dx, dy) / kFixedDt;
+}
+
 void setUp(void) {
     test_setup();
     colSystem = new CollisionSystem();
@@ -50,7 +56,7 @@ void test_is_on_floor() {
     // Move down into the floor
     // moveAndSlide handles multiple iterations. 
     // We move 15 units down. Should hit floor at 10 units travel.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor");
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_ceiling(), "Player should NOT be on ceiling");
@@ -69,7 +75,7 @@ void test_is_on_ceiling() {
     colSystem->addEntity(wall);
 
     // Move up into the ceiling
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(-15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(-15)), kFixedDt);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_ceiling(), "Player should be on ceiling");
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "Player should NOT be on floor");
@@ -84,7 +90,7 @@ void test_is_on_wall() {
     colSystem->addEntity(wall);
 
     // Move right into the wall
-    player->moveAndSlide(Vector2(toScalar(15), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(15), toScalar(0)), kFixedDt);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_wall(), "Player should be on wall");
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "Player should NOT be on floor");
@@ -99,11 +105,11 @@ void test_flags_reset() {
     colSystem->addEntity(wall);
 
     // 1. Hit floor
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE(player->is_on_floor());
 
     // 2. Move up (away from floor) — immediate floor loss (no persistence)
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(-5)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(-5)), kFixedDt);
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "Floor flag should be lost immediately without persistence");
     TEST_ASSERT_FALSE(player->is_on_ceiling());
     TEST_ASSERT_FALSE(player->is_on_wall());
@@ -175,7 +181,7 @@ void test_move_and_slide_45_degree_slope_detection() {
     colSystem->addEntity(slope);
     
     // Move down and right to hit the slope at 45 degrees
-    player->moveAndSlide(Vector2(toScalar(10), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(10), toScalar(15)), kFixedDt);
     
     // Should detect collision - either floor or wall depending on exact angle
     TEST_ASSERT_TRUE(player->is_on_floor() || player->is_on_wall());
@@ -192,7 +198,7 @@ void test_move_and_slide_max_slides_exhausted() {
     }
     
     // Complex motion that will require multiple slide iterations
-    player->moveAndSlide(Vector2(toScalar(30), toScalar(5)));
+    player->moveAndSlide(dispVel(toScalar(30), toScalar(5)), kFixedDt);
     
     // Should complete without crash - motion may be partially completed
     // Verify position is valid (not NaN or infinity) and within reasonable bounds
@@ -208,14 +214,14 @@ void test_move_and_slide_zero_motion() {
     wall->setCollisionMask(1);
     colSystem->addEntity(wall);
     
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE(player->is_on_floor());
     
     // Store floor position
     Scalar floorX = player->position.x;
     
     // Now move with zero motion - flags should be reset
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(0)), kFixedDt);
     
     // Position should remain valid and unchanged
     TEST_ASSERT_TRUE(player->position.x == player->position.x); // NaN check
@@ -326,7 +332,7 @@ void test_kinematic_actor_move_and_slide_max_slides(void) {
     
     // Large velocity that would need multiple slides - maxSlides is 4
     Scalar startX = player->position.x;
-    player->moveAndSlide(Vector2(toScalar(100), toScalar(50)));
+    player->moveAndSlide(dispVel(toScalar(100), toScalar(50)), kFixedDt);
     
     // Cleanup - delete walls AFTER moveAndSlide completes
     for (int i = 0; i < 8; i++) {
@@ -346,7 +352,7 @@ void test_kinematic_actor_move_and_slide_with_remainder(void) {
     colSystem->addEntity(wall);
     
     // Velocity larger than needed to hit wall
-    player->moveAndSlide(Vector2(toScalar(50), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(50), toScalar(0)), kFixedDt);
     
     // Should handle remainder - verify position is valid
     TEST_ASSERT_TRUE(player->position.x == player->position.x); // NaN check
@@ -360,7 +366,7 @@ void test_kinematic_actor_move_and_slide_diagonal_floor(void) {
     colSystem->addEntity(wall);
     
     // Diagonal movement down-right
-    player->moveAndSlide(Vector2(toScalar(10), toScalar(30)));
+    player->moveAndSlide(dispVel(toScalar(10), toScalar(30)), kFixedDt);
     
     // Should detect floor collision
     TEST_ASSERT_TRUE(player->is_on_floor() || player->is_on_wall());
@@ -374,7 +380,7 @@ void test_kinematic_actor_move_and_slide_diagonal_ceiling(void) {
     colSystem->addEntity(wall);
     
     // Diagonal movement up-right
-    player->moveAndSlide(Vector2(toScalar(10), toScalar(-30)));
+    player->moveAndSlide(dispVel(toScalar(10), toScalar(-30)), kFixedDt);
     
     // Should detect ceiling collision
     TEST_ASSERT_TRUE(player->is_on_ceiling() || player->is_on_wall());
@@ -471,7 +477,7 @@ void test_kinematic_actor_move_and_slide_many_iterations(void) {
     }
     
     // Large velocity that will hit multiple walls - maxSlides (default 4) should cap iterations
-    player->moveAndSlide(Vector2(toScalar(100), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(100), toScalar(0)), kFixedDt);
     
     // Should complete without hanging - maxSlides caps the loop
     // Verify position is valid
@@ -497,7 +503,7 @@ void test_kinematic_actor_edge_sliding(void) {
     colSystem->addEntity(floor);
     
     // Move diagonal - test slide path execution
-    player->moveAndSlide(Vector2(toScalar(30), toScalar(30)));
+    player->moveAndSlide(dispVel(toScalar(30), toScalar(30)), kFixedDt);
     
     // Verify position is valid after diagonal slide
     TEST_ASSERT_TRUE(player->position.x == player->position.x); // NaN check
@@ -521,7 +527,7 @@ void test_kinematic_actor_diagonal_both_axes_blocked(void) {
     colSystem->addEntity(topWall);
     
     // Diagonal up-right motion - should hit right wall first (smaller overlap usually)
-    player->moveAndSlide(Vector2(toScalar(25), toScalar(-25)));
+    player->moveAndSlide(dispVel(toScalar(25), toScalar(-25)), kFixedDt);
     
     // Should detect wall collision (from right wall)
     TEST_ASSERT_TRUE(player->is_on_wall() || player->is_on_ceiling());
@@ -556,7 +562,7 @@ void test_kinematic_actor_floor_exact_threshold(void) {
     
     // Pure vertical down - normal is (0, -1), upDirection default is (0, -1)
     // dot = 1.0 > 0.707, should be floor
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     
     TEST_ASSERT_TRUE(player->is_on_floor());
 }
@@ -571,7 +577,7 @@ void test_kinematic_actor_wall_horizontal_normal(void) {
     
     // Pure horizontal right - normal is (1, 0), upDirection is (0, -1)
     // dot = 0, abs(dot) < 0.707, should be wall
-    player->moveAndSlide(Vector2(toScalar(15), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(15), toScalar(0)), kFixedDt);
     
     TEST_ASSERT_TRUE(player->is_on_wall());
 }
@@ -586,7 +592,7 @@ void test_kinematic_actor_ceiling_exact_threshold(void) {
     
     // Pure vertical up - normal is (0, 1), upDirection is (0, -1)
     // dot = -1.0 < -0.707, should be ceiling
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(-15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(-15)), kFixedDt);
     
     TEST_ASSERT_TRUE(player->is_on_ceiling());
 }
@@ -600,7 +606,7 @@ void test_kinematic_actor_slide_vector_calculation(void) {
     colSystem->addEntity(wall);
     
     // Large velocity that gets partially blocked
-    player->moveAndSlide(Vector2(toScalar(100), toScalar(10)));
+    player->moveAndSlide(dispVel(toScalar(100), toScalar(10)), kFixedDt);
     
     // Should complete - verify position is valid (NaN check)
     TEST_ASSERT_TRUE(player->position.x == player->position.x); // NaN check
@@ -625,8 +631,8 @@ void test_snap_api_compile_4arg(void) {
     Vector2 result;
 
     // 4-arg call with explicit params
-    result = player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), Vector2(toScalar(0), toScalar(4)),
-                                          CollisionSystem::FIXED_DT, Vector2(0, -1));
+    result = player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt, Vector2(0, -1),
+                                  SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
 
     // Should return valid values (no NaN, no crash)
     TEST_ASSERT_TRUE_MESSAGE(result.x == result.x, "4-arg return value must be valid (NaN check)");
@@ -642,15 +648,15 @@ void test_snap_engages_3px_above_floor(void) {
     colSystem->addEntity(wall);
 
     // F0: Establish wasSnapFloor=true. Downward movement hits floor via slide.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(0, -1));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1));
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F0: should be on floor after establishing contact");
 
     // Move body 3px above floor to test snap engagement
     player->position.y = toScalar(0);
 
     // F1: Zero velocity + snap. wasSnapFloor=true → snap engages.
-    Vector2 result = player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), Vector2(toScalar(0), toScalar(4)),
-                                                   CollisionSystem::FIXED_DT, Vector2(0, -1));
+    Vector2 result = player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt, Vector2(0, -1),
+                                          SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
 
     // Player bottom should be at floor top: y + 10 = 13 → y = 3
     TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.1f, 3.0f, static_cast<float>(player->position.y),
@@ -667,8 +673,8 @@ void test_snap_degraded_below_MIN_SNAP(void) {
     colSystem->addEntity(wall);
 
     // Player at (0,0). Snap=(0,2) which is below MIN_SNAP=4.0
-    Vector2 result = player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), Vector2(toScalar(0), toScalar(2)),
-                                                   CollisionSystem::FIXED_DT, Vector2(0, -1));
+    Vector2 result = player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt, Vector2(0, -1),
+                                          SnapPolicy::Step, Vector2(toScalar(0), toScalar(2)));
 
     // Snap should NOT engage — player stays at y=0
     TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.1f, 0.0f, static_cast<float>(player->position.y),
@@ -686,8 +692,8 @@ void test_no_snap_on_jump_launch(void) {
 
     // Jump up with zero snap — zero vector disables snap regardless of current state
     // Old pattern: displacement=(0,-10) → new pattern: velocity = -10 / FIXED_DT = -600 units/s
-    Vector2 result = player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(-600)), Vector2(toScalar(0), toScalar(0)),
-                                                   CollisionSystem::FIXED_DT, Vector2(0, -1));
+    Vector2 result = player->moveAndSlide(Vector2(toScalar(0), toScalar(-600)), kFixedDt, Vector2(0, -1),
+                                          SnapPolicy::Step, Vector2(toScalar(0), toScalar(0)));
 
     // Body should move up (away from floor) with zero snap
     TEST_ASSERT_TRUE_MESSAGE(player->position.y < toScalar(0), "Jump should move body upward");
@@ -713,16 +719,17 @@ void test_snap_plus_velocity_movement(void) {
     colSystem->addEntity(wall);
 
     // F0: Establish wasSnapFloor=true. Downward movement hits floor via slide.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(toScalar(0), toScalar(-1)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(toScalar(0), toScalar(-1)));
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F0: should be on floor after establishing contact");
 
     // F1: Horizontal velocity + snap. wasSnapFloor=true → snap fires.
     // Internal: velocity * dt = 180 * 1/60 = 3 → same displacement as old test.
-    Vector2 result = player->moveAndSlideWithSnap(
+    Vector2 result = player->moveAndSlide(
         Vector2(toScalar(180), toScalar(0)),
-        Vector2(toScalar(0), toScalar(4)),
-        CollisionSystem::FIXED_DT,
-        Vector2(toScalar(0), toScalar(-1))
+        kFixedDt,
+        Vector2(toScalar(0), toScalar(-1)),
+        SnapPolicy::Step,
+        Vector2(toScalar(0), toScalar(4))
     );
 
     // Snap engaged floor contact
@@ -751,11 +758,12 @@ void test_snap_on_valid_slope(void) {
     // Binary search finds safe position at ~(3.5, 2.0) where bottom = floor top.
     // snap=(0,4): from y=2 could push further but body is already on floor → normal=(0,-1).
     // Old pattern: displacement=(5,5) → velocity = 5 / FIXED_DT = 300 units/s
-    player->moveAndSlideWithSnap(
+    player->moveAndSlide(
         Vector2(toScalar(300), toScalar(300)),
-        Vector2(toScalar(0), toScalar(4)),
-        CollisionSystem::FIXED_DT,
-        Vector2(toScalar(0), toScalar(-1))
+        kFixedDt,
+        Vector2(toScalar(0), toScalar(-1)),
+        SnapPolicy::Step,
+        Vector2(toScalar(0), toScalar(4))
     );
 
     // Player bottom at floor top: y + 10 = 12 → y = 2
@@ -778,11 +786,12 @@ void test_snap_rejected_on_steep_slope(void) {
     // Player at (0,0) 10x10, wall at x=15 (5px gap to player right edge).
     // velocity=(0,0), snap=(0,4). Snap pushes down but no floor within 4px → miss.
     // onFloor stays false, body position unchanged.
-    player->moveAndSlideWithSnap(
+    player->moveAndSlide(
         Vector2(toScalar(0), toScalar(0)),
-        Vector2(toScalar(0), toScalar(4)),
-        CollisionSystem::FIXED_DT,
-        Vector2(toScalar(0), toScalar(-1))
+        kFixedDt,
+        Vector2(toScalar(0), toScalar(-1)),
+        SnapPolicy::Step,
+        Vector2(toScalar(0), toScalar(4))
     );
 
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "TS-008: snap rejected on steep slope (no floor contact)");
@@ -803,21 +812,21 @@ void test_snap_jump_recontact(void) {
     Vector2 up(toScalar(0), toScalar(-1));
 
     // F0: Establish wasSnapFloor=true via moveAndSlide (now symmetric).
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), up);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     // Reset position to y=0 (wasSnapFloor persists as member variable)
     player->position.y = toScalar(0);
 
     // Frame 1: On floor (snap engages) — wasSnapFloor=true from F0
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), snap, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snap);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "TS-006 F1: should be on floor via snap");
 
     // Frame 2: Jump up — old displacement=(0,-5) → velocity=(0,-300)
     // player.y starts at 2, moves up to -3, snap tries y=1 → no floor → restored to y=-3
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(-300)), snap, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(-300)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snap);
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "TS-006 F2: should NOT be on floor after jump");
 
     // Frame 3: Fall back down — old displacement=(0,15) → velocity=(0,900)
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(900)), snap, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(900)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snap);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "TS-006 F3: should re-contact floor via slide");
 }
 
@@ -830,7 +839,7 @@ void test_static_floor_no_inheritance(void) {
 
     // Player at (0,0) 10x10. Move down 15 → should land on static floor
     // No inheritance expected → player y = 10 (bottom at platform top)
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor after landing on STATIC floor");
     // Player bottom should be at floor top: y + 10 = 20 → y = 10
@@ -845,7 +854,7 @@ void test_kinematic_floor_out_floor_body_static(void) {
     colSystem->addEntity(wall);
 
     PhysicsActor* floorPtr = reinterpret_cast<PhysicsActor*>(static_cast<uintptr_t>(0xDEAD));
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(0, -1), &floorPtr);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1), SnapPolicy::None, {}, &floorPtr);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor");
     TEST_ASSERT_NULL_MESSAGE(floorPtr, "STATIC floor should leave outFloorBody as nullptr");
@@ -860,21 +869,21 @@ void test_kinematic_floor_out_floor_body_kinematic(void) {
     colSystem->addEntity(platform);
 
     PhysicsActor* floorPtr = nullptr;
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(0, -1), &floorPtr);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1), SnapPolicy::None, {}, &floorPtr);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor");
     TEST_ASSERT_NULL_MESSAGE(floorPtr, "v1: outFloorBody always returns nullptr (floorBody dead in v1)");
 }
 
 void test_default_nullptr_parameter_no_crash(void) {
-    // Call with default nullptr (2-arg call) → no crash, unchanged behavior
+    // Call with default snap/outFloorBody → no crash, unchanged behavior
     wall = new StaticActor(toScalar(-50), toScalar(20), 100, 10);
     wall->setCollisionLayer(1);
     wall->setCollisionMask(1);
     colSystem->addEntity(wall);
 
-    // 2-arg call (inherits default nullptr for outFloorBody)
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(0, -1));
+    // Default snap/outFloorBody parameters
+    (void)player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1));
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor with 2-arg call");
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_ceiling(), "Player should NOT be on ceiling");
@@ -903,24 +912,24 @@ void test_was_snap_floor_prevents_snap_on_first_air_frame(void) {
     Vector2 snapBig(toScalar(0), toScalar(6));
 
     // F0: Establish wasSnapFloor=true. Body falls into floor via slide.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), up);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F0: should be on floor after establishing contact");
     // Reset position so F1 tests snap from origin
     player->position.y = toScalar(0);
 
     // F1: On floor via snap (wasSnapFloor=true from F0).
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), snapBig, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snapBig);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F1: should be on floor via snap");
 
     // F2: Jump up — old displacement=(0,-12) → velocity=(0,-720)
     // wasSnapFloor=true, snap fires but misses (gap > 6). onFloor=false.
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(-720)), snapBig, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(-720)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snapBig);
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "F2: should be airborne after jump");
     Scalar afterJumpY = player->position.y;
 
     // F3: Zero velocity + non-zero snap. wasSnapFloor=false → guard prevents snap.
     // Body should NOT move (no slide motion, no snap). Position unchanged.
-    player->moveAndSlideWithSnap(Vector2(toScalar(0), toScalar(0)), snapBig, CollisionSystem::FIXED_DT, up);
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), CollisionSystem::FIXED_DT, up, SnapPolicy::Step, snapBig);
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "F3: should NOT snap (wasSnapFloor guard)");
     TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.1f, static_cast<float>(afterJumpY), static_cast<float>(player->position.y),
         "F3: position must not change — guard prevented snap");
@@ -931,7 +940,7 @@ void test_was_snap_floor_allows_snap_on_floor_frame(void) {
     // to establish wasSnapFloor=true, then verify snap re-engages on the next frame.
     //
     // GIVEN: wasSnapFloor=true (after floor contact in F0).
-    // WHEN: moveAndSlideWithSnap with non-zero snap.
+    // WHEN: moveAndSlide with non-zero snap.
     // THEN: Snap engages, onFloor=true, body snaps to floor surface.
     // Floor top at y=14 (body at y=0, bottom=10, gap=4).
     wall = new StaticActor(toScalar(0), toScalar(14), 100, 10);
@@ -940,16 +949,17 @@ void test_was_snap_floor_allows_snap_on_floor_frame(void) {
     colSystem->addEntity(wall);
 
     // F0: Establish wasSnapFloor=true via moveAndSlide (now sets wasSnapFloor,
-    // symmetric with moveAndSlideWithSnap). Body falls into floor via slide.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), Vector2(toScalar(0), toScalar(-1)));
+    // symmetric with moveAndSlide). Body falls into floor via slide.
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(toScalar(0), toScalar(-1)));
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "F0: body should be on floor after landing");
 
     // F1: Zero velocity + snap=(0,6) with wasSnapFloor=true → snap fires, places body on floor
-    player->moveAndSlideWithSnap(
+    player->moveAndSlide(
         Vector2(toScalar(0), toScalar(0)),
-        Vector2(toScalar(0), toScalar(6)),
-        CollisionSystem::FIXED_DT,
-        Vector2(toScalar(0), toScalar(-1))
+        kFixedDt,
+        Vector2(toScalar(0), toScalar(-1)),
+        SnapPolicy::Step,
+        Vector2(toScalar(0), toScalar(6))
     );
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "wasSnapFloor=true should allow snap on floor frame");
     // Body bottom at floor top: y + 10 = 14 → y = 4
@@ -968,12 +978,12 @@ void test_is_on_floor_raw_contact(void) {
     colSystem->addEntity(wall);
 
     // Frame 1: Land on floor
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Frame 1: should be on floor (direct contact)");
 
     // Frame 2: Walk off floor (move right with no floor below)
     player->position.x = toScalar(60);
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(1)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(1)), kFixedDt);
 
     // No persistence: should immediately lose floor
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "Frame 2: should NOT be on floor (no persistence)");
@@ -988,7 +998,7 @@ void test_depenetration_post_slide(void) {
     colSystem->addEntity(platform);
 
     // Frame 1: Land on platform
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should land");
 
     // Simulate platform shifting up into the player (e.g. moving wall pushes into player)
@@ -999,7 +1009,7 @@ void test_depenetration_post_slide(void) {
     // Frame 2: Pre-slide adds platform velocity (0,0). Depenetration should push player UP
     // Player center (~15) is above platform center (~17), so player goes UP
     Scalar preY = player->position.y;
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(0)), kFixedDt);
 
     // Player should be pushed out from the overlap (clamped to 2.0 units max)
     // Player is above platform center, pushed upward
@@ -1019,10 +1029,54 @@ void test_safe_margin_expansion(void) {
 
     // With default safeMargin (0.08f), moveAndCollide should still detect this
     // but moveAndSlide uses default 0.08f margin
-    player->moveAndSlide(Vector2(toScalar(5), toScalar(0)));
+    player->moveAndSlide(dispVel(toScalar(5), toScalar(0)), kFixedDt);
 
     // Player should NOT pass through the wall
     TEST_ASSERT_TRUE_MESSAGE(player->position.x < toScalar(11.0f), "Safe margin should prevent passing through near wall");
+}
+
+void test_snap_policy_none_default_no_snap(void) {
+    wall = new StaticActor(toScalar(-50), toScalar(13), 100, 10);
+    wall->setCollisionLayer(1);
+    wall->setCollisionMask(1);
+    colSystem->addEntity(wall);
+
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
+    TEST_ASSERT_TRUE(player->is_on_floor());
+    player->position.y = toScalar(0);
+
+    Scalar yBefore = player->position.y;
+    (void)player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, static_cast<float>(yBefore), static_cast<float>(player->position.y));
+}
+
+void test_snap_policy_continuous_no_snap(void) {
+#if PIXELROOT32_DEBUG_MODE
+    TEST_IGNORE_MESSAGE("SnapPolicy::Continuous triggers one-shot debug assert by design");
+#else
+    wall = new StaticActor(toScalar(-50), toScalar(13), 100, 10);
+    wall->setCollisionLayer(1);
+    wall->setCollisionMask(1);
+    colSystem->addEntity(wall);
+
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
+    player->position.y = toScalar(0);
+
+    (void)player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt, Vector2(0, -1),
+                               SnapPolicy::Continuous, Vector2(toScalar(0), toScalar(4)));
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, static_cast<float>(player->position.y));
+#endif
+}
+
+void test_move_and_slide_returns_wall_stopped_velocity(void) {
+    wall = new StaticActor(toScalar(20), toScalar(-50), 10, 100);
+    wall->setCollisionLayer(1);
+    wall->setCollisionMask(1);
+    colSystem->addEntity(wall);
+
+    Vector2 result = player->moveAndSlide(dispVel(toScalar(15), toScalar(0)), kFixedDt);
+    TEST_ASSERT_TRUE(player->is_on_wall());
+    TEST_ASSERT_TRUE(result.x < dispVel(toScalar(15), toScalar(0)).x);
 }
 
 // =============================================================================
@@ -1052,20 +1106,20 @@ void test_player_cube_jump_sequence(void) {
 
     // Land on floor
     player->position = Vector2(toScalar(50), toScalar(-10));
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(35)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(35)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Start: body should be on floor after landing");
     Scalar startY = player->position.y;
 
     // Frame 0: Establish wasSnapFloor=true via moveAndSlide (now sets wasSnapFloor).
     // Small downward movement so slide step detects floor contact.
     Vector2 vel(toScalar(0), toScalar(15));
-    player->moveAndSlide(vel, up);
+    player->moveAndSlide(dispVel(vel.x, vel.y), kFixedDt, up);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Frame 0: body on floor after snap setup");
 
     // Frame 1: Jump — direct jump velocity (no gravity during ascent frame,
     // matching PlayerCube simplified jump model)
     vel = Vector2(toScalar(0), toScalar(-jumpVelocity));
-    player->moveAndSlideWithSnap(vel, Vector2{}, dt, up); // snap=0 on jump
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(-jumpVelocity)), dt, up, SnapPolicy::Step, Vector2{});
     TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(), "Frame 1: body should NOT be on floor during jump ascent");
     TEST_ASSERT_TRUE_MESSAGE(player->position.y < startY, "Frame 1: body should be higher (lower y) after jump");
 
@@ -1074,7 +1128,7 @@ void test_player_cube_jump_sequence(void) {
     // The snap guard prevents re-engagement even if snap magnitude exceeds MIN_SNAP.
     for (int frame = 2; frame <= 4; ++frame) {
         vel.y = toScalar(1.0f); // Small downward per frame
-        player->moveAndSlideWithSnap(vel, Vector2(toScalar(0), toScalar(4)), dt, up);
+        player->moveAndSlide(dispVel(toScalar(0), vel.y), dt, up, SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
         // wasSnapFloor=false → snap skipped → body stays airborne
         TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(),
             "Frame 2-4: should remain airborne (snap guard)");
@@ -1090,9 +1144,9 @@ void test_snap_edge_detachment(void) {
     //
     // Approach:
     //   1. Land body on platform via slide
-    //   2. Establish wasSnapFloor=true via one moveAndSlideWithSnap frame
+    //   2. Establish wasSnapFloor=true via one moveAndSlide frame
     //   3. Teleport body past the platform edge + below the surface
-    //   4. Call moveAndSlideWithSnap again — guard should skip snap
+    //   4. Call moveAndSlide again — guard should skip snap
     //      because body was not on floor in the slide step
     Vector2 up(toScalar(0), toScalar(-1));
     Scalar dt = toScalar(1.0f / 60.0f);
@@ -1106,12 +1160,12 @@ void test_snap_edge_detachment(void) {
 
     // Step 1: Land on platform
     player->position = Vector2(toScalar(30), toScalar(-10));
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(35)));
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(35)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Landing: body should be on platform");
 
     // Step 2: Establish wasSnapFloor=true via moveAndSlide (now symmetric).
     // Small downward movement so slide step detects floor contact.
-    player->moveAndSlide(Vector2(toScalar(0), toScalar(15)), up);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt);
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Setup: body on floor after snap setup");
 
     // Step 3: Teleport past platform edge and clearly below it.
@@ -1125,9 +1179,7 @@ void test_snap_edge_detachment(void) {
     // wasSnapFloor=false after this call. Next call: snap skipped.
     for (int frame = 1; frame <= 5; ++frame) {
         vel.y += gravity * dt;
-        player->moveAndSlideWithSnap(
-            vel,
-            Vector2(toScalar(0), toScalar(4)), dt, up);
+        player->moveAndSlide(vel, dt, up, SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
         // Body should NOT be on floor — it's past the platform edge
         TEST_ASSERT_FALSE_MESSAGE(player->is_on_floor(),
             "Body should remain airborne past platform edge");
@@ -1212,6 +1264,10 @@ int main(int argc, char **argv) {
     RUN_TEST(test_was_snap_floor_prevents_snap_on_first_air_frame);
     RUN_TEST(test_was_snap_floor_allows_snap_on_floor_frame);
     
+    RUN_TEST(test_snap_policy_none_default_no_snap);
+    RUN_TEST(test_snap_policy_continuous_no_snap);
+    RUN_TEST(test_move_and_slide_returns_wall_stopped_velocity);
+
     // Integration regression tests
     RUN_TEST(test_player_cube_jump_sequence);
     RUN_TEST(test_snap_edge_detachment);

--- a/test/unit/test_sensor_actor/test_sensor_actor.cpp
+++ b/test/unit/test_sensor_actor/test_sensor_actor.cpp
@@ -169,7 +169,7 @@ void test_sensor_actor_detects_overlap(void) {
     sensorTestSystem->addEntity(sensor);
     
     // Move actor into sensor
-    movingActor->moveAndSlide(Vector2(toScalar(10), toScalar(10)));
+    movingActor->moveAndSlide(Vector2(toScalar(10), toScalar(10)) / CollisionSystem::FIXED_DT, CollisionSystem::FIXED_DT);
     
     // The sensor should detect the overlap (though we can't directly test
     // the collision callback without more setup)


### PR DESCRIPTION
Updated the KinematicActor's moveAndSlide method to include snap behavior, consolidating functionality with moveAndSlideWithSnap. Adjusted related documentation and examples to reflect the new parameters, including SnapPolicy and snap vector. Modified existing tests to utilize the updated method, ensuring consistent behavior across the physics system.