### PR TITLE
feat(platform): add opt-in gameplay-framework feature flags

### DIFF
--- a/include/platforms/EngineConfig.h
+++ b/include/platforms/EngineConfig.h
@@ -203,6 +203,18 @@
     #define PHYSICS_MAX_PAIRS 128
 #endif
 
+#ifndef GAMEPLAY_EVENT_QUEUE_CAPACITY
+    #define GAMEPLAY_EVENT_QUEUE_CAPACITY 32
+#endif
+
+#ifndef GAMEPLAY_MAX_INTERACTIVE_ACTORS
+    #define GAMEPLAY_MAX_INTERACTIVE_ACTORS 16
+#endif
+
+#ifndef SPATIAL_QUERY_MAX_RADIUS
+    #define SPATIAL_QUERY_MAX_RADIUS 128
+#endif
+
 #ifndef PIXELROOT32_VELOCITY_ITERATIONS
     #define PIXELROOT32_VELOCITY_ITERATIONS 2
 #endif
@@ -325,7 +337,18 @@ namespace pixelroot32::platforms::config {
 
     /** @brief Type-safe access to VelocityIterations configuration. */
     inline constexpr int VelocityIterations = PIXELROOT32_VELOCITY_ITERATIONS;
-    
+
+    // Gameplay Framework
+
+    /** @brief Type-safe access to GameplayEventQueueCapacity configuration. */
+    inline constexpr int GameplayEventQueueCapacity = GAMEPLAY_EVENT_QUEUE_CAPACITY;
+
+    /** @brief Type-safe access to GameplayMaxInteractiveActors configuration. */
+    inline constexpr int GameplayMaxInteractiveActors = GAMEPLAY_MAX_INTERACTIVE_ACTORS;
+
+    /** @brief Type-safe access to SpatialQueryMaxRadius configuration. */
+    inline constexpr int SpatialQueryMaxRadius = SPATIAL_QUERY_MAX_RADIUS;
+
     // Deprecated for backward compatibility
 
     /** @brief Type-safe access to PhysicsRelaxationIterations configuration. */
@@ -451,6 +474,46 @@ namespace pixelroot32::platforms::config {
 
     /** @brief Type-safe access to EnableSceneTransitions configuration. */
     inline constexpr bool EnableSceneTransitions = false;
+    #endif
+
+    #if PIXELROOT32_ENABLE_GAMEPLAY_EVENTS
+
+    /** @brief Type-safe access to EnableGameplayEvents configuration. */
+    inline constexpr bool EnableGameplayEvents = true;
+    #else
+
+    /** @brief Type-safe access to EnableGameplayEvents configuration. */
+    inline constexpr bool EnableGameplayEvents = false;
+    #endif
+
+    #if PIXELROOT32_ENABLE_INTERACTION_TRIGGERS
+
+    /** @brief Type-safe access to EnableInteractionTriggers configuration. */
+    inline constexpr bool EnableInteractionTriggers = true;
+    #else
+
+    /** @brief Type-safe access to EnableInteractionTriggers configuration. */
+    inline constexpr bool EnableInteractionTriggers = false;
+    #endif
+
+    #if PIXELROOT32_ENABLE_SPATIAL_QUERY
+
+    /** @brief Type-safe access to EnableSpatialQuery configuration. */
+    inline constexpr bool EnableSpatialQuery = true;
+    #else
+
+    /** @brief Type-safe access to EnableSpatialQuery configuration. */
+    inline constexpr bool EnableSpatialQuery = false;
+    #endif
+
+    #if PIXELROOT32_ENABLE_DEPTH_SORT
+
+    /** @brief Type-safe access to EnableDepthSort configuration. */
+    inline constexpr bool EnableDepthSort = true;
+    #else
+
+    /** @brief Type-safe access to EnableDepthSort configuration. */
+    inline constexpr bool EnableDepthSort = false;
     #endif
 
     inline unsigned long profilerMicros() {

--- a/include/platforms/PlatformDefaults.h
+++ b/include/platforms/PlatformDefaults.h
@@ -73,6 +73,35 @@
 #define PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE 1
 #endif
 
+// -----------------------------------------------------------------------------
+// Gameplay Framework Feature Defaults
+// -----------------------------------------------------------------------------
+// By default, the gameplay framework capabilities are disabled. No existing
+// example uses them, so games that do not opt in pay zero RAM/flash cost.
+#if !defined(PIXELROOT32_ENABLE_GAMEPLAY_EVENTS)
+#define PIXELROOT32_ENABLE_GAMEPLAY_EVENTS 0
+#endif
+
+#if !defined(PIXELROOT32_ENABLE_INTERACTION_TRIGGERS)
+#define PIXELROOT32_ENABLE_INTERACTION_TRIGGERS 0
+#endif
+
+#if !defined(PIXELROOT32_ENABLE_SPATIAL_QUERY)
+#define PIXELROOT32_ENABLE_SPATIAL_QUERY 0
+#endif
+
+#if !defined(PIXELROOT32_ENABLE_DEPTH_SORT)
+#define PIXELROOT32_ENABLE_DEPTH_SORT 0
+#endif
+
+// Interaction triggers and spatial queries are built on top of CollisionSystem
+// and SpatialGrid, which only exist when physics is enabled (see
+// include/core/Scene.h:213-216). Fail the build loudly instead of silently
+// disabling the flag.
+#if (PIXELROOT32_ENABLE_INTERACTION_TRIGGERS || PIXELROOT32_ENABLE_SPATIAL_QUERY) && !PIXELROOT32_ENABLE_PHYSICS
+#error "PIXELROOT32_ENABLE_INTERACTION_TRIGGERS and PIXELROOT32_ENABLE_SPATIAL_QUERY require PIXELROOT32_ENABLE_PHYSICS=1 (CollisionSystem and SpatialGrid only exist when physics is enabled)"
+#endif
+
 // =============================================================================
 // Target-dependent feature defaults
 // =============================================================================


### PR DESCRIPTION
## Summary

PR 1 of 6 in a stacked chain implementing Phase 1 of an audit-driven Gameplay Framework (see `docs/audits/topdown-genre-capability-audit.md` and OpenSpec change `gameplay-framework-phase1`, not committed to this repo per `.gitignore:100`).

This slice is the foundation: four new opt-in `PIXELROOT32_ENABLE_*` flags and their `constexpr` mirrors/capacities. No new logic, no new files — pure additive configuration, every flag defaults to `0`.

- `include/platforms/PlatformDefaults.h`: `PIXELROOT32_ENABLE_GAMEPLAY_EVENTS`, `_INTERACTION_TRIGGERS`, `_SPATIAL_QUERY`, `_DEPTH_SORT` (all default `0`), plus a compile-time `#error` guard when `_INTERACTION_TRIGGERS` or `_SPATIAL_QUERY` is enabled without `PIXELROOT32_ENABLE_PHYSICS` (both depend on `CollisionSystem`/`SpatialGrid`, which only exist under physics).
- `include/platforms/EngineConfig.h`: matching `constexpr bool` mirrors under `pixelroot32::platforms::config`, plus three capacity macros/mirrors — `GAMEPLAY_EVENT_QUEUE_CAPACITY` (32), `GAMEPLAY_MAX_INTERACTIVE_ACTORS` (16), `SPATIAL_QUERY_MAX_RADIUS` (128).

## Dependency chain

```
PR 1 (this PR): Foundation / Feature Flags        📍
PR 2: Gameplay Event Bus            (branches off PR 1)
PR 3: Actor Interaction Triggers    (branches off PR 2)
PR 4: Spatial Area Query            (branches off PR 3)
PR 5: Scene Depth Sort              (branches off PR 4)
PR 6: Cross-Cutting Verification    (branches off PR 5)
```

## Test plan

- Native build verification was performed on the maintainer's machine, not in the implementing session — the implementing session's sandbox has a broken native toolchain (`g++`/`cc1plus.exe` subprocess invocations exit non-zero with zero diagnostics, reproduced identically on the unmodified baseline).
- Full `pio test -e native_test` run on the maintainer's machine: 1579 test cases, 1574 succeeded, 4 skipped, 1 ERRORED (`test_background_palette_render_integration`).
- That single ERRORED result was isolated and confirmed pre-existing/unrelated to this diff: running it alone with this diff stashed passed (4/4), and running it alone with this diff present also passed (4/4) — a transient flake/resource-contention issue specific to the full sequential run, not caused by this change.
- This change is pure macro/constexpr addition with every new flag defaulting to `0`; no existing example or test path is reachable through the new flags at their default.