### PR TITLE
feat(physics): enhance KinematicActor's moveAndSlide for kinematic floor interaction

### DIFF
--- a/docs/api/generated/core/Scene.md
+++ b/docs/api/generated/core/Scene.md
@@ -8,13 +8,21 @@
 
 Represents a game level or screen containing entities.
 
+init() is idempotent — may be called any number of times, each call
+      leaves the state equivalent to a fresh init.
+
+::: tip
+init() is idempotent — may be called any number of times, each call
+      leaves the state equivalent to a fresh init.
+:::
+
 ## Methods
 
 ### `virtual void init()`
 
 **Description:**
 
-Initializes the scene. Called when entering the scene.
+Initialises the scene. Called when entering the scene.
 
 ### `virtual void initUI()`
 
@@ -135,3 +143,9 @@ Removes an entity from the scene.
 **Description:**
 
 Removes all entities from the scene.
+
+### `virtual void resetState() noexcept; Entity* entities[pixelroot32::platforms::config::MaxEntities]; ///< Array of entities in the scene. int entityCount;            ///< Current number of entities. bool needsSorting = false;      ///< Flag to trigger sorting by layer. void sortEntities();            ///< Sorts entities by render layer. bool isVisibleInViewport(Entity* entity, pixelroot32::graphics::Renderer& renderer)`
+
+**Description:**
+
+Resets the scene to a clean initial state.

--- a/src/physics/KinematicActor.cpp
+++ b/src/physics/KinematicActor.cpp
@@ -340,9 +340,13 @@ pixelroot32::math::Vector2 KinematicActor::moveAndSlide(
     Vector2 startPos = position;
     Vector2 currentMotion = velocity * dt;
 
+    if (wasSnapFloor && floorBody != nullptr &&
+        floorBody->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
+        currentMotion += floorBody->getVelocity() * dt;
+    }
+
     pixelroot32::core::PhysicsActor* localFloorBody = nullptr;
     slide(currentMotion, upDirection, localFloorBody);
-    Vector2 afterSlidePos = position;
 
     if (snapPolicy == SnapPolicy::Step) {
         applySnapStep(snapVector, upDirection, localFloorBody);
@@ -356,6 +360,18 @@ pixelroot32::math::Vector2 KinematicActor::moveAndSlide(
 #endif
     }
 
+    if (onFloor && localFloorBody != nullptr &&
+        localFloorBody->getBodyType() == pixelroot32::core::PhysicsBodyType::KINEMATIC) {
+        floorBody = localFloorBody;
+        floorVelocity = localFloorBody->getVelocity();
+    } else if (!onFloor) {
+        floorBody = nullptr;
+        floorVelocity = Vector2::ZERO();
+    } else {
+        floorBody = nullptr;
+        floorVelocity = Vector2::ZERO();
+    }
+
     resolvePostSlideKinematicDepenetration();
 
     if (outFloorBody) {
@@ -367,7 +383,7 @@ pixelroot32::math::Vector2 KinematicActor::moveAndSlide(
     if (dt == Scalar(0)) {
         return Vector2::ZERO();
     }
-    Vector2 displacement = afterSlidePos - startPos;
+    Vector2 displacement = position - startPos;
     return displacement / dt;
 }
 

--- a/test/unit/test_kinematic_actor/test_kinematic_actor.cpp
+++ b/test/unit/test_kinematic_actor/test_kinematic_actor.cpp
@@ -861,7 +861,6 @@ void test_kinematic_floor_out_floor_body_static(void) {
 }
 
 void test_kinematic_floor_out_floor_body_kinematic(void) {
-    // v1: outFloorBody always returns nullptr (floorBody storage is dead)
     platform = new KinematicActor(toScalar(-50), toScalar(20), 100, 10);
     platform->setCollisionLayer(1);
     platform->setCollisionMask(1);
@@ -869,10 +868,36 @@ void test_kinematic_floor_out_floor_body_kinematic(void) {
     colSystem->addEntity(platform);
 
     PhysicsActor* floorPtr = nullptr;
-    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1), SnapPolicy::None, {}, &floorPtr);
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1),
+                         SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)), &floorPtr);
 
     TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should be on floor");
-    TEST_ASSERT_NULL_MESSAGE(floorPtr, "v1: outFloorBody always returns nullptr (floorBody dead in v1)");
+    TEST_ASSERT_NOT_NULL_MESSAGE(floorPtr, "KINEMATIC floor should expose outFloorBody");
+    TEST_ASSERT_EQUAL_PTR_MESSAGE(platform, floorPtr, "outFloorBody should reference kinematic platform");
+}
+
+void test_kinematic_floor_velocity_injection_horizontal(void) {
+    platform = new KinematicActor(toScalar(-50), toScalar(20), 100, 10);
+    platform->setCollisionLayer(1);
+    platform->setCollisionMask(1);
+    platform->setVelocity(toScalar(60), toScalar(0));
+    colSystem->addEntity(platform);
+
+    player->moveAndSlide(dispVel(toScalar(0), toScalar(15)), kFixedDt, Vector2(0, -1),
+                         SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
+    TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should land on platform");
+
+    Scalar playerXAfterLand = player->position.x;
+
+    player->moveAndSlide(Vector2(toScalar(0), toScalar(0)), kFixedDt, Vector2(0, -1),
+                         SnapPolicy::Step, Vector2(toScalar(0), toScalar(4)));
+
+    TEST_ASSERT_TRUE_MESSAGE(player->is_on_floor(), "Player should remain on platform");
+    Scalar expectedDelta = toScalar(60) * kFixedDt;
+    Scalar actualDelta = player->position.x - playerXAfterLand;
+    TEST_ASSERT_FLOAT_WITHIN_MESSAGE(0.5f, static_cast<float>(expectedDelta),
+        static_cast<float>(actualDelta),
+        "Riding player should inherit horizontal platform displacement");
 }
 
 void test_default_nullptr_parameter_no_crash(void) {
@@ -1253,6 +1278,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_static_floor_no_inheritance);
     RUN_TEST(test_kinematic_floor_out_floor_body_static);
     RUN_TEST(test_kinematic_floor_out_floor_body_kinematic);
+    RUN_TEST(test_kinematic_floor_velocity_injection_horizontal);
     RUN_TEST(test_default_nullptr_parameter_no_crash);
     
     // Phase 4 (V2): Raw contact + platform riding tests


### PR DESCRIPTION
Updated the moveAndSlide method to correctly handle kinematic floor bodies, allowing for velocity injection from the floor. Added logic to manage floor body state and velocity based on the actor's position relative to the floor. Introduced new tests to validate kinematic floor behavior and ensure proper player interaction with moving platforms.