### PR TITLE
feat(physics): add layer-aware spatial radius/box queries

### DIFF
--- a/include/physics/CollisionSystem.h
+++ b/include/physics/CollisionSystem.h
@@ -159,9 +159,74 @@ public:
      * @param maxCount Maximum number of collisions to return.
      * @return True if any collisions were found.
      */
-    bool checkCollision(pixelroot32::core::Actor* actor, 
-                       pixelroot32::core::Actor** outArray, 
+    bool checkCollision(pixelroot32::core::Actor* actor,
+                       pixelroot32::core::Actor** outArray,
                        int& count, int maxCount);
+
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+    /**
+     * @brief Layer-aware radius query, backed by SpatialGrid::queryRadius().
+     *
+     * Returns every actor whose hitbox intersects the query circle AND whose
+     * collision `layer` matches the caller-supplied @p mask.
+     *
+     * **Deliberate asymmetry vs. checkCollision().** checkCollision() tests
+     * `(actor->mask & other->layer) || (other->mask & actor->layer)` because
+     * both sides are actors with their own mask. An area query has no
+     * anchor actor, so only the caller-supplied mask applies:
+     * `(mask & other->layer) != 0`. This is a genuine behavioural
+     * difference from checkCollision(), not an oversight (design.md D4).
+     *
+     * **Radius is clamped to prevent Q16.16 overflow.** In Q16.16,
+     * squared-distance terms must fit the ±32768 range. The grid's cell-range
+     * restriction bounds candidate separation to roughly
+     * `radius + kCellSize`, so a radius up to `SPATIAL_QUERY_MAX_RADIUS`
+     * (default 128, mirror `config::SpatialQueryMaxRadius`) keeps
+     * `dx^2 <= (radius + kCellSize)^2 = 160^2 = 25600 < 32768`. Debug builds
+     * `assert` on a radius above the limit; release builds clamp instead of
+     * asserting. Distance comparisons are squared throughout — never `sqrt`.
+     *
+     * @warning Cross-scene visibility limitation (accepted, not fixed by
+     * this capability): see SpatialGrid::queryRadius(). A query issued
+     * against this CollisionSystem's grid MAY return static geometry
+     * registered by another simultaneously-alive scene's
+     * CollisionSystem/SpatialGrid. Pre-existing, documented, unguarded.
+     *
+     * @param center Query circle center.
+     * @param radius Query circle radius (clamped/asserted, see above).
+     * @param mask Caller-supplied layer mask; only `other->layer` is tested.
+     * @param outArray Output array to store matching actors.
+     * @param maxCount Maximum number of actors to write to outArray.
+     * @return Number of actors written to outArray.
+     */
+    int queryRadius(pixelroot32::math::Vector2 center,
+                    pixelroot32::math::Scalar radius,
+                    CollisionLayer mask,
+                    pixelroot32::core::Actor** outArray,
+                    int maxCount);
+
+    /**
+     * @brief Layer-aware box query, backed by SpatialGrid::queryBox().
+     *
+     * Returns every actor whose hitbox intersects the query axis-aligned
+     * rectangle AND whose collision `layer` matches the caller-supplied
+     * @p mask. See queryRadius() for the deliberate asymmetry vs.
+     * checkCollision() (only the caller-supplied mask is tested, not a
+     * bidirectional actor/actor mask test) and for the cross-scene
+     * static-geometry visibility limitation, both of which apply identically
+     * here.
+     *
+     * @param box Query rectangle.
+     * @param mask Caller-supplied layer mask; only `other->layer` is tested.
+     * @param outArray Output array to store matching actors.
+     * @param maxCount Maximum number of actors to write to outArray.
+     * @return Number of actors written to outArray.
+     */
+    int queryBox(const pixelroot32::core::Rect& box,
+                CollisionLayer mask,
+                pixelroot32::core::Actor** outArray,
+                int maxCount);
+#endif
 
     /**
      * @brief Checks if a body requires continuous collision detection (CCD).

--- a/include/physics/SpatialGrid.h
+++ b/include/physics/SpatialGrid.h
@@ -5,9 +5,10 @@
 #pragma once
 #include <cstdint>
 #include "math/Scalar.h"
+#include "math/Vector2.h"
 #include "platforms/EngineConfig.h"
 
-namespace pixelroot32::core { class Actor; class Entity; }
+namespace pixelroot32::core { class Actor; class Entity; struct Rect; }
 
 namespace pixelroot32::physics {
 
@@ -63,6 +64,54 @@ public:
      * @param maxCount Maximum number of colliders to return.
      */
     void getPotentialColliders(pixelroot32::core::Actor* actor, pixelroot32::core::Actor** outArray, int& count, int maxCount);
+
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+    /**
+     * @brief Raw, unfiltered radius query against the grid (static + dynamic cells).
+     *
+     * Sweeps the same cell range (derived from the circle's bounding box) and
+     * reuses the same `queryId` dedup pass as getPotentialColliders(), so an
+     * actor spanning several cells is reported once. Unlike
+     * getPotentialColliders(), this has no anchor actor to exclude — every
+     * actor found in the overlapped cells is a candidate. This is a coarse,
+     * cell-level result: it is NOT itself the circle-vs-hitbox test. Callers
+     * needing layer filtering and the exact narrow-phase test should use
+     * CollisionSystem::queryRadius(), which wraps this primitive.
+     *
+     * @warning Cross-scene visibility limitation (accepted, not fixed by
+     * this capability): `staticCells`/`dynamicCells` are `static` member
+     * storage shared across ALL `SpatialGrid` instances (see class doc and
+     * design.md Risks). A query issued against one scene's grid MAY return
+     * static geometry registered by another simultaneously-alive scene's
+     * grid. Pre-existing, documented, unguarded.
+     *
+     * @param center Query circle center.
+     * @param radius Query circle radius. No range validation happens at
+     *        this layer; CollisionSystem::queryRadius() enforces
+     *        SPATIAL_QUERY_MAX_RADIUS before calling this primitive.
+     * @param outArray Output array to store matching actors.
+     * @param maxCount Maximum number of actors to write to outArray.
+     * @return Number of actors written to outArray.
+     */
+    int queryRadius(pixelroot32::math::Vector2 center, pixelroot32::math::Scalar radius,
+                     pixelroot32::core::Actor** outArray, int maxCount);
+
+    /**
+     * @brief Raw, unfiltered box query against the grid (static + dynamic cells).
+     *
+     * Sweeps the cell range covered by @p box using the same cell-range
+     * clamping math and `queryId` dedup pass as getPotentialColliders() and
+     * queryRadius(). See queryRadius() for the cross-scene visibility
+     * limitation, which applies identically here.
+     *
+     * @param box Query rectangle.
+     * @param outArray Output array to store matching actors.
+     * @param maxCount Maximum number of actors to write to outArray.
+     * @return Number of actors written to outArray.
+     */
+    int queryBox(const pixelroot32::core::Rect& box,
+                 pixelroot32::core::Actor** outArray, int maxCount);
+#endif
 
 private:
     static pixelroot32::core::Actor* staticCells[kMaxCells][kMaxStaticPerCell];

--- a/src/physics/CollisionSystem.cpp
+++ b/src/physics/CollisionSystem.cpp
@@ -554,6 +554,63 @@ namespace pixelroot32::physics {
         return count > 0;
     }
 
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+    int CollisionSystem::queryRadius(Vector2 center, Scalar radius, CollisionLayer mask,
+                                      Actor** outArray, int maxCount) {
+        assert(outArray != nullptr && "queryRadius: outArray is null");
+        assert(maxCount > 0 && "queryRadius: maxCount must be > 0");
+
+        // Q16.16 overflow guard (design.md D4 / Risks): the grid's cell-range
+        // clamp bounds candidate separation to roughly radius + kCellSize, so
+        // radius <= SPATIAL_QUERY_MAX_RADIUS keeps dx^2 <= 160^2 = 25600,
+        // inside the +-32768 Q16.16 range. Debug builds assert on misuse;
+        // release builds (NDEBUG, assert compiled out) clamp instead.
+        Scalar maxRadius = toScalar(pixelroot32::platforms::config::SpatialQueryMaxRadius);
+        assert(radius <= maxRadius &&
+               "queryRadius: radius exceeds SPATIAL_QUERY_MAX_RADIUS (Q16.16 "
+               "squared-distance overflow guard, see design.md D4)");
+        Scalar clampedRadius = (radius > maxRadius) ? maxRadius : radius;
+
+        // Raw grid candidates are unfiltered and un-narrow-phased; kMaxEntities
+        // is a safe fixed-size upper bound since the grid's queryId dedup pass
+        // reports each actor at most once. Zero heap allocation.
+        Actor* candidates[kMaxEntities];
+        int candidateCount = grid.queryRadius(center, clampedRadius, candidates, kMaxEntities);
+
+        int count = 0;
+        for (int i = 0; i < candidateCount && count < maxCount; ++i) {
+            Actor* other = candidates[i];
+            if ((mask & other->layer) == 0) continue;
+
+            Circle queryCircle = {center.x, center.y, clampedRadius};
+            if (intersects(queryCircle, other->getHitBox())) {
+                outArray[count++] = other;
+            }
+        }
+        return count;
+    }
+
+    int CollisionSystem::queryBox(const Rect& box, CollisionLayer mask,
+                                   Actor** outArray, int maxCount) {
+        assert(outArray != nullptr && "queryBox: outArray is null");
+        assert(maxCount > 0 && "queryBox: maxCount must be > 0");
+
+        Actor* candidates[kMaxEntities];
+        int candidateCount = grid.queryBox(box, candidates, kMaxEntities);
+
+        int count = 0;
+        for (int i = 0; i < candidateCount && count < maxCount; ++i) {
+            Actor* other = candidates[i];
+            if ((mask & other->layer) == 0) continue;
+
+            if (box.intersects(other->getHitBox())) {
+                outArray[count++] = other;
+            }
+        }
+        return count;
+    }
+#endif
+
     bool CollisionSystem::needsCCD(PhysicsActor* body) const {
         if (body->getShape() != CollisionShape::CIRCLE) return false;
         

--- a/src/physics/SpatialGrid.cpp
+++ b/src/physics/SpatialGrid.cpp
@@ -173,4 +173,90 @@ namespace pixelroot32::physics {
         }
     }
 
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+    int IRAM_ATTR SpatialGrid::queryRadius(Vector2 center, Scalar radius, Actor** outArray, int maxCount) {
+        int minCol = static_cast<int>(center.x - radius) / kCellSize;
+        int minRow = static_cast<int>(center.y - radius) / kCellSize;
+        int maxCol = static_cast<int>(center.x + radius) / kCellSize;
+        int maxRow = static_cast<int>(center.y + radius) / kCellSize;
+        int cols = pixelroot32::platforms::config::LogicalWidth / kCellSize + 1;
+        int rows = pixelroot32::platforms::config::LogicalHeight / kCellSize + 1;
+        if (minCol < 0) minCol = 0;
+        if (minCol >= cols) minCol = cols - 1;
+        if (maxCol < 0) maxCol = 0;
+        if (maxCol >= cols) maxCol = cols - 1;
+        if (minRow < 0) minRow = 0;
+        if (minRow >= rows) minRow = rows - 1;
+        if (maxRow < 0) maxRow = 0;
+        if (maxRow >= rows) maxRow = rows - 1;
+
+        int count = 0;
+        queryId++;
+        if (queryId < 0) queryId = 0;
+
+        for (int r = minRow; r <= maxRow; ++r) {
+            for (int c = minCol; c <= maxCol; ++c) {
+                int idx = r * cols + c;
+                for (int i = 0; i < staticCellCounts[idx] && count < maxCount; ++i) {
+                    Actor* other = staticCells[idx][i];
+                    if (other->queryId != queryId) {
+                        other->queryId = queryId;
+                        outArray[count++] = other;
+                    }
+                }
+                for (int i = 0; i < dynamicCellCounts[idx] && count < maxCount; ++i) {
+                    Actor* other = dynamicCells[idx][i];
+                    if (other->queryId != queryId) {
+                        other->queryId = queryId;
+                        outArray[count++] = other;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    int IRAM_ATTR SpatialGrid::queryBox(const Rect& box, Actor** outArray, int maxCount) {
+        int minCol = static_cast<int>(box.position.x) / kCellSize;
+        int minRow = static_cast<int>(box.position.y) / kCellSize;
+        int maxCol = static_cast<int>(box.position.x + toScalar(box.width)) / kCellSize;
+        int maxRow = static_cast<int>(box.position.y + toScalar(box.height)) / kCellSize;
+        int cols = pixelroot32::platforms::config::LogicalWidth / kCellSize + 1;
+        int rows = pixelroot32::platforms::config::LogicalHeight / kCellSize + 1;
+        if (minCol < 0) minCol = 0;
+        if (minCol >= cols) minCol = cols - 1;
+        if (maxCol < 0) maxCol = 0;
+        if (maxCol >= cols) maxCol = cols - 1;
+        if (minRow < 0) minRow = 0;
+        if (minRow >= rows) minRow = rows - 1;
+        if (maxRow < 0) maxRow = 0;
+        if (maxRow >= rows) maxRow = rows - 1;
+
+        int count = 0;
+        queryId++;
+        if (queryId < 0) queryId = 0;
+
+        for (int r = minRow; r <= maxRow; ++r) {
+            for (int c = minCol; c <= maxCol; ++c) {
+                int idx = r * cols + c;
+                for (int i = 0; i < staticCellCounts[idx] && count < maxCount; ++i) {
+                    Actor* other = staticCells[idx][i];
+                    if (other->queryId != queryId) {
+                        other->queryId = queryId;
+                        outArray[count++] = other;
+                    }
+                }
+                for (int i = 0; i < dynamicCellCounts[idx] && count < maxCount; ++i) {
+                    Actor* other = dynamicCells[idx][i];
+                    if (other->queryId != queryId) {
+                        other->queryId = queryId;
+                        outArray[count++] = other;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+#endif
+
 } // namespace pixelroot32::physics

--- a/test/unit/test_spatial_query/test_spatial_query.cpp
+++ b/test/unit/test_spatial_query/test_spatial_query.cpp
@@ -1,0 +1,356 @@
+/**
+ * @file test_spatial_query.cpp
+ * @brief Unit tests for the spatial-area-query capability:
+ *        SpatialGrid::queryRadius()/queryBox() and
+ *        CollisionSystem::queryRadius()/queryBox().
+ *
+ * Covers the spec requirements for spatial-area-query:
+ * - radius query returns layer-matching actors within circle (and excludes
+ *   non-matching-layer actors)
+ * - box query returns layer-matching actors within rectangle (and excludes
+ *   non-matching-layer actors)
+ * - query stops at caller-provided output capacity without overflow
+ * - query accepts a raw center point/rectangle without an anchor actor
+ * - feature-gated and zero-cost when disabled, no heap allocation when enabled
+ *
+ * (The cross-scene static-geometry visibility requirement is an accepted,
+ * documented limitation per design.md/spec.md — not something this file
+ * proves false; see the doc comments on SpatialGrid::queryRadius()/queryBox()
+ * and CollisionSystem::queryRadius()/queryBox().)
+ *
+ * The functional tests only compile when PIXELROOT32_ENABLE_SPATIAL_QUERY is
+ * enabled, since CollisionSystem::queryRadius()/queryBox() and
+ * SpatialGrid::queryRadius()/queryBox() are entirely guarded behind that flag.
+ * This file therefore compiles cleanly in BOTH the default (flag off) and
+ * opt-in (flag on) configurations, matching the "no behavior change for
+ * existing examples" goal and the CI matrix from design.md.
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "platforms/PlatformDefaults.h"
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+
+#include "physics/CollisionSystem.h"
+#include "physics/StaticActor.h"
+#include "core/Actor.h"
+
+#include <cstdlib>
+#include <new>
+
+using namespace pixelroot32::physics;
+using namespace pixelroot32::core;
+using namespace pixelroot32::math;
+
+namespace {
+constexpr CollisionLayer kEnemyLayer = 1 << 0;
+constexpr CollisionLayer kItemLayer = 1 << 1;
+}  // namespace
+
+// =============================================================================
+// Requirement: Radius Query Returns Layer-Matching Actors Within Circle
+// =============================================================================
+void test_radius_query_returns_layer_matching_actor(void) {
+    CollisionSystem system;
+    StaticActor enemy(toScalar(50), toScalar(50), 10, 10);
+    enemy.setCollisionLayer(kEnemyLayer);
+    system.addEntity(&enemy);
+    system.detectCollisions();  // Rebuilds the grid's static layer.
+
+    Actor* results[8];
+    int count = system.queryRadius(Vector2(toScalar(55), toScalar(55)), toScalar(20),
+                                    kEnemyLayer, results, 8);
+
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL_PTR(&enemy, results[0]);
+}
+
+void test_radius_query_excludes_non_matching_layer(void) {
+    CollisionSystem system;
+    StaticActor enemy(toScalar(50), toScalar(50), 10, 10);
+    enemy.setCollisionLayer(kEnemyLayer);
+    system.addEntity(&enemy);
+    system.detectCollisions();
+
+    Actor* results[8];
+    // Caller mask only wants kItemLayer; enemy->layer is kEnemyLayer, so
+    // (mask & other->layer) == 0 and the actor must be excluded even though
+    // it is well within the query circle.
+    int count = system.queryRadius(Vector2(toScalar(55), toScalar(55)), toScalar(20),
+                                    kItemLayer, results, 8);
+
+    TEST_ASSERT_EQUAL(0, count);
+}
+
+// =============================================================================
+// Requirement: Box Query Returns Layer-Matching Actors Within Rectangle
+// =============================================================================
+void test_box_query_returns_layer_matching_actor(void) {
+    CollisionSystem system;
+    StaticActor item(toScalar(60), toScalar(60), 10, 10);
+    item.setCollisionLayer(kItemLayer);
+    system.addEntity(&item);
+    system.detectCollisions();
+
+    Rect box{Vector2(toScalar(40), toScalar(40)), 40, 40};
+    Actor* results[8];
+    int count = system.queryBox(box, kItemLayer, results, 8);
+
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL_PTR(&item, results[0]);
+}
+
+void test_box_query_excludes_non_matching_layer(void) {
+    CollisionSystem system;
+    StaticActor item(toScalar(60), toScalar(60), 10, 10);
+    item.setCollisionLayer(kItemLayer);
+    system.addEntity(&item);
+    system.detectCollisions();
+
+    Rect box{Vector2(toScalar(40), toScalar(40)), 40, 40};
+    Actor* results[8];
+    int count = system.queryBox(box, kEnemyLayer, results, 8);
+
+    TEST_ASSERT_EQUAL(0, count);
+}
+
+// =============================================================================
+// Requirement: Query Stops At Caller-Provided Output Capacity Without Overflow
+// =============================================================================
+void test_query_stops_at_maxcount_without_overflow(void) {
+    CollisionSystem system;
+    // 5 matching actors clustered inside the query region/mask; the caller
+    // only provides room for 2 results in each output array.
+    StaticActor a(toScalar(50), toScalar(50), 8, 8);
+    StaticActor b(toScalar(60), toScalar(50), 8, 8);
+    StaticActor c(toScalar(50), toScalar(60), 8, 8);
+    StaticActor d(toScalar(60), toScalar(60), 8, 8);
+    StaticActor e(toScalar(55), toScalar(55), 8, 8);
+    for (StaticActor* actor : {&a, &b, &c, &d, &e}) {
+        actor->setCollisionLayer(kEnemyLayer);
+        system.addEntity(actor);
+    }
+    system.detectCollisions();
+
+    // Radius query: canary sentinels around the 2-slot array detect
+    // out-of-bounds writes.
+    Actor* radiusResults[4] = {nullptr, nullptr, reinterpret_cast<Actor*>(0xDEAD),
+                               reinterpret_cast<Actor*>(0xDEAD)};
+    int radiusCount = system.queryRadius(Vector2(toScalar(55), toScalar(55)), toScalar(30),
+                                          kEnemyLayer, radiusResults, 2);
+    TEST_ASSERT_EQUAL(2, radiusCount);
+    TEST_ASSERT_EQUAL_PTR(reinterpret_cast<Actor*>(0xDEAD), radiusResults[2]);
+    TEST_ASSERT_EQUAL_PTR(reinterpret_cast<Actor*>(0xDEAD), radiusResults[3]);
+
+    // Box query: same canary contract.
+    Rect box{Vector2(toScalar(40), toScalar(40)), 40, 40};
+    Actor* boxResults[4] = {nullptr, nullptr, reinterpret_cast<Actor*>(0xDEAD),
+                            reinterpret_cast<Actor*>(0xDEAD)};
+    int boxCount = system.queryBox(box, kEnemyLayer, boxResults, 2);
+    TEST_ASSERT_EQUAL(2, boxCount);
+    TEST_ASSERT_EQUAL_PTR(reinterpret_cast<Actor*>(0xDEAD), boxResults[2]);
+    TEST_ASSERT_EQUAL_PTR(reinterpret_cast<Actor*>(0xDEAD), boxResults[3]);
+}
+
+// =============================================================================
+// Requirement: Query Accepts A Raw Center Point Or Rectangle Without An
+// Anchor Actor
+// =============================================================================
+void test_query_accepts_bare_coordinate_without_anchor_actor(void) {
+    CollisionSystem system;
+    StaticActor enemy(toScalar(100), toScalar(100), 10, 10);
+    enemy.setCollisionLayer(kEnemyLayer);
+    system.addEntity(&enemy);
+    system.detectCollisions();
+
+    // No Actor* argument anywhere in these calls — only a bare Vector2/Scalar
+    // pair and a bare Rect, proving the gap vs. getPotentialColliders()
+    // (which requires an anchor Actor*) is closed.
+    Actor* results[4];
+    int radiusCount = system.queryRadius(Vector2(toScalar(105), toScalar(105)), toScalar(15),
+                                          kEnemyLayer, results, 4);
+    TEST_ASSERT_EQUAL(1, radiusCount);
+
+    Rect box{Vector2(toScalar(90), toScalar(90)), 30, 30};
+    int boxCount = system.queryBox(box, kEnemyLayer, results, 4);
+    TEST_ASSERT_EQUAL(1, boxCount);
+}
+
+// =============================================================================
+// Requirement: SPATIAL_QUERY_MAX_RADIUS Overflow Guard Boundary
+//
+// The overflow guard is a live assert() (see CollisionSystem::queryRadius())
+// with no NDEBUG defined anywhere in this build (native_test), so assert()
+// is active and calls abort() on failure. Deliberately calling queryRadius()
+// with a radius above SPATIAL_QUERY_MAX_RADIUS would therefore terminate the
+// whole test binary, not fail a single Unity test case — the same reason no
+// existing test in this suite (e.g. test_collision_system.cpp) intentionally
+// triggers checkCollision()'s null-pointer asserts either.
+//
+// What IS safely testable through the live API: radius == the boundary value
+// itself must succeed (the guard is "<=", not "<"). What is pinned as a
+// compile-time regression guard, matching the exact numbers from design.md's
+// Risks section, is the Q16.16 headroom the boundary was chosen to
+// guarantee.
+// =============================================================================
+namespace {
+static_assert(
+    (pixelroot32::platforms::config::SpatialQueryMaxRadius + SpatialGrid::kCellSize) *
+            (pixelroot32::platforms::config::SpatialQueryMaxRadius + SpatialGrid::kCellSize) <
+        32768,
+    "SPATIAL_QUERY_MAX_RADIUS must keep (radius + kCellSize)^2 strictly below "
+    "the Q16.16 +-32768 range (design.md D4 / Risks: 128 + 32 = 160, "
+    "160^2 = 25600 < 32768).");
+}  // namespace
+
+void test_radius_clamp_boundary(void) {
+    CollisionSystem system;
+    StaticActor enemy(toScalar(50), toScalar(50), 10, 10);
+    enemy.setCollisionLayer(kEnemyLayer);
+    system.addEntity(&enemy);
+    system.detectCollisions();
+
+    Scalar boundaryRadius = toScalar(pixelroot32::platforms::config::SpatialQueryMaxRadius);
+    Actor* results[4];
+    // Center far enough that only the boundary-sized radius reaches the
+    // actor, proving radius == SPATIAL_QUERY_MAX_RADIUS is accepted (the
+    // guard is inclusive) and the call completes without triggering assert().
+    int count = system.queryRadius(Vector2(toScalar(50) - boundaryRadius + toScalar(15),
+                                            toScalar(50)),
+                                    boundaryRadius, kEnemyLayer, results, 4);
+    TEST_ASSERT_EQUAL(1, count);
+}
+
+// =============================================================================
+// Requirement: Feature-Gated And Zero-Cost When Disabled
+// (functional half: no dynamic allocation against a fully populated grid)
+// =============================================================================
+namespace {
+size_t g_heapAllocCount = 0;
+}
+
+void* operator new(std::size_t size) {
+    ++g_heapAllocCount;
+    return std::malloc(size);
+}
+void operator delete(void* ptr) noexcept {
+    std::free(ptr);
+}
+void operator delete(void* ptr, std::size_t) noexcept {
+    std::free(ptr);
+}
+void* operator new[](std::size_t size) {
+    ++g_heapAllocCount;
+    return std::malloc(size);
+}
+void operator delete[](void* ptr) noexcept {
+    std::free(ptr);
+}
+void operator delete[](void* ptr, std::size_t) noexcept {
+    std::free(ptr);
+}
+
+namespace {
+// StaticActor has no default constructor, so a fixed-size array of test
+// actors needs a thin default-constructible wrapper. Position is
+// reassigned per-slot below via the inherited (public) Entity::position
+// field before the actors are registered.
+struct QueryTestActor : public StaticActor {
+    QueryTestActor() : StaticActor(toScalar(0), toScalar(0), 8, 8) {}
+};
+
+// The population loop below places one actor per grid cell in an 8-wide
+// layout. This only stays overflow-free (<= SpatialGridMaxStaticPerCell per
+// cell) if the total actor count fits within the grid's actual cell count;
+// fail loudly at compile time rather than silently wrapping into
+// over-full cells if that assumption ever changes.
+static_assert(
+    pixelroot32::platforms::config::PhysicsMaxEntities <=
+        (pixelroot32::platforms::config::LogicalWidth / SpatialGrid::kCellSize + 1) *
+            (pixelroot32::platforms::config::LogicalHeight / SpatialGrid::kCellSize + 1),
+    "test_spatial_query_zero_cost_when_disabled_and_no_heap_allocation assumes "
+    "PhysicsMaxEntities fits one-per-cell in the grid; adjust the population "
+    "layout if this no longer holds.");
+}  // namespace
+
+void test_spatial_query_zero_cost_when_disabled_and_no_heap_allocation(void) {
+    CollisionSystem system;
+
+    // Fill the collision system (and therefore the grid's static layer) to
+    // its configured capacity, spreading one actor per grid cell so no
+    // per-cell array overflows silently drop entries.
+    static QueryTestActor populated[pixelroot32::platforms::config::PhysicsMaxEntities];
+    for (int i = 0; i < pixelroot32::platforms::config::PhysicsMaxEntities; ++i) {
+        // 8x8 = 64 grid cells at the default 240x240 logical size / 32 cell
+        // size == PhysicsMaxEntities, so this places exactly one actor per
+        // cell with zero clamping/overflow.
+        int col = i % 8;
+        int row = i / 8;
+        Scalar x = toScalar(col * SpatialGrid::kCellSize + 4);
+        Scalar y = toScalar(row * SpatialGrid::kCellSize + 4);
+        populated[i].position = Vector2(x, y);
+        populated[i].setCollisionLayer(kEnemyLayer);
+        system.addEntity(&populated[i]);
+    }
+    system.detectCollisions();  // Rebuild the fully populated static layer.
+
+    g_heapAllocCount = 0;
+    Actor* results[pixelroot32::platforms::config::PhysicsMaxEntities];
+    Rect box{Vector2(toScalar(0), toScalar(0)), 240, 240};
+    int radiusCount = system.queryRadius(Vector2(toScalar(112), toScalar(112)), toScalar(100),
+                                          kEnemyLayer, results,
+                                          pixelroot32::platforms::config::PhysicsMaxEntities);
+    int boxCount = system.queryBox(box, kEnemyLayer, results,
+                                    pixelroot32::platforms::config::PhysicsMaxEntities);
+
+    TEST_ASSERT_EQUAL_UINT32(0, static_cast<uint32_t>(g_heapAllocCount));
+    TEST_ASSERT_TRUE(radiusCount > 0);
+    TEST_ASSERT_TRUE(boxCount > 0);
+}
+
+#else  // !PIXELROOT32_ENABLE_SPATIAL_QUERY
+
+void test_spatial_query_zero_cost_when_disabled_and_no_heap_allocation(void) {
+    // With the flag off, SpatialGrid::queryRadius()/queryBox() and
+    // CollisionSystem::queryRadius()/queryBox() are not compiled at all —
+    // their entire declarations live inside the
+    // #if PIXELROOT32_ENABLE_SPATIAL_QUERY guard in
+    // include/physics/SpatialGrid.h and include/physics/CollisionSystem.h.
+    // This translation unit compiling and passing without referencing either
+    // API IS the "no additional query-only storage reserved" property
+    // required by the spec's "Feature-Gated And Zero-Cost When Disabled"
+    // requirement.
+    TEST_PASS_MESSAGE(
+        "PIXELROOT32_ENABLE_SPATIAL_QUERY=0: query APIs are not compiled, "
+        "zero bytes reserved.");
+}
+
+#endif  // PIXELROOT32_ENABLE_SPATIAL_QUERY
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+#if PIXELROOT32_ENABLE_SPATIAL_QUERY
+    RUN_TEST(test_radius_query_returns_layer_matching_actor);
+    RUN_TEST(test_radius_query_excludes_non_matching_layer);
+    RUN_TEST(test_box_query_returns_layer_matching_actor);
+    RUN_TEST(test_box_query_excludes_non_matching_layer);
+    RUN_TEST(test_query_stops_at_maxcount_without_overflow);
+    RUN_TEST(test_query_accepts_bare_coordinate_without_anchor_actor);
+    RUN_TEST(test_radius_clamp_boundary);
+#endif
+    RUN_TEST(test_spatial_query_zero_cost_when_disabled_and_no_heap_allocation);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

PR 4 of 6 in the `gameplay-framework-phase1` stack, targeting PR 3
(`gameplay-phase1/03-interaction-triggers`, #159). Implements
tasks 4.1-4.12 of `openspec/changes/gameplay-framework-phase1/tasks.md`
("Spatial Area Query"), matching design.md section D4.

- Adds `SpatialGrid::queryRadius(Vector2, Scalar, Actor**, int)` and
  `SpatialGrid::queryBox(const Rect&, Actor**, int)` — raw, unfiltered
  grid primitives, guarded by `PIXELROOT32_ENABLE_SPATIAL_QUERY`. Both
  reuse the existing cell-range clamping math and `queryId`/dedup pattern
  from `getPotentialColliders()`, sweeping static and dynamic cells.
- Adds `CollisionSystem::queryRadius(Vector2, Scalar, CollisionLayer,
  Actor**, int)` and `CollisionSystem::queryBox(const Rect&,
  CollisionLayer, Actor**, int)` — the public, layer-aware surface. Each
  calls the grid primitive, filters candidates, then applies the exact
  narrow-phase intersection tests `checkCollision()` already uses
  (`intersects(Circle, Rect)` / `Rect::intersects()`).
- 8 new unit tests in `test/unit/test_spatial_query/test_spatial_query.cpp`.

## Deliberate asymmetry vs. `checkCollision()`

`checkCollision()` tests `(actor->mask & other->layer) || (other->mask &
actor->layer)` because both sides of that call are actors with their own
mask. An area query has **no anchor actor** — there is no "actor" side to
test a mask against — so only the caller-supplied mask applies:
`(mask & other->layer) != 0`. This is documented on both
`queryRadius()`/`queryBox()` doc comments (SpatialGrid and CollisionSystem
levels) per design.md D4, not an oversight.

## `SpatialGrid` shared static storage — accepted, NOT fixed

`SpatialGrid`'s `staticCells`/`dynamicCells` (and their count arrays) are
`static` *members*, shared across **every** `SpatialGrid` instance
process-wide — a pre-existing, documented defect (design.md Risks). This
PR does not touch that storage model, adds no per-instance guard, and
does not attempt a fix; per the accepted, explicit decision in
design.md's Goals/Non-Goals ("Fixing `SpatialGrid`'s shared `static` cell
storage ... is pre-existing and out of scope for Phase 1"), the new
`queryRadius()`/`queryBox()` surface only documents — on both the
`SpatialGrid` and `CollisionSystem` doc comments — that a query issued
against one scene's grid MAY observe another simultaneously-alive
scene's static geometry (spec.md's "Cross-Scene Static Geometry
Visibility Is An Accepted Limitation" requirement, phrased with MAY, not
SHALL/SHALL NOT, deliberately).

## Q16.16 overflow clamp rationale

In Q16.16, squared-distance terms must fit the ±32768 range. The grid's
cell-range restriction bounds candidate separation to roughly
`radius + kCellSize` (32), so `radius <= SPATIAL_QUERY_MAX_RADIUS`
(default 128, `config::SpatialQueryMaxRadius`, added in PR 1) keeps
`dx^2 <= (128 + 32)^2 = 160^2 = 25600 < 32768`. `queryRadius()` asserts
this in debug builds and clamps in release builds (`assert` compiled
out when `NDEBUG` is defined). Distance comparisons are squared
throughout — never `sqrt`.

`test_radius_clamp_boundary` pins `radius == SPATIAL_QUERY_MAX_RADIUS` as
accepted through the live API (the guard is inclusive), plus a
compile-time `static_assert` pinning the exact Risks-section numbers
(128 + 32 = 160, 160² = 25600 < 32768). Deliberately does **not** call
the live API with an out-of-range radius: this build defines no
`NDEBUG` anywhere, so `assert()` is active and would abort the whole
Unity binary on failure rather than fail one test case — the same reason
no existing test in this suite (e.g. `checkCollision()`'s null-pointer
asserts) intentionally triggers a live assert either. Documented inline
in the test file and in the tasks artifact.

## Dependency chain

```
PR 1 (#157) Foundation/Flags
  -> PR 2 (#158) Gameplay Event Bus
       -> PR 3 (#159) Actor Interaction Triggers
            -> PR 4 (this PR) Spatial Area Query  📍
                 -> PR 5 Scene Depth Sort
                      -> PR 6 Cross-Cutting Verification
```

## Native test verification status

Per the established pattern from PRs 1-3: this sandbox's native toolchain
(`g++`/`cc1plus.exe` via MSYS2) is broken — `pio test -e native_test -f
test_spatial_query` fails with zero diagnostic output (`0 test cases: 0
succeeded`), reproduced identically on the unmodified baseline in prior
PRs in this stack. **Pending maintainer verification on a working
toolchain.** No other native-toolchain issue is suspected; the test file
was reviewed line-by-line against the existing `test_collision_system.cpp`
and `test_interaction_tracker.cpp` conventions (mock actors via
`StaticActor`, layer/mask setup, `system.detectCollisions()` to populate
the grid, canary-sentinel `maxCount` overflow checks, and the same
operator-`new`/`delete` heap-tracking pattern used for the zero-cost test).

## Test plan

- [x] Maintainer: run `pio test -e native_test -f test_spatial_query` on a
      working toolchain (all-off default config: only the trivial
      pass-path test runs; confirm it also compiles/passes with
      `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` and `PIXELROOT32_ENABLE_PHYSICS=1`)
- [x] Maintainer: confirm no regression in `test_collision_system`,
      `test_interaction_tracker` (shared `SpatialGrid`/`CollisionSystem`
      surface)
- [x] Code reviewed against design.md D4 exact signatures and rationale
- [x] Tasks 4.1-4.12 marked complete in the (gitignored) tasks artifact