### PR TITLE
feat(gameplay): add ObjectPool capability (3/5)

### DIFF
--- a/include/gameplay/ObjectPool.h
+++ b/include/gameplay/ObjectPool.h
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#pragma once
+
+#include "platforms/PlatformDefaults.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+/**
+ * @file ObjectPool.h
+ * @brief Fixed-capacity, zero-heap object pool with placement-new storage.
+ *
+ * ## Arena-backed pool storage is NOT supported (design.md D6)
+ *
+ * `ObjectPool<T, N>` is designed to be a plain member of the owning `Scene`
+ * or game object (or a file-scope `static`) — never allocated through
+ * `arenaNew`, and never backed by memory obtained from `SceneArena`. This is
+ * a structural limitation, not an oversight:
+ *
+ * - `Scene::resetState()` calls `arena.reset()` unconditionally, and the
+ *   arena runs no destructors: it only rewinds a bump offset. A pool placed
+ *   in arena memory would therefore never run `~ObjectPool()`, so `~T()`
+ *   never runs for any slot that was still live at reset time — a silent
+ *   resource leak for any `T` owning a resource.
+ * - Worse, a pool whose *storage* lives in arena memory keeps a
+ *   `liveWords_` bitmask asserting slots are live while the arena has
+ *   already rewound its offset and is about to hand those exact bytes to
+ *   the next `arenaNew` caller. Two live objects then alias one address,
+ *   and a later `release()`/`reset()` runs `~T()` over memory owned by
+ *   something else.
+ *
+ * There is no placement-site check in C++ that can catch this, and the one
+ * enforcement point that could — a `Scene::resetState()` hook — is exactly
+ * the engine-side wiring this capability is designed NOT to require. A
+ * documented contract with no enforcement point is worse than an
+ * unsupported feature stated plainly, so this header states it plainly.
+ *
+ * The supported reset contract instead: a pool owned by a `Scene` is reset
+ * from that scene's `init()` override, *after* the base `Scene::init()` has
+ * already run (which runs `resetState()` first):
+ *
+ * @code
+ * void MyScene::init() {
+ *     Scene::init();   // clears entities + removes them from CollisionSystem
+ *     pool_.reset();   // now safe: no dangling entity references remain
+ *     // ... repopulate
+ * }
+ * @endcode
+ *
+ * The ordering is "after", not "before": if a pooled `T` is also a
+ * registered `Entity`, destructing it before `Scene::init()`'s
+ * `resetState()` runs would leave dangling pointers in the scene's entity
+ * list for the window until `clearEntities()` runs.
+ *
+ * Narrow footnote, not a supported mode: if `std::is_trivially_destructible_v<T>`
+ * (e.g. a plain POD payload), arena placement degrades to the harmless
+ * "the pool's bytes disappear" case, since skipping a trivial `~T()` has no
+ * observable effect. This is not offered as a supported configuration
+ * because it cannot be enforced at the placement site — a caller who later
+ * changes `T` to own a resource gets silent corruption with no diagnostic.
+ */
+
+namespace pixelroot32::gameplay {
+
+namespace detail {
+
+#if defined(__GNUC__) || defined(__clang__)
+
+/// Index of the lowest set bit in `bits`. Every call site in ObjectPool
+/// guarantees `bits != 0` before calling.
+inline int objectPoolCountTrailingZero(uint32_t bits) {
+    return __builtin_ctz(bits);
+}
+
+#else
+
+/// Portable bit-loop fallback for toolchains without `__builtin_ctz`. Every
+/// call site in ObjectPool guarantees `bits != 0` before calling.
+inline int objectPoolCountTrailingZero(uint32_t bits) {
+    int index = 0;
+    while ((bits & 1u) == 0u) {
+        bits >>= 1u;
+        ++index;
+    }
+    return index;
+}
+
+#endif  // defined(__GNUC__) || defined(__clang__)
+
+}  // namespace detail
+
+/**
+ * @class ObjectPool
+ * @brief Fixed-capacity, zero-heap slot pool over aligned raw storage.
+ *
+ * Slots are `alignas(T) unsigned char storage_[N * sizeof(T)]`, constructed
+ * in place with placement new and recovered with `std::launder` for
+ * standard-correct aliasing (design.md D4). `T` is NOT required to have a
+ * default constructor: `acquire()` forwards its arguments to `T`'s
+ * constructor. Liveness is tracked by a `uint32_t` bitmask with a scan hint
+ * (design.md D5) — `acquire()` finds a free bit with `__builtin_ctz` (or a
+ * portable fallback), and `nextLive()` supports the ascending-index
+ * iteration pattern both hand-rolled precedents in this codebase already
+ * use:
+ *
+ * @code
+ * for (uint16_t i = pool.nextLive(0); i != Pool::kEnd; i = pool.nextLive(i + 1)) {
+ *     T& obj = *pool.at(i);
+ *     // ...
+ * }
+ * @endcode
+ *
+ * Never allocates: no `new`, no `malloc`, no `std::vector`. With
+ * `-fno-exceptions`, a constructor cannot fail, so there is no
+ * partially-constructed-slot case to unwind.
+ *
+ * Copy construction and copy assignment are deleted — a pool's slot
+ * pointers are identity, not value; copying the raw bytes without
+ * re-running every live `T`'s copy constructor would alias two pools over
+ * one set of resources.
+ *
+ * See this file's header-level doc comment for why arena-backed pool
+ * storage is NOT supported (design.md D6).
+ */
+template <typename T, uint16_t N>
+class ObjectPool {
+    static_assert(N >= 1, "ObjectPool capacity must be at least 1");
+
+public:
+    /// Fixed slot capacity of this pool instantiation.
+    static constexpr uint16_t kCapacity = N;
+
+    /// nextLive()/indexOf() end-of-iteration / not-found sentinel.
+    static constexpr uint16_t kEnd = 0xFFFFu;
+
+    ObjectPool() = default;
+
+    /// Destructs every remaining live slot via reset().
+    ~ObjectPool() { reset(); }
+
+    ObjectPool(const ObjectPool&) = delete;
+    ObjectPool& operator=(const ObjectPool&) = delete;
+
+    /**
+     * @brief Constructs a `T` in a free slot, forwarding `args` to `T`'s
+     *        constructor.
+     * @return A pointer to the newly constructed, live object, or `nullptr`
+     *         when the pool is full — every existing live slot is left
+     *         unmodified in that case.
+     *
+     * Never allocates (no `new`, no `malloc`). `T` does NOT need a default
+     * constructor; only a constructor matching `args` is required.
+     */
+    template <typename... Args>
+    T* acquire(Args&&... args) {
+        if (liveCount_ >= N) {
+            return nullptr;
+        }
+        for (uint16_t scanned = 0; scanned < kWordCount; ++scanned) {
+            const uint16_t wordIndex = static_cast<uint16_t>((scanHint_ + scanned) % kWordCount);
+            const uint32_t freeBits = (~liveWords_[wordIndex]) & wordMask(wordIndex);
+            if (freeBits != 0u) {
+                const uint32_t bit =
+                    static_cast<uint32_t>(detail::objectPoolCountTrailingZero(freeBits));
+                const uint16_t index = static_cast<uint16_t>(wordIndex * 32u + bit);
+
+                // Placement new's own return value is the correct pointer to
+                // use immediately — no std::launder needed on this path
+                // (design.md D4). Laundering is only required when a T* is
+                // later recovered from the raw bytes (at()/indexOf()/nextLive()).
+                T* slot = ::new (static_cast<void*>(rawSlot(index))) T(std::forward<Args>(args)...);
+
+                liveWords_[wordIndex] |= (uint32_t{1} << bit);
+                ++liveCount_;
+                scanHint_ = wordIndex;
+                return slot;
+            }
+        }
+        // Unreachable when liveCount_ < N and bookkeeping is consistent;
+        // kept as a defensive fallback rather than an assert.
+        return nullptr;
+    }
+
+    /**
+     * @brief Runs `~T()` on the slot holding `object` and frees it.
+     * @return `true` if a live slot was released; `false` (safe no-op, no
+     *         bookkeeping change, `~T()` NOT invoked again) for `nullptr`, a
+     *         pointer foreign to this pool, or a slot that is already free.
+     */
+    bool release(T* object) {
+        if (object == nullptr) {
+            return false;
+        }
+        const uint16_t index = indexOf(object);
+        if (index == kEnd) {
+            return false;
+        }
+        return releaseAt(index);
+    }
+
+    /**
+     * @brief Runs `~T()` on the slot at `index` and frees it.
+     * @return `true` if the slot was live and is now freed; `false` (safe
+     *         no-op) for an out-of-range index or a slot that is already
+     *         free.
+     */
+    bool releaseAt(uint16_t index) {
+        if (index >= N || !isLive(index)) {
+            return false;
+        }
+        std::launder(reinterpret_cast<T*>(rawSlot(index)))->~T();
+        clearBit(index);
+        --liveCount_;
+
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        if (wordIndex < scanHint_) {
+            scanHint_ = wordIndex;
+        }
+        return true;
+    }
+
+    /**
+     * @brief Runs `~T()` on every live slot, ascending index order, then
+     *        clears all bookkeeping. Safe to call on an empty pool.
+     */
+    void reset() {
+        for (uint16_t i = nextLive(0); i != kEnd; i = nextLive(static_cast<uint16_t>(i + 1))) {
+            std::launder(reinterpret_cast<T*>(rawSlot(i)))->~T();
+        }
+        for (uint16_t w = 0; w < kWordCount; ++w) {
+            liveWords_[w] = 0u;
+        }
+        liveCount_ = 0;
+        scanHint_ = 0;
+    }
+
+    /** @brief Fixed slot capacity (same value as kCapacity). */
+    uint16_t capacity() const { return N; }
+
+    /** @brief Number of slots currently live. */
+    uint16_t size() const { return liveCount_; }
+
+    /** @brief True when size() == capacity(). */
+    bool isFull() const { return liveCount_ == N; }
+
+    /** @brief True when `index` is in range and currently holds a live object. */
+    bool isLive(uint16_t index) const {
+        if (index >= N) {
+            return false;
+        }
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        const uint32_t bit = static_cast<uint32_t>(index % 32u);
+        return (liveWords_[wordIndex] & (uint32_t{1} << bit)) != 0u;
+    }
+
+    /**
+     * @brief Recovers a pointer to the live object at `index`.
+     * @return A `std::launder`-corrected `T*`, or `nullptr` if `index` is
+     *         out of range or dead.
+     */
+    T* at(uint16_t index) {
+        if (!isLive(index)) {
+            return nullptr;
+        }
+        return std::launder(reinterpret_cast<T*>(rawSlot(index)));
+    }
+
+    /**
+     * @brief Finds the slot index owning `object`.
+     * @return The slot index if `object` was returned by this pool's
+     *         `acquire()` and is still live; `kEnd` for a null, foreign, or
+     *         no-longer-live pointer.
+     */
+    uint16_t indexOf(const T* object) const {
+        if (object == nullptr) {
+            return kEnd;
+        }
+        const auto objAddr = reinterpret_cast<std::uintptr_t>(object);
+        const auto baseAddr = reinterpret_cast<std::uintptr_t>(storage_);
+        const auto totalBytes = static_cast<std::uintptr_t>(N) * sizeof(T);
+        if (objAddr < baseAddr || objAddr >= baseAddr + totalBytes) {
+            return kEnd;
+        }
+        const std::uintptr_t offset = objAddr - baseAddr;
+        if (offset % sizeof(T) != 0u) {
+            return kEnd;
+        }
+        const uint16_t index = static_cast<uint16_t>(offset / sizeof(T));
+        return isLive(index) ? index : kEnd;
+    }
+
+    /**
+     * @brief Returns the first live index `>= from`, or `kEnd` when none
+     *        remains.
+     *
+     * Masks off bits below `from` in the first word examined and skips
+     * whole zero words, so iterating with
+     * `for (i = nextLive(0); i != kEnd; i = nextLive(i + 1))` visits exactly
+     * the live indices, in ascending order, each exactly once.
+     */
+    uint16_t nextLive(uint16_t from) const {
+        if (from >= N) {
+            return kEnd;
+        }
+        uint16_t wordIndex = static_cast<uint16_t>(from / 32u);
+        const uint32_t bitOffset = static_cast<uint32_t>(from % 32u);
+        uint32_t word = liveWords_[wordIndex] & (0xFFFFFFFFu << bitOffset);
+
+        while (true) {
+            if (word != 0u) {
+                const uint32_t bit =
+                    static_cast<uint32_t>(detail::objectPoolCountTrailingZero(word));
+                return static_cast<uint16_t>(wordIndex * 32u + bit);
+            }
+            ++wordIndex;
+            if (wordIndex >= kWordCount) {
+                return kEnd;
+            }
+            word = liveWords_[wordIndex];
+        }
+    }
+
+private:
+    static constexpr uint16_t kWordCount = static_cast<uint16_t>((N + 31u) / 32u);
+
+    /// Mask of the bits within `liveWords_[wordIndex]` that correspond to a
+    /// real slot. Always all-ones except for the last word when N is not a
+    /// multiple of 32, where the high bits beyond N-1 have no backing slot
+    /// and must never be treated as "free" by acquire()/nextLive().
+    static constexpr uint32_t wordMask(uint16_t wordIndex) {
+        const uint32_t remaining =
+            static_cast<uint32_t>(N) - static_cast<uint32_t>(wordIndex) * 32u;
+        if (remaining >= 32u) {
+            return 0xFFFFFFFFu;
+        }
+        return (remaining == 0u) ? 0u : ((uint32_t{1} << remaining) - 1u);
+    }
+
+    unsigned char* rawSlot(uint16_t index) {
+        return storage_ + static_cast<size_t>(index) * sizeof(T);
+    }
+    const unsigned char* rawSlot(uint16_t index) const {
+        return storage_ + static_cast<size_t>(index) * sizeof(T);
+    }
+
+    void clearBit(uint16_t index) {
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        const uint32_t bit = static_cast<uint32_t>(index % 32u);
+        liveWords_[wordIndex] &= ~(uint32_t{1} << bit);
+    }
+
+    alignas(T) unsigned char storage_[static_cast<size_t>(N) * sizeof(T)]{};
+    uint32_t liveWords_[kWordCount]{};
+    uint16_t liveCount_ = 0;
+    uint16_t scanHint_ = 0;
+};
+
+}  // namespace pixelroot32::gameplay
+
+#endif  // PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL

--- a/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
+++ b/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
@@ -1,0 +1,554 @@
+/**
+ * @file test_gameplay_object_pool.cpp
+ * @brief Unit tests for gameplay/ObjectPool module
+ *
+ * Covers the spec requirements for gameplay-object-pool:
+ * - acquire-returns-usable-object-or-null-at-capacity-never-overflows-or-allocates
+ * - t-requires-no-default-constructor-construction-forwards-caller-arguments
+ * - destructor-invocation-on-release-and-reset
+ * - iteration-visits-only-live-slots-in-ascending-index-order
+ * - free-live-bookkeeping-correctness-across-interleaved-acquire-release-cycles
+ * - feature-gated-and-zero-cost-when-disabled
+ *
+ * (Arena-Backed Pool Storage Is Not Supported and Pool Owned By A Scene Must
+ * Be Reset After The Base Scene::init() Call are documented contracts, not
+ * runtime-testable behaviors — see include/gameplay/ObjectPool.h's
+ * header-level doc comment for the former and design.md D6 for both.)
+ *
+ * The functional tests only compile when PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+ * is enabled, since ObjectPool is entirely guarded behind that flag (see
+ * include/gameplay/ObjectPool.h). This file therefore compiles cleanly in
+ * BOTH the default (flag off) and opt-in (flag on) configurations, matching
+ * the "no behavior change for existing examples" goal and the CI matrix from
+ * design.md.
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "platforms/PlatformDefaults.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+#include "gameplay/ObjectPool.h"
+
+#include <cstddef>
+#include <cstdint>
+
+using namespace pixelroot32::gameplay;
+
+namespace {
+
+/**
+ * @brief Mock payload with NO default constructor — only a two-argument
+ *        constructor — so that acquire()'s forwarding is exercised, and
+ *        with static construct/destruct counters plus an ordered destruct
+ *        log so release()/reset()/~ObjectPool() lifetime can be verified.
+ */
+struct TrackedPayload {
+    static constexpr int kMaxLog = 64;
+    static int constructCount;
+    static int destructCount;
+    static int destructOrderLog[kMaxLog];
+    static int destructOrderCount;
+
+    static void resetCounters() {
+        constructCount = 0;
+        destructCount = 0;
+        destructOrderCount = 0;
+    }
+
+    int value;
+    int tag;
+
+    // No default constructor on purpose (spec: "T Requires No Default
+    // Constructor; Construction Forwards Caller Arguments").
+    TrackedPayload(int v, int t) : value(v), tag(t) { ++constructCount; }
+
+    ~TrackedPayload() {
+        ++destructCount;
+        if (destructOrderCount < kMaxLog) {
+            destructOrderLog[destructOrderCount++] = tag;
+        }
+    }
+};
+
+int TrackedPayload::constructCount = 0;
+int TrackedPayload::destructCount = 0;
+int TrackedPayload::destructOrderLog[TrackedPayload::kMaxLog] = {};
+int TrackedPayload::destructOrderCount = 0;
+
+/// Over-aligned mock payload for the alignment scenario (task 3.14).
+struct alignas(16) AlignedPayload {
+    int value;
+    explicit AlignedPayload(int v) : value(v) {}
+};
+
+}  // namespace
+
+// =============================================================================
+// Requirement: Acquire Returns A Usable Object Or Null At Capacity, Never
+// Overflows Or Allocates
+// =============================================================================
+
+void test_acquire_on_nonfull_pool_returns_live_constructed_object(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(11, 0);
+
+    TEST_ASSERT_NOT_NULL(obj);
+    TEST_ASSERT_EQUAL_INT(11, obj->value);
+    TEST_ASSERT_EQUAL_UINT16(1, pool.size());
+    const uint16_t index = pool.indexOf(obj);
+    TEST_ASSERT_TRUE(index != ObjectPool<TrackedPayload, 4>::kEnd);
+    TEST_ASSERT_TRUE(pool.isLive(index));
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::constructCount);
+}
+
+void test_acquire_on_full_pool_returns_null_without_corrupting_live_objects(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* objs[4];
+    for (int i = 0; i < 4; ++i) {
+        objs[i] = pool.acquire(100 + i, i);
+        TEST_ASSERT_NOT_NULL(objs[i]);
+    }
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+
+    TrackedPayload* overflow = pool.acquire(999, 999);
+
+    TEST_ASSERT_NULL(overflow);
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+    // Every previously-live object must still read back its original value —
+    // acquire() on a full pool must not touch any existing slot.
+    for (int i = 0; i < 4; ++i) {
+        TEST_ASSERT_EQUAL_INT(100 + i, objs[i]->value);
+        TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(objs[i])));
+    }
+}
+
+void test_acquire_never_allocates_dynamically(void) {
+    // Structural guarantee, verified by inspection of ObjectPool.h: acquire()
+    // only performs placement-new into alignas(T) raw storage that is a
+    // member of the pool itself — there is no `new`, `malloc`, or any other
+    // dynamic allocator anywhere on the acquire() path (design.md D4). This
+    // test exercises acquire() across empty, partial, and full states to
+    // confirm none of those paths crash or behave as if memory had to be
+    // sourced externally.
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 2> pool;
+
+    TEST_ASSERT_NOT_NULL(pool.acquire(1, 0));
+    TEST_ASSERT_NOT_NULL(pool.acquire(2, 1));
+    TEST_ASSERT_NULL(pool.acquire(3, 2));  // full: no allocation fallback exists
+}
+
+// =============================================================================
+// Requirement: T Requires No Default Constructor; Construction Forwards
+// Caller Arguments
+// =============================================================================
+
+void test_acquire_constructs_t_with_no_default_constructor_via_forwarded_args(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 2> pool;
+
+    // TrackedPayload has no default constructor; this compiling and
+    // constructing correctly IS the requirement.
+    TrackedPayload* obj = pool.acquire(42, 7);
+
+    TEST_ASSERT_NOT_NULL(obj);
+    TEST_ASSERT_EQUAL_INT(42, obj->value);
+    TEST_ASSERT_EQUAL_INT(7, obj->tag);
+}
+
+// =============================================================================
+// Requirement: Destructor Invocation On Release And Reset
+// =============================================================================
+
+void test_release_destroys_exactly_once_and_frees_slot(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(5, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    const bool released = pool.release(obj);
+
+    TEST_ASSERT_TRUE(released);
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::destructCount);
+    TEST_ASSERT_FALSE(pool.isLive(index));
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+}
+
+void test_release_by_index_destroys_exactly_once_and_frees_slot(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(6, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    const bool released = pool.releaseAt(index);
+
+    TEST_ASSERT_TRUE(released);
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::destructCount);
+    TEST_ASSERT_FALSE(pool.isLive(index));
+}
+
+void test_releasing_null_foreign_or_already_free_pointer_is_safe_noop(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    // Null pointer.
+    TEST_ASSERT_FALSE(pool.release(nullptr));
+    TEST_ASSERT_EQUAL_INT(0, TrackedPayload::destructCount);
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+
+    // Foreign pointer: a live TrackedPayload that does not belong to `pool`.
+    TrackedPayload standalone(1, 1);
+    TEST_ASSERT_FALSE(pool.release(&standalone));
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+    TEST_ASSERT_EQUAL_UINT16(ObjectPool<TrackedPayload, 4>::kEnd, pool.indexOf(&standalone));
+
+    // Already-free slot: release a live object, then release it again.
+    TrackedPayload* obj = pool.acquire(2, 2);
+    TEST_ASSERT_TRUE(pool.release(obj));
+    const int destructCountAfterFirstRelease = TrackedPayload::destructCount;
+
+    TEST_ASSERT_FALSE(pool.release(obj));
+    TEST_ASSERT_EQUAL_INT(destructCountAfterFirstRelease, TrackedPayload::destructCount);
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+
+    // Out-of-range index is likewise a safe no-op.
+    TEST_ASSERT_FALSE(pool.releaseAt(999));
+}
+
+void test_reset_destroys_all_live_slots_in_ascending_index_order(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 8> pool;
+
+    // Acquire several, release a non-contiguous subset, leaving a fragmented
+    // mix of live slots — reset() must still destroy the survivors in
+    // ascending INDEX order, not acquisition order.
+    TrackedPayload* p0 = pool.acquire(0, 100);
+    TrackedPayload* p1 = pool.acquire(1, 101);
+    TrackedPayload* p2 = pool.acquire(2, 102);
+    TrackedPayload* p3 = pool.acquire(3, 103);
+    TEST_ASSERT_TRUE(pool.release(p1));  // fragment the middle
+
+    const uint16_t idx0 = pool.indexOf(p0);
+    const uint16_t idx2 = pool.indexOf(p2);
+    const uint16_t idx3 = pool.indexOf(p3);
+    (void)p1;
+
+    TrackedPayload::destructOrderCount = 0;  // ignore p1's destruction above
+    pool.reset();
+
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+    for (uint16_t i = 0; i < pool.capacity(); ++i) {
+        TEST_ASSERT_FALSE(pool.isLive(i));
+    }
+
+    // The three survivors (tags 100, 102, 103 at idx0 < idx2 < idx3) must be
+    // destroyed in that ascending-index order.
+    TEST_ASSERT_TRUE(idx0 < idx2);
+    TEST_ASSERT_TRUE(idx2 < idx3);
+    TEST_ASSERT_EQUAL_INT(3, TrackedPayload::destructOrderCount);
+    TEST_ASSERT_EQUAL_INT(100, TrackedPayload::destructOrderLog[0]);
+    TEST_ASSERT_EQUAL_INT(102, TrackedPayload::destructOrderLog[1]);
+    TEST_ASSERT_EQUAL_INT(103, TrackedPayload::destructOrderLog[2]);
+}
+
+void test_pool_destructor_destroys_remaining_live_slots_on_scope_exit(void) {
+    TrackedPayload::resetCounters();
+    {
+        ObjectPool<TrackedPayload, 4> pool;
+        pool.acquire(1, 0);
+        pool.acquire(2, 1);
+        pool.acquire(3, 2);
+        TEST_ASSERT_EQUAL_INT(0, TrackedPayload::destructCount);
+    }  // ~ObjectPool() must run here, destroying all three live slots.
+    TEST_ASSERT_EQUAL_INT(3, TrackedPayload::destructCount);
+}
+
+// =============================================================================
+// Requirement: Iteration Visits Only Live Slots, In Ascending Index Order
+// =============================================================================
+
+void test_nextlive_visits_exactly_live_indices_in_ascending_order(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 8> pool;
+
+    TrackedPayload* items[8];
+    for (int i = 0; i < 8; ++i) {
+        items[i] = pool.acquire(i, i);
+    }
+    // Release a non-contiguous subset: indices 1, 3, 6.
+    TEST_ASSERT_TRUE(pool.release(items[1]));
+    TEST_ASSERT_TRUE(pool.release(items[3]));
+    TEST_ASSERT_TRUE(pool.release(items[6]));
+
+    uint16_t visited[8];
+    int visitedCount = 0;
+    using Pool = ObjectPool<TrackedPayload, 8>;
+    for (uint16_t i = pool.nextLive(0); i != Pool::kEnd; i = pool.nextLive(static_cast<uint16_t>(i + 1))) {
+        TEST_ASSERT_TRUE(visitedCount < 8);
+        visited[visitedCount++] = i;
+    }
+
+    // Expected surviving indices, strictly ascending: 0, 2, 4, 5, 7.
+    TEST_ASSERT_EQUAL_INT(5, visitedCount);
+    TEST_ASSERT_EQUAL_UINT16(0, visited[0]);
+    TEST_ASSERT_EQUAL_UINT16(2, visited[1]);
+    TEST_ASSERT_EQUAL_UINT16(4, visited[2]);
+    TEST_ASSERT_EQUAL_UINT16(5, visited[3]);
+    TEST_ASSERT_EQUAL_UINT16(7, visited[4]);
+    for (int i = 1; i < visitedCount; ++i) {
+        TEST_ASSERT_TRUE(visited[i - 1] < visited[i]);
+    }
+}
+
+void test_nextlive_on_empty_and_fully_live_pool(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+    using Pool = ObjectPool<TrackedPayload, 4>;
+
+    // Empty pool: no live index anywhere.
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.nextLive(0));
+
+    for (int i = 0; i < 4; ++i) {
+        pool.acquire(i, i);
+    }
+    // Fully live: visits every index 0..3, then kEnd.
+    uint16_t i = pool.nextLive(0);
+    for (uint16_t expected = 0; expected < 4; ++expected) {
+        TEST_ASSERT_EQUAL_UINT16(expected, i);
+        i = pool.nextLive(static_cast<uint16_t>(i + 1));
+    }
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, i);
+}
+
+// =============================================================================
+// Requirement: Free/Live Bookkeeping Correctness Across Interleaved
+// Acquire/Release Cycles
+// =============================================================================
+
+void test_bookkeeping_correct_across_interleaved_acquire_release(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* a = pool.acquire(1, 0);
+    TrackedPayload* b = pool.acquire(2, 1);
+    const uint16_t indexA = pool.indexOf(a);
+    TEST_ASSERT_EQUAL_UINT16(2, pool.size());
+    TEST_ASSERT_FALSE(pool.isFull());
+
+    TEST_ASSERT_TRUE(pool.release(a));
+    TEST_ASSERT_EQUAL_UINT16(1, pool.size());
+    TEST_ASSERT_FALSE(pool.isLive(indexA));  // a's old slot is now dead
+
+    TrackedPayload* c = pool.acquire(3, 2);
+    TrackedPayload* d = pool.acquire(4, 3);
+    TEST_ASSERT_EQUAL_UINT16(3, pool.size());
+
+    TrackedPayload* e = pool.acquire(5, 4);
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+
+    TEST_ASSERT_TRUE(pool.release(c));
+    TEST_ASSERT_FALSE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(3, pool.size());
+
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(b)));
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(d)));
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(e)));
+}
+
+void test_released_slot_is_available_for_reuse_on_full_pool(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* items[4];
+    for (int i = 0; i < 4; ++i) {
+        items[i] = pool.acquire(10 + i, i);
+    }
+    TEST_ASSERT_TRUE(pool.isFull());
+
+    TEST_ASSERT_TRUE(pool.release(items[2]));
+    TEST_ASSERT_FALSE(pool.isFull());
+
+    TrackedPayload* reused = pool.acquire(999, 999);
+
+    TEST_ASSERT_NOT_NULL(reused);
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+}
+
+void test_indexof_roundtrips_for_live_object_and_kend_for_foreign_pointer(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+    using Pool = ObjectPool<TrackedPayload, 4>;
+
+    TrackedPayload* obj = pool.acquire(7, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    TEST_ASSERT_TRUE(index != Pool::kEnd);
+    TEST_ASSERT_EQUAL_PTR(obj, pool.at(index));
+
+    TrackedPayload standalone(1, 1);
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(&standalone));
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(nullptr));
+}
+
+// =============================================================================
+// Multi-word bitmask boundary check (design.md D5): N = 40 spans two
+// liveWords_ words (word0 = indices 0-31, word1 = indices 32-39, with bits
+// 8-31 of word1 unused padding). This exercises the tail-word mask that
+// prevents acquire()/nextLive() from treating word1's unused high bits as
+// free slots — the exact off-by-one class the bit math is most at risk of.
+// =============================================================================
+
+void test_multiword_bitmask_handles_tail_word_and_boundary_correctly(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 40> pool;
+    using Pool = ObjectPool<TrackedPayload, 40>;
+
+    TrackedPayload* items[40];
+    for (int i = 0; i < 40; ++i) {
+        items[i] = pool.acquire(i, i);
+        TEST_ASSERT_NOT_NULL(items[i]);
+    }
+    // All 40 slots (including all 8 valid bits of the tail word) are live:
+    // the pool must report full, and a further acquire must return nullptr
+    // rather than treating word1's unused bits 8-31 as free.
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(40, pool.size());
+    TEST_ASSERT_NULL(pool.acquire(999, 999));
+
+    // Release two adjacent-across-the-word-boundary slots (31 in word0, 32
+    // in word1) and confirm nextLive() steps cleanly across that boundary.
+    TEST_ASSERT_TRUE(pool.release(items[31]));
+    TEST_ASSERT_TRUE(pool.release(items[32]));
+    TEST_ASSERT_FALSE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(38, pool.size());
+
+    TEST_ASSERT_EQUAL_UINT16(30, pool.nextLive(30));
+    TEST_ASSERT_EQUAL_UINT16(33, pool.nextLive(31));  // 31 and 32 both dead
+    TEST_ASSERT_EQUAL_UINT16(33, pool.nextLive(32));
+
+    // The last valid index (39) must still be reachable and never mistaken
+    // for out-of-range or for the kEnd sentinel.
+    TEST_ASSERT_TRUE(pool.isLive(39));
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.nextLive(40));
+
+    // Reacquiring must reuse one of the two freed slots (31 or 32), not
+    // spill into a nonexistent index 40.
+    TrackedPayload* reused = pool.acquire(1000, 1000);
+    TEST_ASSERT_NOT_NULL(reused);
+    const uint16_t reusedIndex = pool.indexOf(reused);
+    TEST_ASSERT_TRUE(reusedIndex == 31 || reusedIndex == 32);
+    TEST_ASSERT_EQUAL_UINT16(39, pool.size());
+}
+
+// =============================================================================
+// D8 byte-budget property assertions (not hardcoded byte counts — native_test
+// runs 64-bit, where pointer width and alignof(T) differ from ESP32-C3).
+// =============================================================================
+
+void test_pool_sizeof_stays_within_declared_budget(void) {
+    using Pool = ObjectPool<TrackedPayload, 8>;
+
+    // Bookkeeping per design.md D5: one uint32_t per 32 slots, plus the
+    // liveCount_/scanHint_ uint16_t counters.
+    constexpr size_t kWordCount = (8 + 31) / 32;
+    constexpr size_t declaredBookkeeping = kWordCount * sizeof(uint32_t) + 2 * sizeof(uint16_t);
+    const size_t declaredStorage = static_cast<size_t>(Pool::kCapacity) * sizeof(TrackedPayload);
+
+    // Storage may need up to (alignof(T) - 1) bytes of leading padding, and
+    // the object as a whole may need up to one machine word of trailing
+    // alignment padding — the same "declared members + one machine word"
+    // property bound test_gameplay_event_bus.cpp uses for GameplayEventBus.
+    const size_t declaredTotal =
+        declaredStorage + declaredBookkeeping + (alignof(TrackedPayload) - 1);
+
+    TEST_ASSERT_TRUE(sizeof(Pool) <= declaredTotal + sizeof(void*));
+}
+
+void test_at_returns_correctly_aligned_pointer_for_overaligned_t(void) {
+    ObjectPool<AlignedPayload, 4> pool;
+
+    AlignedPayload* a = pool.acquire(1);
+    AlignedPayload* b = pool.acquire(2);
+    AlignedPayload* c = pool.acquire(3);
+
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_NOT_NULL(c);
+
+    const uint16_t indices[3] = {pool.indexOf(a), pool.indexOf(b), pool.indexOf(c)};
+
+    for (int i = 0; i < 3; ++i) {
+        AlignedPayload* recovered = pool.at(indices[i]);
+        TEST_ASSERT_NOT_NULL(recovered);
+        const auto addr = reinterpret_cast<std::uintptr_t>(recovered);
+        TEST_ASSERT_EQUAL_UINT32(0u, static_cast<uint32_t>(addr % alignof(AlignedPayload)));
+    }
+}
+
+#else  // !PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+void test_gameplay_object_pool_zero_cost_when_disabled(void) {
+    // With the flag off, ObjectPool<T, N> is not compiled at all — its
+    // entire declaration lives inside the
+    // #if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL guard in
+    // include/gameplay/ObjectPool.h. This translation unit compiling and
+    // passing without referencing the template IS the "zero bytes reserved"
+    // property required by the spec's "Feature-Gated And Zero-Cost When
+    // Disabled" requirement — and it trivially subsumes the narrower
+    // "an uninstantiated (T, N) pairing costs nothing" scenario: with the
+    // flag off, EVERY (T, N) pairing is uninstantiated, and every one of
+    // them costs zero code and zero data.
+    TEST_PASS_MESSAGE(
+        "PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=0: ObjectPool is not "
+        "compiled, zero bytes reserved for any (T, N) pairing.");
+}
+
+#endif  // PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+    RUN_TEST(test_acquire_on_nonfull_pool_returns_live_constructed_object);
+    RUN_TEST(test_acquire_on_full_pool_returns_null_without_corrupting_live_objects);
+    RUN_TEST(test_acquire_never_allocates_dynamically);
+    RUN_TEST(test_acquire_constructs_t_with_no_default_constructor_via_forwarded_args);
+    RUN_TEST(test_release_destroys_exactly_once_and_frees_slot);
+    RUN_TEST(test_release_by_index_destroys_exactly_once_and_frees_slot);
+    RUN_TEST(test_releasing_null_foreign_or_already_free_pointer_is_safe_noop);
+    RUN_TEST(test_reset_destroys_all_live_slots_in_ascending_index_order);
+    RUN_TEST(test_pool_destructor_destroys_remaining_live_slots_on_scope_exit);
+    RUN_TEST(test_nextlive_visits_exactly_live_indices_in_ascending_order);
+    RUN_TEST(test_nextlive_on_empty_and_fully_live_pool);
+    RUN_TEST(test_bookkeeping_correct_across_interleaved_acquire_release);
+    RUN_TEST(test_released_slot_is_available_for_reuse_on_full_pool);
+    RUN_TEST(test_indexof_roundtrips_for_live_object_and_kend_for_foreign_pointer);
+    RUN_TEST(test_multiword_bitmask_handles_tail_word_and_boundary_correctly);
+    RUN_TEST(test_pool_sizeof_stays_within_declared_budget);
+    RUN_TEST(test_at_returns_correctly_aligned_pointer_for_overaligned_t);
+#endif
+    RUN_TEST(test_gameplay_object_pool_zero_cost_when_disabled);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
Third PR of the Gameplay Framework **Phase 2** chain. Adds the generic fixed-capacity object pool with individual slot reuse (audit §5.11) behind `PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL`.

**Base is PR #164.** Header-only template, 2 files, 922 lines added, no engine file modified.

## Why this one IS a template, when the FSM is not

Deliberate asymmetry, worth stating since the two land back to back. `StateMachine` is templated on nothing because templating on the *owner* would duplicate the whole dispatch body in flash once per actor type. `ObjectPool<T, N>` is a template because `T`'s size, alignment and construction *are* the thing the pool does — there is no owner-type duplication to avoid, and the storage layout genuinely differs per `T`.

## Why it is not built "over `SceneArena`"

The audit's §5.11 wording proposed a free-list "over `SceneArena`". That is not implementable as written: `SceneArena` (`include/core/Scene.h:27-46`) is bump-only — `allocate()` advances an offset, `reset()` zeroes it, and **no `deallocate()` exists**. There is no per-slot free primitive to build on.

The pool therefore owns its storage and its bookkeeping. Arena-*backed* storage is explicitly **not supported** this phase, and the header says so with the reason: `Scene::resetState()` (`src/core/Scene.cpp:198-210`) calls `arena.reset()` unconditionally and the arena never runs destructors, so a pool living in arena memory would have its slots silently recycled underneath it. That is a contract nobody can enforce at the placement site, so it is excluded rather than documented-and-hoped.

## Implementation

`alignas(T) unsigned char storage_[N * sizeof(T)]` with placement new, so **`T` needs no default constructor** — `acquire()` forwards constructor arguments. `std::launder` recovers `T*` from the raw bytes for standard-correct aliasing. Liveness is a `uint32_t` bitmask array with a scan hint, `__builtin_ctz` behind a `__GNUC__`/`__clang__` guard with a portable bit-loop fallback.

Destructors run exactly once per live object on `release`, `releaseAt`, `reset` and `~ObjectPool()`, never twice — pinned by a mock `T` that counts construction and destruction.

## The tail-word mask is load-bearing, not a nicety

The subtle part of this diff. For any `N` that is not a multiple of 32, the last bitmask word has high bits with no backing slot. Without masking them off, a **full** pool computes:

```
~liveWords_[1]  = 0xFFFFFF00   // N=40: 8 real slots, 24 phantom bits
ctz(...)        = 8
index           = 32 + 8 = 40  // valid indices are 0..39
```

That is a placement new past the end of `storage_`, reached through the ordinary "pool is full" path that the spec requires to return `nullptr`. `wordMask()` clears those phantom bits so `acquire()` sees zero free bits and correctly returns null.

`test_multiword_bitmask_handles_tail_word_and_boundary_correctly` uses `N = 40` specifically to span two words with a partial tail, and asserts the full-pool `acquire()` returns null, that `nextLive()` steps across the word boundary, and that a reacquire reuses a freed slot rather than spilling into index 40.

## One judgment call worth reviewing

`release()`/`releaseAt()` **do not** `assert()` on a null, foreign, or already-free pointer — they no-op, as the spec requires. This departs from `StateMachine.cpp`'s assert-then-fallback style on purpose: `platformio.ini` does not define `NDEBUG` for `[env:native_test]`, so `assert()` is live in exactly the configuration that runs the "safe no-op" test. An assert there would abort the very test verifying the contract.

## Verification

Whole body inside `#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL`, default `0`, so existing examples are untouched. The suite dual-compiles — with the flag off it still registers a passing test, so `main()` never has zero `RUN_TEST` calls.

Maintainer runs `pio test -e native_test` (all off) plus a build with `PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=1`. CI still has no flags-on environment until PR 4.
