### PR TITLE
docs(gameplay): verify and document Gameplay Framework Phase 1 (6/6)

### DIFF
--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -51,6 +51,9 @@ Understanding the engine's memory limits is crucial for developing stable games 
 | **Max Static Per Cell** | 12 | ✅ via `SPATIAL_GRID_MAX_STATIC_PER_CELL` | Static layer capacity per cell |
 | **Max Dynamic Per Cell** | 12 | ✅ via `SPATIAL_GRID_MAX_DYNAMIC_PER_CELL` | Dynamic layer capacity per cell |
 | **Velocity Iterations** | 2 | ✅ via `PIXELROOT32_VELOCITY_ITERATIONS` | Physics solver iterations |
+| **Gameplay Event Queue Capacity** | 32 | ✅ via `GAMEPLAY_EVENT_QUEUE_CAPACITY` | Ring buffer slots for `gameplay::GameplayEventBus` (Gameplay Framework Phase 1) |
+| **Max Interactive Actors** | 16 | ✅ via `GAMEPLAY_MAX_INTERACTIVE_ACTORS` | Registry size for `gameplay::InteractionTracker` (Gameplay Framework Phase 1) |
+| **Spatial Query Max Radius** | 128 | ✅ via `SPATIAL_QUERY_MAX_RADIUS` | Clamp for `queryRadius()` to avoid Q16.16 squared-distance overflow (Gameplay Framework Phase 1) |
 
 **Modular Compilation Impact:**
 
@@ -63,6 +66,26 @@ When subsystems are disabled via `PIXELROOT32_ENABLE_*` flags, their memory allo
 | `PIXELROOT32_ENABLE_UI_SYSTEM=0` | ~4 KB | ~20 KB | UIElement, all layouts, UI containers |
 | `PIXELROOT32_ENABLE_PARTICLES=0` | ~6 KB | ~10 KB | ParticleEmitter, particle pools |
 | **All disabled** | **~30 KB** | **~70 KB** | Maximum savings |
+
+**Gameplay Framework Phase 1 flags (opt-in, default `0`):** unlike the flags above — which default to `1` because audio/physics/UI/particles are load-bearing for existing examples — these four capabilities are purely additive and default **off**, so none of the 15 existing examples pays their cost unless explicitly enabled:
+
+| Flag | Default | RAM Cost When Enabled | Subsystem Added |
+|------|---------|------------------------|------------------|
+| `PIXELROOT32_ENABLE_GAMEPLAY_EVENTS=1` | `0` | ~512 B (ESP32-C3) / ~768 B (native) | `gameplay::GameplayEventBus` — single-threaded, `Engine`-owned event ring buffer |
+| `PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1` | `0` | ~704 B (ESP32, `PHYSICS_MAX_CONTACTS=64`) / ~1.2 KB (native default 128) | `gameplay::InteractionTracker` — enter/exit edge detection over `CollisionSystem` contacts. Requires `PIXELROOT32_ENABLE_PHYSICS=1` |
+| `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` | `0` | 0 B extra static storage (adds methods only) | `SpatialGrid::queryRadius/queryBox` + `CollisionSystem::queryRadius/queryBox`. Requires `PIXELROOT32_ENABLE_PHYSICS=1` |
+| `PIXELROOT32_ENABLE_DEPTH_SORT=1` | `0` | ~8 B per `Scene` (comparator pointer + bool) | `Scene::depthComparator` / `depthSortEnabled` secondary sort key, used by `Scene::sortEntities()` |
+
+`PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1` or `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` combined with `PIXELROOT32_ENABLE_PHYSICS=0` fails the build at compile time via an `#error` in `PlatformDefaults.h` (`CollisionSystem` and `SpatialGrid` only exist when physics is enabled), rather than silently disabling the feature.
+
+**`GameplayEvent` byte budget (`GAMEPLAY_EVENT_QUEUE_CAPACITY` slots, default 32):**
+
+| Target | `void*` | `Scalar` | ids (2× `uint16_t`) | type tag | padding | `sizeof(GameplayEvent)` | Queue total |
+|--------|---------|----------|----------------------|----------|---------|--------------------------|-------------|
+| ESP32-C3 (32-bit, `Scalar` = `Fixed16`) | 4 B | 4 B | 4 B | 1 B | 3 B | **16 B** | **512 B** |
+| native/PC (64-bit, `Scalar` = `float`) | 8 B | 4 B | 4 B | 1 B | 7 B | **24 B** | **768 B** |
+
+**Non-atomic bus contract:** `gameplay::GameplayEventBus` is produced and consumed entirely inside the single-threaded `Scene::update()`/`Scene::draw()` loop driven from `SceneManager::update()`. Its head/tail/count indices are plain `uint16_t`, not `std::atomic` — unlike `AudioCommandQueue`, which bridges the game thread and the audio task. Publishing from an ISR or the audio task is **explicitly unsupported** and will corrupt the ring buffer's indices; it is not a replacement for `AudioCommandQueue`. Overflow policy is drop-newest with a monotonic `getDroppedCount()` diagnostic (preserves enter/exit pairing rather than risking a dangling `TriggerExit` for an evicted `TriggerEnter`). The bus is drained (`clear()`) on every `SceneManager::setCurrentScene()` call (including `SceneSwap` transitions), but **not** on `pushScene()`/`popScene()`, since a paused scene under an overlay never runs and should not lose events it expects to consume on resume.
 
 #### Subsystem Compilation Patterns
 


### PR DESCRIPTION
## Summary

PR 6 of 6 — the final PR closing the Gameplay Framework Phase 1 stacked chain (#157 → #158 → #159 → #160 → #161 → this one). This PR performs Cross-Cutting Verification (tasks 6.1–6.6 of `openspec/changes/gameplay-framework-phase1/tasks.md`) across all four capabilities added by the prior five PRs: the gameplay event bus, actor interaction triggers, spatial area query, and scene depth sort.

This PR contains **documentation only** — updating `docs/architecture/memory-system.md` with the four new flags, their capacity macros, `GameplayEvent` byte budgets, and the non-atomic single-threaded bus contract — plus marking tasks 6.1–6.6 complete in the (gitignored, local-only) tasks tracker. No engine source changes. All verification below was executed by the maintainer on their own machine (this sandbox has a known broken native C++ toolchain — `g++`/`cc1plus.exe` fail silently even on the unmodified baseline — so no build/test was re-run in this session).

## Dependency chain

```
#157 (01-foundation-flags) -> #158 (02-event-bus) -> #159 (03-interaction-triggers) -> #160 (04-spatial-query) -> #161 (05-depth-sort) -> 📍 this PR (06-verification)
```

All five prior PRs are open (not yet merged). Once this chain merges, in order, `feature/top-down-games` will have the complete audit-driven Gameplay Framework Phase 1 (event bus, interaction triggers, spatial query, depth sort). Originating audit: `docs/audits/topdown-genre-capability-audit.md`.

## Verification evidence (tasks 6.1-6.6)

**6.1 - All 15 examples, default flags (`0`):** All 15 examples under `examples/` (2048, animated_tilemap, brick_breaker, camera, camera-effect-demo, dual_palette, flappy_bird, hello_world, metroidvania, music-demo, physics, snake, space_invaders, sprites, tic_tac_toe) built successfully via `pio run -e native` against the `gameplay-phase1/05-depth-sort` tree (each references the engine via `symlink://../../`, a real test against these changes). Zero build failures — confirms no behavior/compile change for any existing example with the four new flags at their default.

**6.2 - All-off (default) `native_test` run:** 1604 test cases collected (65 test binaries), 1599 succeeded, 4 skipped, 1 ERRORED (`test_background_palette_render_integration` — a PlatformIO tooling race condition, not a code defect; see root cause below). All new capability suites (`unit/test_gameplay_event_bus`, `unit/test_interaction_tracker`, `unit/test_spatial_query`, `unit/test_scene_depth_sort`) present and passed.

**6.3 - All-on (all 4 flags = 1) `native_test` run:** Same result shape: 1599 succeeded, 4 skipped, 1 ERRORED (same tooling race condition, not a regression). All 4 new capability suites passed with their functional (non-default-off) test paths exercised.

**6.4 - Each flag alone (`native_test`), with a clean build (`pio run -e native_test --target clean` between runs) to rule out build-cache artifacts:**
- `PIXELROOT32_ENABLE_GAMEPLAY_EVENTS=1` alone: only the same tooling race condition failed; everything else passed.
- `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` alone: only the same tooling race condition failed; everything else passed.
- `PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1` alone: **first attempt** (without a clean build) showed 4 ERRORED tests (the flake plus `test_engine_integration`, `test_game_loop`, `test_player_jump_integration`). Investigated and ruled out as a code issue: `CollisionSystem::triggerCallbacks()`'s interaction hook is correctly null-checked (`if (interactionTracker_) { ... }`) and every `GameplayEventBus`/`GameplayEvent` reference in `InteractionTracker.h`/`.cpp` is correctly wrapped in `#if PIXELROOT32_ENABLE_GAMEPLAY_EVENTS` — confirmed no unguarded reference. **Re-ran with a clean build cache**: only the same tooling race condition failed, confirming the first attempt's extra failures were stale/inconsistent build-cache artifacts from the sequential matrix runs, not a real regression.
- `PIXELROOT32_ENABLE_DEPTH_SORT=1` alone: **first attempt** showed 2 ERRORED (the flake plus `test_engine_integration`). This is the decisive proof the extra failures were build-cache noise, not code: `PIXELROOT32_ENABLE_DEPTH_SORT`/`config::EnableDepthSort` is referenced ONLY in its own definition (`PlatformDefaults.h`, `EngineConfig.h`) and its own test file (`test_scene_depth_sort.cpp`) — confirmed via a repo-wide grep — it is not referenced anywhere in `Scene.h`/`Scene.cpp`/`Engine`/anywhere else, so it is logically impossible for this flag's value to affect `test_engine_integration`'s outcome. Re-ran with a clean build cache: only the tooling race condition failed, as expected.

**6.5 - `#error` guard verification:** Built with `PIXELROOT32_ENABLE_PHYSICS=0` + `PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1`. Compilation failed as designed, citing:
```
include/platforms/PlatformDefaults.h:102:2: error: #error "PIXELROOT32_ENABLE_INTERACTION_TRIGGERS and PIXELROOT32_ENABLE_SPATIAL_QUERY require PIXELROOT32_ENABLE_PHYSICS=1 (CollisionSystem and SpatialGrid only exist when physics is enabled)"
```
This is a compile-time failure (not a test result), confirming the guard fires correctly and loudly rather than silently misconfiguring.

**6.6 - Documentation:** Extended `docs/architecture/memory-system.md` (the doc design.md itself cites for this repo's existing flag/capacity table conventions — the legacy `docs/MEMORY_MANAGEMENT_GUIDE.md`/`docs/ARCHITECTURE.md` filenames no longer exist, already migrated) with:
- Three new capacity macros in the "Hard Limits" table: `GAMEPLAY_EVENT_QUEUE_CAPACITY` (32), `GAMEPLAY_MAX_INTERACTIVE_ACTORS` (16), `SPATIAL_QUERY_MAX_RADIUS` (128).
- A new "Gameplay Framework Phase 1 flags" table (all default `0`, RAM cost when enabled, subsystem added), following the exact format of the existing "Modular Compilation Impact" table.
- A `GameplayEvent` byte-budget table (16 B on ESP32-C3 / 24 B on native, 512 B / 768 B queue totals at the default 32-slot capacity).
- A dedicated "Non-atomic bus contract" paragraph: single-threaded production/consumption inside `Scene::update()`/`draw()`, drop-newest overflow policy with `getDroppedCount()`, drain on `SceneManager::setCurrentScene()` (including scene-swap transitions) but not on `pushScene()`/`popScene()`.

## Root cause of the one persistent `ERRORED` test (fully diagnosed)

`test_background_palette_render_integration` is alphabetically/build-order the FIRST test PlatformIO processes in an unfiltered `pio test -e native_test` run. On the maintainer's machine, the local PlatformIO library cache does not have `throwtheswitch/Unity` pre-cached for this exact project/environment state, so PlatformIO triggers a fresh `Library Manager: Installing throwtheswitch/Unity @ ^2.6.1` mid-build — and the compilation of this FIRST test proceeds before the freshly-installed library's include path is fully registered, producing `fatal error: unity.h: No such file or directory`. Every subsequent test in the same run benefits from the now-installed library and passes.

This is a PlatformIO dependency-resolution race condition local to that machine's library cache state — entirely a tooling/environment issue, unrelated to any of the 5 PRs' code. It reproduces identically regardless of which (if any) of the 4 new flags are set, including with all 4 off (the pre-existing baseline, proven in the original PR 1 investigation before any of this chain's code existed).

## Files changed

- `docs/architecture/memory-system.md` — new flags, capacities, byte budgets, bus contract.

## Test plan

- [x] All 15 examples build at default flags (evidence above)
- [x] `native_test` all-off run (1599/1604 pass, 4 skipped, 1 known unrelated flake)
- [x] `native_test` all-on run (same shape, no regressions)
- [x] `native_test` each-flag-alone run x4, with clean-build re-verification for the two that showed cache-related noise
- [x] `#error` guard verified to fire at compile time
- [x] Documentation updated and reviewed against design.md's byte-budget wording

## Out of scope

- No engine source changes (all four capabilities were implemented and tested in PRs #157-#161).
- Retrofitting existing examples to use the new capabilities (explicit non-goal in design.md).
- Fixing the pre-existing `SpatialGrid` shared static-storage limitation (explicit non-goal in design.md).
