### PR TITLE
feat(platform): add opt-in gameplay-framework phase 2 feature flags (1/5)

### DIFF
--- a/include/platforms/EngineConfig.h
+++ b/include/platforms/EngineConfig.h
@@ -516,6 +516,26 @@ namespace pixelroot32::platforms::config {
     inline constexpr bool EnableDepthSort = false;
     #endif
 
+    #if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+    /** @brief Type-safe access to EnableGameplayStateMachine configuration. */
+    inline constexpr bool EnableGameplayStateMachine = true;
+    #else
+
+    /** @brief Type-safe access to EnableGameplayStateMachine configuration. */
+    inline constexpr bool EnableGameplayStateMachine = false;
+    #endif
+
+    #if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+    /** @brief Type-safe access to EnableGameplayObjectPool configuration. */
+    inline constexpr bool EnableGameplayObjectPool = true;
+    #else
+
+    /** @brief Type-safe access to EnableGameplayObjectPool configuration. */
+    inline constexpr bool EnableGameplayObjectPool = false;
+    #endif
+
     inline unsigned long profilerMicros() {
         return micros();
     }

--- a/include/platforms/PlatformDefaults.h
+++ b/include/platforms/PlatformDefaults.h
@@ -94,6 +94,19 @@
 #define PIXELROOT32_ENABLE_DEPTH_SORT 0
 #endif
 
+#if !defined(PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE)
+#define PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE 0
+#endif
+
+#if !defined(PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL)
+#define PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL 0
+#endif
+
+// No dependency guard is declared for the two flags above: unlike interaction
+// triggers and spatial queries, neither the state machine nor the object pool
+// includes any physics-gated header, so both are usable with
+// PIXELROOT32_ENABLE_PHYSICS=0 and are independent of each other.
+
 // Interaction triggers and spatial queries are built on top of CollisionSystem
 // and SpatialGrid, which only exist when physics is enabled (see
 // include/core/Scene.h:213-216). Fail the build loudly instead of silently


### PR DESCRIPTION
First PR of the Gameplay Framework **Phase 2** chain (5 PRs). Declares the two opt-in compile flags the remaining PRs build on. Nothing consumes them yet.

## What changes

| File | Change |
|---|---|
| `include/platforms/PlatformDefaults.h` | `PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE` and `PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL`, both defaulting to `0` |
| `include/platforms/EngineConfig.h` | `constexpr` mirrors `EnableGameplayStateMachine` / `EnableGameplayObjectPool` |

33 lines, all additions. No deletions, no modifications to existing lines.

## Two deliberate omissions

**No `#error` dependency guard.** Phase 1 needed one because interaction triggers and spatial queries are built on `CollisionSystem` and `SpatialGrid`, which only exist under `PIXELROOT32_ENABLE_PHYSICS`. Neither Phase 2 header includes anything physics-gated, so both capabilities work with physics off and are independent of each other. A comment in `PlatformDefaults.h` records this so the asymmetry with the block below it does not read as an oversight.

**No capacity macros.** The state machine's state count is a runtime value over a caller-owned table, and the object pool's capacity is the template parameter `N`. A global capacity constant would force one number onto every unrelated pool instantiation. Per-instantiation sizing against the ESP32-C3 ceiling is covered by the design's byte-budget table instead.

## Verification

Both flags default to `0`, so every existing example and test compiles exactly as before — the preprocessor sees no reachable new code. The maintainer runs `pio test -e native_test` to confirm no suite breaks.

## Chain

| PR | Branch | Contents |
|---|---|---|
| **1/5 (this)** | `gameplay-phase2/01-foundation-flags` | The two flags |
| 2/5 | `gameplay-phase2/02-state-machine` | `StateMachine.h` + suite |
| 3/5 | `gameplay-phase2/03-object-pool` | `ObjectPool.h` + suite |
| 4/5 | `gameplay-phase2/04-ci-gameplay-env-docs` | `[env:native_test_gameplay]`, §5.9 pattern docs, `memory-system.md` |
| 5/5 | `gameplay-phase2/05-verification` | Cross-cutting evidence |
