### PR TITLE
fix(audio): allow zero-duration stacked percussion hits

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/examples/music_demo/src/MusicDemoScene.cpp
+++ b/examples/music_demo/src/MusicDemoScene.cpp
@@ -239,22 +239,22 @@ void MusicDemoScene::playMelody(int idx) {
 
     switch (idx) {
         case 1: {
-            player.setBPM(140.0f);
+            player.setBPM(classic_arcade_bpm);
             player.play(sClassicArcadeTrack);
             break;
         }
         case 2: {
-            player.setBPM(125.0f);
+            player.setBPM(adventure_bpm);
             player.play(sAdventureTrack);
             break;
         }
         case 3: {
-            player.setBPM(160.0f);
+            player.setBPM(action_bpm);
             player.play(sActionTrack);
             break;
         }
         case 4: {
-            player.setBPM(145.0f);
+            player.setBPM(arp_demo_bpm);
             player.play(sArpDemoTrack);
             break;
         }

--- a/examples/music_demo/src/assets/action_melody.h
+++ b/examples/music_demo/src/assets/action_melody.h
@@ -11,6 +11,8 @@ namespace musicdemo {
 // MELODY 3 — Action — 8 bars / 32 beats + break
 // =============================================================================
 
+static const float action_bpm = 160.0f;
+
 #define ARP_EM() \
     pr32::audio::makeNote(DEMO_SNES_LEAD_TIGHT, pr32::audio::Note::E, 5, S), \
     pr32::audio::makeNote(DEMO_SNES_LEAD_TIGHT, pr32::audio::Note::G, 5, S), \
@@ -215,7 +217,8 @@ static const pr32::audio::MusicTrack sActionLead = {
     0.5f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sActionBass = {
     sActionBassNotes,
@@ -225,7 +228,8 @@ static const pr32::audio::MusicTrack sActionBass = {
     0.5f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sActionHarmony = {
     sActionHarmonyNotes,
@@ -235,7 +239,8 @@ static const pr32::audio::MusicTrack sActionHarmony = {
     0.125f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sActionDrums = {
     sActionDrumsNotes,
@@ -245,7 +250,8 @@ static const pr32::audio::MusicTrack sActionDrums = {
     0.0f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sActionTrack = {
     sActionLeadNotes,
@@ -256,5 +262,4 @@ static const pr32::audio::MusicTrack sActionTrack = {
     &sActionBass,
     &sActionHarmony,
     &sActionDrums};
-    
 }

--- a/examples/music_demo/src/assets/adventure_melody.h
+++ b/examples/music_demo/src/assets/adventure_melody.h
@@ -11,6 +11,8 @@ namespace musicdemo {
 // MELODY 2 — Adventure — 16 bars / 64 beats: A | B | A' | C
 // =============================================================================
 
+static const float adventure_bpm = 125.0f;
+
 static const pr32::audio::MusicNote sAdventureLeadNotes[] = {
     pr32::audio::makeNote(pr32::audio::INSTR_PULSE_LEAD, pr32::audio::Note::C, 5, E),
     pr32::audio::makeNote(pr32::audio::INSTR_PULSE_LEAD, pr32::audio::Note::D, 5, E),

--- a/examples/music_demo/src/assets/arpeggio_melody.h
+++ b/examples/music_demo/src/assets/arpeggio_melody.h
@@ -11,6 +11,8 @@ namespace musicdemo {
 // MELODY 4 — Em arpeggio + full arrangement (4 flat layers)
 // =============================================================================
 
+static const float arp_demo_bpm = 145.0f;
+
 // 16 × (4 × ARP_STEP) = 32 beats to align with the main theme loop.
 #define ARP_DEMO_CELL()                                                                                               \
     pr32::audio::makeNote(pr32::audio::INSTR_TRIANGLE_LEAD, pr32::audio::Note::E, 3, ARP_STEP),                       \
@@ -162,7 +164,8 @@ static const pr32::audio::MusicTrack sArpDemoBass = {
     0.5f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sArpDemoDrums = {
     sArpDemoDrumsNotes,
@@ -172,7 +175,8 @@ static const pr32::audio::MusicTrack sArpDemoDrums = {
     0.0f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sArpDemoTrack = {
     sArpDemoLeadNotes,

--- a/examples/music_demo/src/assets/classic_arcade_melody.h
+++ b/examples/music_demo/src/assets/classic_arcade_melody.h
@@ -11,6 +11,8 @@ namespace musicdemo {
 // MELODY 1 — Classic Arcade — 8 bars / 32 beats: A | A' | B | B'
 // =============================================================================
 
+static const float classic_arcade_bpm = 140.0f;
+
 static const pr32::audio::MusicNote sClassicArcadeLeadNotes[] = {
     pr32::audio::makeNote(pr32::audio::INSTR_PULSE_LEAD, pr32::audio::Note::E, 5, Q),
     pr32::audio::makeNote(pr32::audio::INSTR_PULSE_LEAD, pr32::audio::Note::B, 4, Q),
@@ -130,7 +132,8 @@ static const pr32::audio::MusicTrack sClassicArcadeLead = {
     0.5f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sClassicArcadeBass = {
     sClassicArcadeBassNotes,
@@ -140,7 +143,8 @@ static const pr32::audio::MusicTrack sClassicArcadeBass = {
     0.5f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sClassicArcadeHarmony = {
     sClassicArcadeHarmonyNotes,
@@ -150,7 +154,8 @@ static const pr32::audio::MusicTrack sClassicArcadeHarmony = {
     0.125f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sClassicArcadeDrums = {
     sClassicArcadeDrumsNotes,
@@ -160,7 +165,8 @@ static const pr32::audio::MusicTrack sClassicArcadeDrums = {
     0.0f,
     nullptr,
     nullptr,
-    nullptr};
+    nullptr
+};
 
 static const pr32::audio::MusicTrack sClassicArcadeTrack = {
     sClassicArcadeLeadNotes,
@@ -170,6 +176,7 @@ static const pr32::audio::MusicTrack sClassicArcadeTrack = {
     0.5f,
     &sClassicArcadeBass,
     &sClassicArcadeHarmony,
-    &sClassicArcadeDrums};
+    &sClassicArcadeDrums
+};
 
 }

--- a/include/audio/AudioMusicTypes.h
+++ b/include/audio/AudioMusicTypes.h
@@ -97,7 +97,9 @@ inline float noteToFrequency(Note note, int octave) {
 struct MusicNote {
     Note note;
     uint8_t octave; // 0-8 (for percussion: 1=Kick, 2=Snare, 3+=Hi-HAT)
-    float duration; // Seconds
+    /// Sequencer advance in beats (quarter = 1.0; ApuCore TICKS_PER_BEAT = 4).
+    /// Use 0.0 to fire a stacked hit without advancing tempo (same-step drums).
+    float duration;
     float volume;   // 0.0 - 1.0
     const InstrumentPreset* preset = nullptr;  // nullptr = use track preset or legacy behavior
 };

--- a/src/audio/ApuCore.cpp
+++ b/src/audio/ApuCore.cpp
@@ -318,13 +318,18 @@ namespace pixelroot32::audio {
 
             while (musicPlayingFlag.load(std::memory_order_acquire)
                    && globalTickCounter >= nextTick) {
-                // Check note limit per frame - bounded processing
-                if (notesProcessedThisFrame >= limit) {
+                if (noteIdx >= track->count) {
+                    break;
+                }
+                const MusicNote& note = track->notes[noteIdx];
+                // duration == 0 => fire without advancing (stacked drum hits).
+                uint64_t noteTicks =
+                    (uint64_t)(note.duration * (float)TICKS_PER_BEAT / tempoFactor);
+
+                // Check note limit per frame - bounded processing.
+                // Zero-tick stacked hits always process so same-step drums stay together.
+                if (notesProcessedThisFrame >= limit && noteTicks > 0) {
                     frameDeferredNotes++;
-                    // Still need to advance timing even if we skip the note
-                    const MusicNote& note = track->notes[noteIdx];
-                    uint64_t noteTicks = (uint64_t)(note.duration * (float)TICKS_PER_BEAT / tempoFactor);
-                    if (noteTicks == 0) noteTicks = 1;
                     nextTick += noteTicks;
                     noteIdx++;
                     if (noteIdx >= track->count) {
@@ -337,46 +342,37 @@ namespace pixelroot32::audio {
                     }
                     continue;
                 }
-                const MusicNote& note = track->notes[noteIdx];
 
-                // On NOISE channels, Rest notes are treated as hits so
-                // percussion tracks can be authored as a pattern of hits.
-                bool shouldPlay = (note.note != Note::Rest)
-                               || (track->channelType == WaveType::NOISE);
+                // Percussion hits use Note::Rest + noise preset. Plain rests are silence.
+                const bool isPercussionHit =
+                    track->channelType == WaveType::NOISE && note.preset &&
+                    note.preset->duty == 0.0f;
+                const bool shouldPlay =
+                    (note.note != Note::Rest) || isPercussionHit;
 
                 if (shouldPlay) {
                     AudioEvent event{};
                     event.type = track->channelType;
 
-                    const InstrumentPreset* percPreset = nullptr;
-                    if (note.preset && note.preset->duty == 0.0f) {
-                        percPreset = note.preset;
-                    }
-
-                    if (percPreset) {
-                        event.frequency = instrumentToFrequency(*percPreset, note.note, note.octave);
-                        event.duration = (percPreset->defaultDuration > 0.0f)
-                            ? percPreset->defaultDuration / tempoFactor
-                            : note.duration / tempoFactor;
-                        event.noisePeriod = percPreset->noisePeriod;
+                    if (isPercussionHit) {
+                        event.frequency = instrumentToFrequency(*note.preset, note.note, note.octave);
+                        event.duration = (note.preset->defaultDuration > 0.0f)
+                            ? note.preset->defaultDuration / tempoFactor
+                            : (note.duration > 0.0f ? note.duration : 0.05f) / tempoFactor;
+                        event.noisePeriod = note.preset->noisePeriod;
+                        event.preset = note.preset;
                     } else {
-                        if (note.note == Note::Rest && event.type == WaveType::NOISE) {
-                            event.frequency = 1000.0f;
-                        } else {
-                            event.frequency = noteToFrequency(note.note, note.octave);
-                        }
+                        event.frequency = noteToFrequency(note.note, note.octave);
                         event.duration = note.duration / tempoFactor;
                         event.noisePeriod = 0;
+                        event.preset = note.preset;
                     }
 
                     event.volume = note.volume;
                     event.duty = (event.type == WaveType::PULSE) ? track->duty : 0.5f;
-                    event.preset = note.preset;  // Forward ADSR/LFO params
                     executePlayEvent(event);
                 }
 
-                uint64_t noteTicks = (uint64_t)(note.duration * (float)TICKS_PER_BEAT / tempoFactor);
-                if (noteTicks == 0) noteTicks = 1;
                 nextTick += noteTicks;
 
                 noteIdx++;
@@ -388,7 +384,10 @@ namespace pixelroot32::audio {
                         break;
                     }
                 }
-                notesProcessedThisFrame++;
+                // Count only tempo-advancing notes toward the per-frame budget.
+                if (noteTicks > 0) {
+                    notesProcessedThisFrame++;
+                }
             }
         }
 

--- a/test/unit/test_audio_scheduler/test_audio_scheduler.cpp
+++ b/test/unit/test_audio_scheduler/test_audio_scheduler.cpp
@@ -374,6 +374,42 @@ void test_music_play_no_burst_after_long_idle(void) {
     TEST_ASSERT_EQUAL(0u, scheduler.core().getDroppedCommands());
 }
 
+/** duration == 0 fires without advancing so Kick+HiHat can share one sequencer step. */
+void test_music_stacked_zero_duration_percussion_hits(void) {
+    DefaultAudioScheduler scheduler;
+    initScheduler(scheduler);
+
+    static const MusicNote kStackedDrumNotes[] = {
+        makeNote(INSTR_KICK, Note::Rest, 1, 0.0f),   // stacked: no tempo advance
+        makeNote(INSTR_HIHAT, Note::Rest, 3, 1.0f),  // carries 1 beat (4 ticks)
+        makeNote(INSTR_SNARE, Note::Rest, 2, 1.0f),
+    };
+    static const MusicTrack kStackedDrumTrack{
+        kStackedDrumNotes,
+        sizeof(kStackedDrumNotes) / sizeof(kStackedDrumNotes[0]),
+        false,
+        WaveType::NOISE,
+        0.5f,
+        nullptr,
+        nullptr,
+        nullptr,
+    };
+
+    AudioCommand play{};
+    play.type = AudioCommandType::MUSIC_PLAY;
+    play.track = &kStackedDrumTrack;
+    scheduler.submitCommand(play);
+
+    int16_t buf[256];
+    scheduler.generateSamples(buf, 256);
+
+    // Kick (dur 0) + HiHat (dur 1.0) must both process on the first sequencer pass.
+    // Old clamp (dur 0 -> 1 tick) would leave the index at 1 after the first pass.
+    TEST_ASSERT_EQUAL_UINT32(
+        2u, (unsigned)scheduler.core().getSequencerMainNoteIndexForTesting());
+    TEST_ASSERT_TRUE(scheduler.isMusicPlaying());
+}
+
 void test_set_master_volume_clamping(void) {
     DefaultAudioScheduler scheduler;
     initScheduler(scheduler);
@@ -1154,6 +1190,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_music_pause_resume_command);
     RUN_TEST(test_music_set_tempo_command);
     RUN_TEST(test_music_play_no_burst_after_long_idle);
+    RUN_TEST(test_music_stacked_zero_duration_percussion_hits);
     RUN_TEST(test_set_master_volume_clamping);
     
     // Edge case tests


### PR DESCRIPTION
## Summary
- Allow `MusicNote.duration == 0` to fire without advancing the sequencer so Kick/Snare/Hi-Hat can share the same step on the NOISE track.
- Treat only `Rest + noise preset` as percussion hits; plain rests on NOISE are silence again.
- Document duration semantics and add a regression test for stacked zero-duration hits.

## Test plan
- [x] `pio test -e native_test -f unit/test_audio_scheduler` (44 passed, including `test_music_stacked_zero_duration_percussion_hits`)
- [x] CI native_test on the PR
