### PR TITLE
ci+docs: run gameplay suites in CI, document Phase 2 budgets and the session-state pattern (4/5)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,14 @@ jobs:
       run: |
         pio test -e native_test --verbose
 
+    # Separate step, not appended to the one above, so a failure names which
+    # configuration broke. The env above proves the gameplay flags stay
+    # behavior-inert when off; this one is the only place their functional
+    # assertions actually run.
+    - name: Run Tests (gameplay flags enabled)
+      run: |
+        pio test -e native_test_gameplay --verbose
+
     - name: Generate Coverage Report
       run: |
         lcov --capture --directory . --output-file coverage.info

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -78,6 +78,40 @@ When subsystems are disabled via `PIXELROOT32_ENABLE_*` flags, their memory allo
 
 `PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1` or `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` combined with `PIXELROOT32_ENABLE_PHYSICS=0` fails the build at compile time via an `#error` in `PlatformDefaults.h` (`CollisionSystem` and `SpatialGrid` only exist when physics is enabled), rather than silently disabling the feature.
 
+**Gameplay Framework Phase 2 flags (opt-in, default `0`):** two more capabilities in `pixelroot32::gameplay`, each pure composition with zero engine-side wiring — no new member, virtual, or hook on `Scene`, `Actor`, or `Entity`. Unlike Phase 1's `INTERACTION_TRIGGERS`/`SPATIAL_QUERY`, **neither depends on `PIXELROOT32_ENABLE_PHYSICS` or any other flag** — neither header includes `core/`, `physics/`, `math/`, or any other capability's header, so no `#error` guard exists or is needed:
+
+| Flag | Default | RAM Cost When Enabled | Subsystem Added |
+|------|---------|------------------------|------------------|
+| `PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1` | `0` | 20 B/instance (ESP32-C3) / 32 B/instance (native), plus one shared table in flash per class | `gameplay::StateMachine` — non-template FSM over a caller-owned `const` state table |
+| `PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=1` | `0` | `N * sizeof(T)` + 8-12 B bookkeeping per pool instantiation (see table below) | `gameplay::ObjectPool<T, N>` — fixed-capacity, zero-heap slot pool with placement-new storage |
+
+**`StateMachine::State` byte budget (one table row — flash/`.rodata`, shared per class, not per instance):**
+
+| Target | 3 function pointers | `id` (`StateId`/`uint8_t`) | padding | `sizeof(State)` |
+|--------|----------------------|----------------------------|---------|-------------------|
+| ESP32-C3 (32-bit) | 3 × 4 = 12 B | 1 B | 3 B | **16 B** |
+| native/PC (64-bit) | 3 × 8 = 24 B | 1 B | 7 B | **32 B** |
+
+**`StateMachine` instance byte budget (SRAM, one per stateful actor):**
+
+| Target | `owner_` + `states_` (2 pointers) | `timeInStateMs_` | 6 × 1 B fields (`current_`, `previous_`, `pending_`, `stateCount_`, `inTransition_`, `transitionOverflows_`) | padding | `sizeof(StateMachine)` |
+|--------|-----------------------------------|-------------------|----------------------------------------------------------------------------------------------------------|---------|--------------------------|
+| ESP32-C3 (32-bit) | 8 B | 4 B | 6 B | 2 B | **20 B** |
+| native/PC (64-bit) | 16 B | 4 B | 6 B | 6 B | **32 B** |
+
+Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field order is `owner_`, `states_`, `timeInStateMs_`, then the six 1-byte fields, exactly as budgeted; no drift from the design.
+
+**`ObjectPool<T, N>` byte budget:** `N * sizeof(T)` for the aligned slot storage, plus target-independent bookkeeping (a `uint32_t liveWords_[(N+31)/32]` bitmask plus two `uint16_t` counters, `liveCount_` and `scanHint_`) — identical on ESP32-C3 and native because every bookkeeping field is a fixed-width type:
+
+| `N` (pool capacity) | `liveWords_` | counters (`liveCount_` + `scanHint_`) | **bookkeeping total** | per-slot equivalent |
+|---|---|---|---|---|
+| 8 | 1 × 4 B | 4 B | **8 B** | 1.00 B/slot |
+| 16 | 1 × 4 B | 4 B | **8 B** | 0.50 B/slot |
+| 32 | 1 × 4 B | 4 B | **8 B** | 0.25 B/slot |
+| 64 | 2 × 4 B | 4 B | **12 B** | 0.19 B/slot |
+
+Total instance size is `N * sizeof(T) + bookkeeping`, plus up to `alignof(T) - 1` bytes of tail padding for an over-aligned `T`. Since it is a template, only the `(T, N)` pairs a game actually instantiates emit any code or data — an unused instantiation costs nothing.
+
 **`GameplayEvent` byte budget (`GAMEPLAY_EVENT_QUEUE_CAPACITY` slots, default 32):**
 
 | Target | `void*` | `Scalar` | ids (2× `uint16_t`) | type tag | padding | `sizeof(GameplayEvent)` | Queue total |

--- a/docs/patterns/game-session-state.md
+++ b/docs/patterns/game-session-state.md
@@ -1,0 +1,244 @@
+# Pattern: Game Session State (Score / Lives / Game-Over)
+
+> **Status:** deliberate exclusion, not an oversight and not a TODO. There is no
+> `GameState`, `ScoreTracker`, or `LivesSystem` class in this engine, and
+> Gameplay Framework Phase 2 (`docs/architecture/memory-system.md`) does not
+> add one. This page documents why, and shows the pattern to use instead.
+
+If you are looking for the built-in class that tracks score, lives, and
+game-over — it does not exist, and this is the answer to "why not", not a
+placeholder for "not yet".
+
+---
+
+## The audit finding (§5.9)
+
+The engine's top-down capability audit (`docs/audits/topdown-genre-capability-audit.md`,
+§5.9) flagged that several examples repeat the same trio — `int score;
+int lives; bool gameOver;` — and asked whether a small reusable class was
+worth adding. Gameplay Framework Phase 2's design (`design.md` D0) closed that
+question: **no.** The evidence, checked against the 15 examples under
+`examples/`, is weaker than the audit's one-line summary suggested, and the
+shape of what exists is actively incompatible across examples.
+
+### `score`, `lives`, and `gameOver` are not one recurring shape — they are three
+
+| Field | Examples that have it | Count |
+|---|---|---|
+| `score` | `space_invaders`, `brick_breaker`, `2048`, `snake`, `flappy_bird` | 5 of 15 |
+| `lives` | `brick_breaker`, `space_invaders` | **2 of 15** |
+| Full triad (`score` + `lives` + `gameOver`) | `brick_breaker`, `space_invaders` | **2 of 15** |
+
+Two examples out of fifteen is not a pattern worth an engine class — it is
+two examples of the same genre (a breakout clone and a shoot-'em-up) that
+happen to both be "you have N chances, lose one per mistake."
+`metroidvania`, the platformer with the most gameplay logic of any example,
+has **none** of the three fields: no `score`, no `lives`, no `gameOver`.
+A health/lives concept doesn't even apply the same way to every genre.
+
+### `gameOver` itself has three mutually incompatible shapes
+
+1. **A bare `bool`.** `brick_breaker/src/BrickBreakerScene.h`,
+   `space_invaders/src/SpaceInvadersScene.h`, `snake/src/SnakeScene.h`, and
+   `2048/src/Game2048Logic.h` all declare `bool gameOver = false;` (or
+   equivalent) directly. Binary: the game either has ended or it hasn't.
+
+2. **One value inside a 3-state flow enum.** `flappy_bird` has no bare
+   `gameOver` field at all. Instead, `GameState` in
+   `examples/flappy_bird/src/FlappyBirdConstants.h:12-16` is:
+
+   ```cpp
+   enum class GameState {
+       WAITING,   ///< Pre-start, waiting for first jump
+       RUNNING,   ///< Active gameplay
+       GAME_OVER  ///< Bird collided
+   };
+   ```
+
+   Game-over here is one of three *mutually exclusive session phases*, not a
+   flag layered on top of "playing."
+
+3. **A 4-value enum answering a different question entirely.**
+   `tic_tac_toe/src/TicTacToeScene.h:24-29` declares:
+
+   ```cpp
+   enum class GameState {
+       Playing,
+       WinX,
+       WinO,
+       Draw
+   };
+   ```
+
+   This isn't "did the player die" — it's "who won the round," a
+   three-way outcome (X, O, or nobody) that has no `lives` concept at all.
+   Notably, the same header *also* declares a separate, redundant
+   `bool gameOver;` field (line 67) alongside `GameState gameState;` — even
+   within one example, two independent representations of "is this over"
+   coexist unreconciled. That is itself evidence against a single shared
+   type: if a shared `GameState`/`ScoreTracker` class had existed when this
+   example was written, would it have modeled "who won" or "is it over"?
+   There is no single correct answer, because the two questions are not the
+   same question.
+
+None of these three shapes is more "correct" than the others — each is
+correct **for its own game**. A shared type would have to pick one shape,
+and by definition would be wrong for at least two of the three.
+
+### Even the trivially-compatible case doesn't fit
+
+`2048` tracks both `score` and `gameOver`, but neither field lives on the
+`Scene`. Both are members of `Game2048Logic`
+(`examples/2048/src/Game2048Logic.h:41,43`) — a plain domain-logic class the
+scene owns and queries via `getScore()` / `isGameOver()`. A `Scene`-attached
+tracker (the shape the audit's phrasing implies) would not even have
+anywhere to attach in this example, because the scene is deliberately a thin
+presentation layer over logic that owns its own state. This is the fourth
+data point, and it points the same direction as the other three: session
+state belongs with the game's own logic, shaped by that game's own rules,
+not bolted onto every `Scene` uniformly.
+
+---
+
+## Industry precedent
+
+This isn't just a local observation — it matches how established engines
+have handled the same question.
+
+| Engine | Ships a score/lives/game-over type? | What it ships instead |
+|---|---|---|
+| **Unity** | No | `PlayerPrefs` — generic key-value persistence. Score/lives are always user-defined `MonoBehaviour` fields or a project-specific `GameManager` singleton. |
+| **Godot** | No | Documents a project-defined **autoload singleton** (e.g. a `GameState.gd`) as *the* recommended pattern for cross-scene session data — explicitly leaving its shape to the game. |
+| **Bevy** (ECS) | No | A plain `Resource` the game defines itself; ECS engines have no opinion on what constitutes "session state" because that's domain data, not engine data. |
+| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — its only networking surface (ESP-NOW) is explicitly out of scope for this engine's gameplay layer (`docs/audits/topdown-genre-capability-audit.md` line 264). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
+| **GameMaker Studio** | **Shipped one, then deprecated it** | GameMaker is the closest analogue to this project — 2D, sample/tutorial-driven, aimed at exactly this kind of arcade game. It shipped built-in global `score`, `lives`, and `health` variables from its earliest versions. Despite costing next to nothing in memory, they were deprecated in later versions precisely because they baked in an arcade session model (one score, one life counter, one health value, globally) that does not fit every game built with the engine — a puzzle game, a turn-based game, or anything with per-entity rather than per-player health had to work around built-ins that assumed the wrong shape. |
+
+The GameMaker case is the most directly instructive: this is not a
+hypothetical risk. A real engine shipped almost exactly the type §5.9
+proposes, at effectively zero memory cost, and walked it back once enough
+different game shapes proved the built-in model wrong for them.
+
+## The point that actually ties this together
+
+The genuinely universal primitive that established engines *do* provide is
+not a score/lives type — it's **persistence**: Unity's `PlayerPrefs`,
+Godot's `ConfigFile`. Every one of those precedent engines converges on the
+same thing: give the game a place to durably store *whatever shape of
+session data it has*, and let the game define that shape itself.
+
+PixelRoot32 already has this on its roadmap as **§5.8 — a generic key-value
+persistence system**, scheduled for Gameplay Framework Phase 4. That is the
+capability that actually generalizes across every example's ad hoc
+`score`/`lives`/`gameOver` trio: not a shared shape for the data, but a
+shared mechanism for making whatever shape a given game chooses survive a
+reset or a power cycle. §5.9 was reaching for something real — the
+duplication is real, engineers should not be reinventing high-score
+persistence per example — but the fix is one level down the stack from a
+shared struct.
+
+---
+
+## The pattern to use instead
+
+Keep session state as a plain member of your own `Scene`, or — better, for
+anything beyond a single flag and a counter — as a small domain-logic class
+your scene owns and delegates to. This is not a compromise; it's what every
+precedent engine above actually recommends, and it's what the best existing
+example in this codebase already does.
+
+**Simple case — session state as `Scene` members**, when the shape really is
+just a `score`/`lives`/`gameOver` triple for that one game:
+
+```cpp
+class BrickBreakerScene : public pixelroot32::core::Scene {
+    // ...
+private:
+    int score;
+    int lives;
+    bool gameOver;
+
+public:
+    void addScore(int points) { score += points; /* ... */ }
+};
+```
+
+This is exactly what `examples/brick_breaker/src/BrickBreakerScene.h` and
+`examples/space_invaders/src/SpaceInvadersScene.h` already do. Nothing about
+this is a workaround — it is the right amount of structure for two fields
+and a flag that are meaningful only to that one game.
+
+**Richer case — a small domain-logic class the scene owns**, when session
+state has real rules (win/merge logic, multiple derived values, or state
+that shouldn't live in a rendering-facing class):
+
+```cpp
+// Game2048Logic owns score + gameOver; the Scene queries it, never
+// duplicates it.
+class Game2048Logic {
+public:
+    int getScore() const { return score; }
+    bool isGameOver() const { return gameOver; }
+    void checkGameOver();
+
+private:
+    int score = 0;
+    bool gameOver = false;
+};
+
+class Game2048Scene : public pixelroot32::core::Scene {
+    // ...
+private:
+    Game2048Logic gameLogic;
+    // scoreLabel etc. read from gameLogic, they don't own the value
+};
+```
+
+This is `examples/2048/src/Game2048Logic.h` and
+`examples/2048/src/Game2048Scene.h` as they exist today, and it's the
+pattern to reach for once "is the game over" stops being a single boolean
+question — 2048's own answer depends on whether any tile can still merge,
+which is exactly the kind of per-game rule a shared engine class could never
+have anticipated.
+
+**For a flow-state game** (a title screen, a running phase, a game-over
+screen, maybe a win screen), model the flow explicitly as your own enum —
+as `flappy_bird` and `tic_tac_toe` already do — rather than layering a
+`bool` on top of a `Scene` that's also trying to represent "not started
+yet." If your game already needs a state machine for player or enemy
+behavior, Gameplay Framework Phase 2's `pixelroot32::gameplay::StateMachine`
+(`include/gameplay/StateMachine.h`) is a reasonable, general-purpose place to
+put a session-flow enum too — but that's a choice for the specific game,
+not something the engine should decide on your behalf.
+
+### What this buys you that a shared class couldn't
+
+- **The shape matches the game.** A binary `gameOver`, a three-phase flow,
+  and a four-way round outcome are three different data models; forcing them
+  through one shared type would have made at least two of the three worse.
+- **No dependency on engine internals for domain rules.** `checkGameOver()`
+  in `Game2048Logic` encodes 2048-specific merge rules. That logic has no
+  business living in `include/gameplay/`, where it would be compiled into
+  every game whether or not it uses that rule.
+- **Persistence, when you need it, is a separate concern.** Once §5.8 lands,
+  saving/loading whatever session shape you chose becomes a serialization
+  problem against a key-value store, not a redesign of your session type.
+
+---
+
+## Summary
+
+- §5.9's premise — that games under this engine duplicate `score`/`lives`/
+  `gameOver` handling — is real but overstated: only 2 of 15 examples share
+  the full triad, and the `gameOver` concept alone takes three structurally
+  incompatible shapes across the examples that have it at all.
+- Unity, Godot, and Bevy ship no such type; Unreal's `Score` is a side
+  effect of network-replication infrastructure this engine doesn't have;
+  GameMaker shipped one and deprecated it once it proved to fit the wrong
+  games.
+- The real, generalizable need underneath §5.9 is persistence, already
+  tracked as roadmap item §5.8 for Gameplay Framework Phase 4.
+- Keep session state as `Scene` members for the simple case, or as a small
+  owned domain-logic class (`Game2048Logic` is the working precedent) once
+  the rules get non-trivial. This is not a workaround for a missing engine
+  feature — it is the correct, final design for domain data that is
+  specific to your game.

--- a/docs/patterns/game-session-state.md
+++ b/docs/patterns/game-session-state.md
@@ -11,15 +11,13 @@ placeholder for "not yet".
 
 ---
 
-## The audit finding (§5.9)
+## Why there is no engine class
 
-The engine's top-down capability audit (`docs/audits/topdown-genre-capability-audit.md`,
-§5.9) flagged that several examples repeat the same trio — `int score;
-int lives; bool gameOver;` — and asked whether a small reusable class was
-worth adding. Gameplay Framework Phase 2's design (`design.md` D0) closed that
-question: **no.** The evidence, checked against the 15 examples under
-`examples/`, is weaker than the audit's one-line summary suggested, and the
-shape of what exists is actively incompatible across examples.
+At first glance several examples look like they repeat the same trio — `int
+score; int lives; bool gameOver;` — which reads as an obvious candidate for a
+small reusable class. Checked against all 15 examples under `examples/`, that
+impression does not survive: the overlap is much thinner than it looks, and
+the shapes that do exist are actively incompatible with each other.
 
 ### `score`, `lives`, and `gameOver` are not one recurring shape — they are three
 
@@ -91,7 +89,7 @@ and by definition would be wrong for at least two of the three.
 `Scene`. Both are members of `Game2048Logic`
 (`examples/2048/src/Game2048Logic.h:41,43`) — a plain domain-logic class the
 scene owns and queries via `getScore()` / `isGameOver()`. A `Scene`-attached
-tracker (the shape the audit's phrasing implies) would not even have
+tracker — the most natural shape for such a class — would not even have
 anywhere to attach in this example, because the scene is deliberately a thin
 presentation layer over logic that owns its own state. This is the fourth
 data point, and it points the same direction as the other three: session
@@ -110,7 +108,7 @@ have handled the same question.
 | **Unity** | No | `PlayerPrefs` — generic key-value persistence. Score/lives are always user-defined `MonoBehaviour` fields or a project-specific `GameManager` singleton. |
 | **Godot** | No | Documents a project-defined **autoload singleton** (e.g. a `GameState.gd`) as *the* recommended pattern for cross-scene session data — explicitly leaving its shape to the game. |
 | **Bevy** (ECS) | No | A plain `Resource` the game defines itself; ECS engines have no opinion on what constitutes "session state" because that's domain data, not engine data. |
-| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — its only networking surface (ESP-NOW) is explicitly out of scope for this engine's gameplay layer (`docs/audits/topdown-genre-capability-audit.md` line 264). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
+| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — it ships no networking at all today; the ESP-NOW module is a roadmap item (`README.md`, Roadmap). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
 | **GameMaker Studio** | **Shipped one, then deprecated it** | GameMaker is the closest analogue to this project — 2D, sample/tutorial-driven, aimed at exactly this kind of arcade game. It shipped built-in global `score`, `lives`, and `health` variables from its earliest versions. Despite costing next to nothing in memory, they were deprecated in later versions precisely because they baked in an arcade session model (one score, one life counter, one health value, globally) that does not fit every game built with the engine — a puzzle game, a turn-based game, or anything with per-entity rather than per-player health had to work around built-ins that assumed the wrong shape. |
 
 The GameMaker case is the most directly instructive: this is not a

--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,23 @@ build_flags =
 	--coverage
 	-lgcov
 
+; Same suites as [env:native_test], but with every gameplay-framework flag
+; enabled. Keep the two envs separate and both in CI: native_test proves the
+; flags-off contract (no behavior change for existing examples), while this env
+; is the only place the gameplay capabilities' functional assertions actually
+; execute. Without it their test files compile only their #else stub branch and
+; the suites pass without asserting anything.
+[env:native_test_gameplay]
+extends = env:native_test
+build_flags =
+	${env:native_test.build_flags}
+	-D PIXELROOT32_ENABLE_GAMEPLAY_EVENTS=1
+	-D PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1
+	-D PIXELROOT32_ENABLE_SPATIAL_QUERY=1
+	-D PIXELROOT32_ENABLE_DEPTH_SORT=1
+	-D PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1
+	-D PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=1
+
 ; SIMULATOR TARGETS
 
 [native_full]

--- a/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
+++ b/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
@@ -100,7 +100,11 @@ void test_acquire_on_nonfull_pool_returns_live_constructed_object(void) {
     TEST_ASSERT_EQUAL_INT(11, obj->value);
     TEST_ASSERT_EQUAL_UINT16(1, pool.size());
     const uint16_t index = pool.indexOf(obj);
-    TEST_ASSERT_TRUE(index != ObjectPool<TrackedPayload, 4>::kEnd);
+    // Alias, not the spelled-out template: the comma in <TrackedPayload, 4>
+    // is an argument separator to the preprocessor, so naming the template
+    // inside a Unity macro splits it into two arguments and fails to compile.
+    using Pool = ObjectPool<TrackedPayload, 4>;
+    TEST_ASSERT_TRUE(index != Pool::kEnd);
     TEST_ASSERT_TRUE(pool.isLive(index));
     TEST_ASSERT_EQUAL_INT(1, TrackedPayload::constructCount);
 }
@@ -209,7 +213,8 @@ void test_releasing_null_foreign_or_already_free_pointer_is_safe_noop(void) {
     TrackedPayload standalone(1, 1);
     TEST_ASSERT_FALSE(pool.release(&standalone));
     TEST_ASSERT_EQUAL_UINT16(0, pool.size());
-    TEST_ASSERT_EQUAL_UINT16(ObjectPool<TrackedPayload, 4>::kEnd, pool.indexOf(&standalone));
+    using Pool = ObjectPool<TrackedPayload, 4>;
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(&standalone));
 
     // Already-free slot: release a live object, then release it again.
     TrackedPayload* obj = pool.acquire(2, 2);
@@ -494,6 +499,36 @@ void test_at_returns_correctly_aligned_pointer_for_overaligned_t(void) {
         const auto addr = reinterpret_cast<std::uintptr_t>(recovered);
         TEST_ASSERT_EQUAL_UINT32(0u, static_cast<uint32_t>(addr % alignof(AlignedPayload)));
     }
+}
+
+// =============================================================================
+// Requirement: Feature-Gated And Zero-Cost When Disabled
+//
+// Defined in BOTH flag states, mirroring
+// test_gameplay_state_machine.cpp:680/711, because main() RUN_TESTs it
+// unconditionally. Defining it only in the #else branch leaves main()
+// referencing an undeclared function whenever the flag is on.
+// =============================================================================
+
+void test_gameplay_object_pool_zero_cost_when_disabled(void) {
+    // With the flag on, the cost must be exactly the slots and nothing per
+    // slot beyond the shared bitmask. Doubling N must grow the pool by
+    // exactly N * sizeof(T) — proving there is no hidden per-slot header,
+    // no vtable, and no indirection. This is the flag-on complement to
+    // test_pool_sizeof_stays_within_declared_budget's upper bound.
+    using Pool8 = ObjectPool<TrackedPayload, 8>;
+    using Pool16 = ObjectPool<TrackedPayload, 16>;
+
+    // Both N values fall in the same single bitmask word ((N + 31) / 32 == 1),
+    // so bookkeeping is identical and the delta is pure storage.
+    const size_t growth = sizeof(Pool16) - sizeof(Pool8);
+    TEST_ASSERT_EQUAL_UINT32(
+        static_cast<uint32_t>(8 * sizeof(TrackedPayload)),
+        static_cast<uint32_t>(growth));
+
+    // An instantiated pool reserves its slots statically: no heap, no
+    // pointer indirection to storage held elsewhere.
+    TEST_ASSERT_TRUE(sizeof(Pool8) >= 8 * sizeof(TrackedPayload));
 }
 
 #else  // !PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL


### PR DESCRIPTION
Fourth PR of the Gameplay Framework **Phase 2** chain. Base is PR #165.

Two commits: a CI fix that closes a real gap, and the documentation for both Phase 2 capabilities plus the §5.9 exclusion.

## The CI gap this closes

Found while designing Phase 2, but it is a **Phase 1** defect:

- `.github/workflows/tests.yml` ran exactly one command: `pio test -e native_test`
- `[env:native_test]`'s `build_flags` define **no** `PIXELROOT32_ENABLE_GAMEPLAY_*` macro
- `PlatformDefaults.h` defaults all of them to `0`

So every gameplay test compiled only its `#else` branch — a bare `TEST_PASS_MESSAGE`. **No functional gameplay assertion had ever executed in CI**, for Phase 1 or Phase 2. The suites passed while asserting nothing.

To be clear about what this does and does not mean: Phase 1's code *is* verified — the maintainer ran the all-flags-on matrix manually and all four suites passed. What was missing is any CI guard against a future regression. Phase 2 would have inherited exactly the same blindness, which would have made its ~1300 lines of new tests decorative.

`[env:native_test_gameplay]` extends `[env:native_test]` and enables all six flags (Phase 1's four plus Phase 2's two). **`[env:native_test]` is left byte-for-byte unchanged** — the flags-off run is what proves the "no behavior change for existing examples" contract, so it has to keep running exactly as it did.

The workflow gets a separate step rather than a second command appended to the existing one, so a failure names which configuration broke.

Verified before writing it: `[env:native_test]` extends `base_native`, which does not set `PIXELROOT32_ENABLE_PHYSICS`, so it falls back to the default `1` in `PlatformDefaults.h:30` — meaning the `#error` guard requiring physics for interaction-triggers and spatial-query is satisfied and the six-flag build is valid.

## Documentation

**`docs/architecture/memory-system.md`** — the two new flags and the D8 byte budgets: `StateMachine::State` row (16 B / 32 B) and instance (20 B / 32 B), `ObjectPool<T,N>` bookkeeping (8-12 B by `N`) plus the `N * sizeof(T)` storage rule, for both native 64-bit and ESP32-C3 32-bit. The figures were re-derived from the shipped headers rather than transcribed from the design, and they match.

**`docs/patterns/game-session-state.md`** (new) — score/lives/game-over as a **pattern**, and why it is deliberately not an engine class. Written so that a future contributor asking "why isn't there a `ScoreTracker` here?" gets a complete answer instead of re-opening the question.

The evidence, re-verified against the tree while writing:

| Field | Examples containing it (of 15) |
|---|---|
| `score` | 5 |
| `lives` | 2 |
| full `score`+`lives`+`gameOver` triad | 2 |

And `gameOver` has no canonical shape. The sharpest illustration is `tic_tac_toe`, which declares **both** representations in the same struct — a 4-value `GameState{Playing,WinX,WinO,Draw}` at `TicTacToeScene.h:65` *and* a separate `bool gameOver` at `:67`. If one example cannot settle on a single shape internally, an engine type cannot impose one across fifteen. Meanwhile metroidvania has none of the three fields, and 2048 keeps its score and game-over inside `Game2048Logic` rather than the `Scene`, so a `Scene`-attached tracker would not even fit it.

The industry precedent points the same way: Unity, Godot and Bevy ship no such type — Godot documents an autoload singleton as the pattern. Unreal *does* ship `Score` on `APlayerState`, but that is its network-replicated per-player container, i.e. replication infrastructure, and this engine has no replication. GameMaker — the closest analogue to this project — shipped built-in `score`/`lives`/`health` globals and later deprecated them despite their near-zero cost, because they imposed an arcade model on games that were not arcade games.

The universal primitive engines actually ship is persistence (`PlayerPrefs`, `ConfigFile`), and that is already roadmap §5.8 in Phase 4. The real need behind §5.9 is covered better, and later, by that.

The page is documentation only. No code under `include/`, `src/`, or `examples/`.

## Verification

`pio test -e native_test` must pass unchanged, and `pio test -e native_test_gameplay` should now execute the real assertions in all six suites — the first time that has ever happened.
