### PR TITLE
feat(gameplay): complete Phase 2 chain onto the tracker branch (5/5)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,14 @@ jobs:
       run: |
         pio test -e native_test --verbose
 
+    # Separate step, not appended to the one above, so a failure names which
+    # configuration broke. The env above proves the gameplay flags stay
+    # behavior-inert when off; this one is the only place their functional
+    # assertions actually run.
+    - name: Run Tests (gameplay flags enabled)
+      run: |
+        pio test -e native_test_gameplay --verbose
+
     - name: Generate Coverage Report
       run: |
         lcov --capture --directory . --output-file coverage.info

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -78,6 +78,40 @@ When subsystems are disabled via `PIXELROOT32_ENABLE_*` flags, their memory allo
 
 `PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1` or `PIXELROOT32_ENABLE_SPATIAL_QUERY=1` combined with `PIXELROOT32_ENABLE_PHYSICS=0` fails the build at compile time via an `#error` in `PlatformDefaults.h` (`CollisionSystem` and `SpatialGrid` only exist when physics is enabled), rather than silently disabling the feature.
 
+**Gameplay Framework Phase 2 flags (opt-in, default `0`):** two more capabilities in `pixelroot32::gameplay`, each pure composition with zero engine-side wiring — no new member, virtual, or hook on `Scene`, `Actor`, or `Entity`. Unlike Phase 1's `INTERACTION_TRIGGERS`/`SPATIAL_QUERY`, **neither depends on `PIXELROOT32_ENABLE_PHYSICS` or any other flag** — neither header includes `core/`, `physics/`, `math/`, or any other capability's header, so no `#error` guard exists or is needed:
+
+| Flag | Default | RAM Cost When Enabled | Subsystem Added |
+|------|---------|------------------------|------------------|
+| `PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1` | `0` | 20 B/instance (ESP32-C3) / 32 B/instance (native), plus one shared table in flash per class | `gameplay::StateMachine` — non-template FSM over a caller-owned `const` state table |
+| `PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=1` | `0` | `N * sizeof(T)` + 8-12 B bookkeeping per pool instantiation (see table below) | `gameplay::ObjectPool<T, N>` — fixed-capacity, zero-heap slot pool with placement-new storage |
+
+**`StateMachine::State` byte budget (one table row — flash/`.rodata`, shared per class, not per instance):**
+
+| Target | 3 function pointers | `id` (`StateId`/`uint8_t`) | padding | `sizeof(State)` |
+|--------|----------------------|----------------------------|---------|-------------------|
+| ESP32-C3 (32-bit) | 3 × 4 = 12 B | 1 B | 3 B | **16 B** |
+| native/PC (64-bit) | 3 × 8 = 24 B | 1 B | 7 B | **32 B** |
+
+**`StateMachine` instance byte budget (SRAM, one per stateful actor):**
+
+| Target | `owner_` + `states_` (2 pointers) | `timeInStateMs_` | 6 × 1 B fields (`current_`, `previous_`, `pending_`, `stateCount_`, `inTransition_`, `transitionOverflows_`) | padding | `sizeof(StateMachine)` |
+|--------|-----------------------------------|-------------------|----------------------------------------------------------------------------------------------------------|---------|--------------------------|
+| ESP32-C3 (32-bit) | 8 B | 4 B | 6 B | 2 B | **20 B** |
+| native/PC (64-bit) | 16 B | 4 B | 6 B | 6 B | **32 B** |
+
+Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field order is `owner_`, `states_`, `timeInStateMs_`, then the six 1-byte fields, exactly as budgeted; no drift from the design.
+
+**`ObjectPool<T, N>` byte budget:** `N * sizeof(T)` for the aligned slot storage, plus target-independent bookkeeping (a `uint32_t liveWords_[(N+31)/32]` bitmask plus two `uint16_t` counters, `liveCount_` and `scanHint_`) — identical on ESP32-C3 and native because every bookkeeping field is a fixed-width type:
+
+| `N` (pool capacity) | `liveWords_` | counters (`liveCount_` + `scanHint_`) | **bookkeeping total** | per-slot equivalent |
+|---|---|---|---|---|
+| 8 | 1 × 4 B | 4 B | **8 B** | 1.00 B/slot |
+| 16 | 1 × 4 B | 4 B | **8 B** | 0.50 B/slot |
+| 32 | 1 × 4 B | 4 B | **8 B** | 0.25 B/slot |
+| 64 | 2 × 4 B | 4 B | **12 B** | 0.19 B/slot |
+
+Total instance size is `N * sizeof(T) + bookkeeping`, plus up to `alignof(T) - 1` bytes of tail padding for an over-aligned `T`. Since it is a template, only the `(T, N)` pairs a game actually instantiates emit any code or data — an unused instantiation costs nothing.
+
 **`GameplayEvent` byte budget (`GAMEPLAY_EVENT_QUEUE_CAPACITY` slots, default 32):**
 
 | Target | `void*` | `Scalar` | ids (2× `uint16_t`) | type tag | padding | `sizeof(GameplayEvent)` | Queue total |

--- a/docs/patterns/game-session-state.md
+++ b/docs/patterns/game-session-state.md
@@ -1,0 +1,244 @@
+# Pattern: Game Session State (Score / Lives / Game-Over)
+
+> **Status:** deliberate exclusion, not an oversight and not a TODO. There is no
+> `GameState`, `ScoreTracker`, or `LivesSystem` class in this engine, and
+> Gameplay Framework Phase 2 (`docs/architecture/memory-system.md`) does not
+> add one. This page documents why, and shows the pattern to use instead.
+
+If you are looking for the built-in class that tracks score, lives, and
+game-over — it does not exist, and this is the answer to "why not", not a
+placeholder for "not yet".
+
+---
+
+## The audit finding (§5.9)
+
+The engine's top-down capability audit (`docs/audits/topdown-genre-capability-audit.md`,
+§5.9) flagged that several examples repeat the same trio — `int score;
+int lives; bool gameOver;` — and asked whether a small reusable class was
+worth adding. Gameplay Framework Phase 2's design (`design.md` D0) closed that
+question: **no.** The evidence, checked against the 15 examples under
+`examples/`, is weaker than the audit's one-line summary suggested, and the
+shape of what exists is actively incompatible across examples.
+
+### `score`, `lives`, and `gameOver` are not one recurring shape — they are three
+
+| Field | Examples that have it | Count |
+|---|---|---|
+| `score` | `space_invaders`, `brick_breaker`, `2048`, `snake`, `flappy_bird` | 5 of 15 |
+| `lives` | `brick_breaker`, `space_invaders` | **2 of 15** |
+| Full triad (`score` + `lives` + `gameOver`) | `brick_breaker`, `space_invaders` | **2 of 15** |
+
+Two examples out of fifteen is not a pattern worth an engine class — it is
+two examples of the same genre (a breakout clone and a shoot-'em-up) that
+happen to both be "you have N chances, lose one per mistake."
+`metroidvania`, the platformer with the most gameplay logic of any example,
+has **none** of the three fields: no `score`, no `lives`, no `gameOver`.
+A health/lives concept doesn't even apply the same way to every genre.
+
+### `gameOver` itself has three mutually incompatible shapes
+
+1. **A bare `bool`.** `brick_breaker/src/BrickBreakerScene.h`,
+   `space_invaders/src/SpaceInvadersScene.h`, `snake/src/SnakeScene.h`, and
+   `2048/src/Game2048Logic.h` all declare `bool gameOver = false;` (or
+   equivalent) directly. Binary: the game either has ended or it hasn't.
+
+2. **One value inside a 3-state flow enum.** `flappy_bird` has no bare
+   `gameOver` field at all. Instead, `GameState` in
+   `examples/flappy_bird/src/FlappyBirdConstants.h:12-16` is:
+
+   ```cpp
+   enum class GameState {
+       WAITING,   ///< Pre-start, waiting for first jump
+       RUNNING,   ///< Active gameplay
+       GAME_OVER  ///< Bird collided
+   };
+   ```
+
+   Game-over here is one of three *mutually exclusive session phases*, not a
+   flag layered on top of "playing."
+
+3. **A 4-value enum answering a different question entirely.**
+   `tic_tac_toe/src/TicTacToeScene.h:24-29` declares:
+
+   ```cpp
+   enum class GameState {
+       Playing,
+       WinX,
+       WinO,
+       Draw
+   };
+   ```
+
+   This isn't "did the player die" — it's "who won the round," a
+   three-way outcome (X, O, or nobody) that has no `lives` concept at all.
+   Notably, the same header *also* declares a separate, redundant
+   `bool gameOver;` field (line 67) alongside `GameState gameState;` — even
+   within one example, two independent representations of "is this over"
+   coexist unreconciled. That is itself evidence against a single shared
+   type: if a shared `GameState`/`ScoreTracker` class had existed when this
+   example was written, would it have modeled "who won" or "is it over"?
+   There is no single correct answer, because the two questions are not the
+   same question.
+
+None of these three shapes is more "correct" than the others — each is
+correct **for its own game**. A shared type would have to pick one shape,
+and by definition would be wrong for at least two of the three.
+
+### Even the trivially-compatible case doesn't fit
+
+`2048` tracks both `score` and `gameOver`, but neither field lives on the
+`Scene`. Both are members of `Game2048Logic`
+(`examples/2048/src/Game2048Logic.h:41,43`) — a plain domain-logic class the
+scene owns and queries via `getScore()` / `isGameOver()`. A `Scene`-attached
+tracker (the shape the audit's phrasing implies) would not even have
+anywhere to attach in this example, because the scene is deliberately a thin
+presentation layer over logic that owns its own state. This is the fourth
+data point, and it points the same direction as the other three: session
+state belongs with the game's own logic, shaped by that game's own rules,
+not bolted onto every `Scene` uniformly.
+
+---
+
+## Industry precedent
+
+This isn't just a local observation — it matches how established engines
+have handled the same question.
+
+| Engine | Ships a score/lives/game-over type? | What it ships instead |
+|---|---|---|
+| **Unity** | No | `PlayerPrefs` — generic key-value persistence. Score/lives are always user-defined `MonoBehaviour` fields or a project-specific `GameManager` singleton. |
+| **Godot** | No | Documents a project-defined **autoload singleton** (e.g. a `GameState.gd`) as *the* recommended pattern for cross-scene session data — explicitly leaving its shape to the game. |
+| **Bevy** (ECS) | No | A plain `Resource` the game defines itself; ECS engines have no opinion on what constitutes "session state" because that's domain data, not engine data. |
+| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — its only networking surface (ESP-NOW) is explicitly out of scope for this engine's gameplay layer (`docs/audits/topdown-genre-capability-audit.md` line 264). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
+| **GameMaker Studio** | **Shipped one, then deprecated it** | GameMaker is the closest analogue to this project — 2D, sample/tutorial-driven, aimed at exactly this kind of arcade game. It shipped built-in global `score`, `lives`, and `health` variables from its earliest versions. Despite costing next to nothing in memory, they were deprecated in later versions precisely because they baked in an arcade session model (one score, one life counter, one health value, globally) that does not fit every game built with the engine — a puzzle game, a turn-based game, or anything with per-entity rather than per-player health had to work around built-ins that assumed the wrong shape. |
+
+The GameMaker case is the most directly instructive: this is not a
+hypothetical risk. A real engine shipped almost exactly the type §5.9
+proposes, at effectively zero memory cost, and walked it back once enough
+different game shapes proved the built-in model wrong for them.
+
+## The point that actually ties this together
+
+The genuinely universal primitive that established engines *do* provide is
+not a score/lives type — it's **persistence**: Unity's `PlayerPrefs`,
+Godot's `ConfigFile`. Every one of those precedent engines converges on the
+same thing: give the game a place to durably store *whatever shape of
+session data it has*, and let the game define that shape itself.
+
+PixelRoot32 already has this on its roadmap as **§5.8 — a generic key-value
+persistence system**, scheduled for Gameplay Framework Phase 4. That is the
+capability that actually generalizes across every example's ad hoc
+`score`/`lives`/`gameOver` trio: not a shared shape for the data, but a
+shared mechanism for making whatever shape a given game chooses survive a
+reset or a power cycle. §5.9 was reaching for something real — the
+duplication is real, engineers should not be reinventing high-score
+persistence per example — but the fix is one level down the stack from a
+shared struct.
+
+---
+
+## The pattern to use instead
+
+Keep session state as a plain member of your own `Scene`, or — better, for
+anything beyond a single flag and a counter — as a small domain-logic class
+your scene owns and delegates to. This is not a compromise; it's what every
+precedent engine above actually recommends, and it's what the best existing
+example in this codebase already does.
+
+**Simple case — session state as `Scene` members**, when the shape really is
+just a `score`/`lives`/`gameOver` triple for that one game:
+
+```cpp
+class BrickBreakerScene : public pixelroot32::core::Scene {
+    // ...
+private:
+    int score;
+    int lives;
+    bool gameOver;
+
+public:
+    void addScore(int points) { score += points; /* ... */ }
+};
+```
+
+This is exactly what `examples/brick_breaker/src/BrickBreakerScene.h` and
+`examples/space_invaders/src/SpaceInvadersScene.h` already do. Nothing about
+this is a workaround — it is the right amount of structure for two fields
+and a flag that are meaningful only to that one game.
+
+**Richer case — a small domain-logic class the scene owns**, when session
+state has real rules (win/merge logic, multiple derived values, or state
+that shouldn't live in a rendering-facing class):
+
+```cpp
+// Game2048Logic owns score + gameOver; the Scene queries it, never
+// duplicates it.
+class Game2048Logic {
+public:
+    int getScore() const { return score; }
+    bool isGameOver() const { return gameOver; }
+    void checkGameOver();
+
+private:
+    int score = 0;
+    bool gameOver = false;
+};
+
+class Game2048Scene : public pixelroot32::core::Scene {
+    // ...
+private:
+    Game2048Logic gameLogic;
+    // scoreLabel etc. read from gameLogic, they don't own the value
+};
+```
+
+This is `examples/2048/src/Game2048Logic.h` and
+`examples/2048/src/Game2048Scene.h` as they exist today, and it's the
+pattern to reach for once "is the game over" stops being a single boolean
+question — 2048's own answer depends on whether any tile can still merge,
+which is exactly the kind of per-game rule a shared engine class could never
+have anticipated.
+
+**For a flow-state game** (a title screen, a running phase, a game-over
+screen, maybe a win screen), model the flow explicitly as your own enum —
+as `flappy_bird` and `tic_tac_toe` already do — rather than layering a
+`bool` on top of a `Scene` that's also trying to represent "not started
+yet." If your game already needs a state machine for player or enemy
+behavior, Gameplay Framework Phase 2's `pixelroot32::gameplay::StateMachine`
+(`include/gameplay/StateMachine.h`) is a reasonable, general-purpose place to
+put a session-flow enum too — but that's a choice for the specific game,
+not something the engine should decide on your behalf.
+
+### What this buys you that a shared class couldn't
+
+- **The shape matches the game.** A binary `gameOver`, a three-phase flow,
+  and a four-way round outcome are three different data models; forcing them
+  through one shared type would have made at least two of the three worse.
+- **No dependency on engine internals for domain rules.** `checkGameOver()`
+  in `Game2048Logic` encodes 2048-specific merge rules. That logic has no
+  business living in `include/gameplay/`, where it would be compiled into
+  every game whether or not it uses that rule.
+- **Persistence, when you need it, is a separate concern.** Once §5.8 lands,
+  saving/loading whatever session shape you chose becomes a serialization
+  problem against a key-value store, not a redesign of your session type.
+
+---
+
+## Summary
+
+- §5.9's premise — that games under this engine duplicate `score`/`lives`/
+  `gameOver` handling — is real but overstated: only 2 of 15 examples share
+  the full triad, and the `gameOver` concept alone takes three structurally
+  incompatible shapes across the examples that have it at all.
+- Unity, Godot, and Bevy ship no such type; Unreal's `Score` is a side
+  effect of network-replication infrastructure this engine doesn't have;
+  GameMaker shipped one and deprecated it once it proved to fit the wrong
+  games.
+- The real, generalizable need underneath §5.9 is persistence, already
+  tracked as roadmap item §5.8 for Gameplay Framework Phase 4.
+- Keep session state as `Scene` members for the simple case, or as a small
+  owned domain-logic class (`Game2048Logic` is the working precedent) once
+  the rules get non-trivial. This is not a workaround for a missing engine
+  feature — it is the correct, final design for domain data that is
+  specific to your game.

--- a/docs/patterns/game-session-state.md
+++ b/docs/patterns/game-session-state.md
@@ -11,15 +11,13 @@ placeholder for "not yet".
 
 ---
 
-## The audit finding (§5.9)
+## Why there is no engine class
 
-The engine's top-down capability audit (`docs/audits/topdown-genre-capability-audit.md`,
-§5.9) flagged that several examples repeat the same trio — `int score;
-int lives; bool gameOver;` — and asked whether a small reusable class was
-worth adding. Gameplay Framework Phase 2's design (`design.md` D0) closed that
-question: **no.** The evidence, checked against the 15 examples under
-`examples/`, is weaker than the audit's one-line summary suggested, and the
-shape of what exists is actively incompatible across examples.
+At first glance several examples look like they repeat the same trio — `int
+score; int lives; bool gameOver;` — which reads as an obvious candidate for a
+small reusable class. Checked against all 15 examples under `examples/`, that
+impression does not survive: the overlap is much thinner than it looks, and
+the shapes that do exist are actively incompatible with each other.
 
 ### `score`, `lives`, and `gameOver` are not one recurring shape — they are three
 
@@ -91,7 +89,7 @@ and by definition would be wrong for at least two of the three.
 `Scene`. Both are members of `Game2048Logic`
 (`examples/2048/src/Game2048Logic.h:41,43`) — a plain domain-logic class the
 scene owns and queries via `getScore()` / `isGameOver()`. A `Scene`-attached
-tracker (the shape the audit's phrasing implies) would not even have
+tracker — the most natural shape for such a class — would not even have
 anywhere to attach in this example, because the scene is deliberately a thin
 presentation layer over logic that owns its own state. This is the fourth
 data point, and it points the same direction as the other three: session
@@ -110,7 +108,7 @@ have handled the same question.
 | **Unity** | No | `PlayerPrefs` — generic key-value persistence. Score/lives are always user-defined `MonoBehaviour` fields or a project-specific `GameManager` singleton. |
 | **Godot** | No | Documents a project-defined **autoload singleton** (e.g. a `GameState.gd`) as *the* recommended pattern for cross-scene session data — explicitly leaving its shape to the game. |
 | **Bevy** (ECS) | No | A plain `Resource` the game defines itself; ECS engines have no opinion on what constitutes "session state" because that's domain data, not engine data. |
-| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — its only networking surface (ESP-NOW) is explicitly out of scope for this engine's gameplay layer (`docs/audits/topdown-genre-capability-audit.md` line 264). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
+| **Unreal Engine** | **Yes** — `Score` lives on `APlayerState` | But `PlayerState` exists as **network-replication infrastructure**: it is Unreal's per-connected-player container, replicated to every client so each peer knows every other player's score. The `Score` field is a side effect of that container already existing for multiplayer, not evidence that "score" deserves first-class engine status on its own. PixelRoot32 has no equivalent — it ships no networking at all today; the ESP-NOW module is a roadmap item (`README.md`, Roadmap). Without replication, there is no structural reason to centralize `Score` the way `APlayerState` does. |
 | **GameMaker Studio** | **Shipped one, then deprecated it** | GameMaker is the closest analogue to this project — 2D, sample/tutorial-driven, aimed at exactly this kind of arcade game. It shipped built-in global `score`, `lives`, and `health` variables from its earliest versions. Despite costing next to nothing in memory, they were deprecated in later versions precisely because they baked in an arcade session model (one score, one life counter, one health value, globally) that does not fit every game built with the engine — a puzzle game, a turn-based game, or anything with per-entity rather than per-player health had to work around built-ins that assumed the wrong shape. |
 
 The GameMaker case is the most directly instructive: this is not a

--- a/include/gameplay/ObjectPool.h
+++ b/include/gameplay/ObjectPool.h
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#pragma once
+
+#include "platforms/PlatformDefaults.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+/**
+ * @file ObjectPool.h
+ * @brief Fixed-capacity, zero-heap object pool with placement-new storage.
+ *
+ * ## Arena-backed pool storage is NOT supported (design.md D6)
+ *
+ * `ObjectPool<T, N>` is designed to be a plain member of the owning `Scene`
+ * or game object (or a file-scope `static`) — never allocated through
+ * `arenaNew`, and never backed by memory obtained from `SceneArena`. This is
+ * a structural limitation, not an oversight:
+ *
+ * - `Scene::resetState()` calls `arena.reset()` unconditionally, and the
+ *   arena runs no destructors: it only rewinds a bump offset. A pool placed
+ *   in arena memory would therefore never run `~ObjectPool()`, so `~T()`
+ *   never runs for any slot that was still live at reset time — a silent
+ *   resource leak for any `T` owning a resource.
+ * - Worse, a pool whose *storage* lives in arena memory keeps a
+ *   `liveWords_` bitmask asserting slots are live while the arena has
+ *   already rewound its offset and is about to hand those exact bytes to
+ *   the next `arenaNew` caller. Two live objects then alias one address,
+ *   and a later `release()`/`reset()` runs `~T()` over memory owned by
+ *   something else.
+ *
+ * There is no placement-site check in C++ that can catch this, and the one
+ * enforcement point that could — a `Scene::resetState()` hook — is exactly
+ * the engine-side wiring this capability is designed NOT to require. A
+ * documented contract with no enforcement point is worse than an
+ * unsupported feature stated plainly, so this header states it plainly.
+ *
+ * The supported reset contract instead: a pool owned by a `Scene` is reset
+ * from that scene's `init()` override, *after* the base `Scene::init()` has
+ * already run (which runs `resetState()` first):
+ *
+ * @code
+ * void MyScene::init() {
+ *     Scene::init();   // clears entities + removes them from CollisionSystem
+ *     pool_.reset();   // now safe: no dangling entity references remain
+ *     // ... repopulate
+ * }
+ * @endcode
+ *
+ * The ordering is "after", not "before": if a pooled `T` is also a
+ * registered `Entity`, destructing it before `Scene::init()`'s
+ * `resetState()` runs would leave dangling pointers in the scene's entity
+ * list for the window until `clearEntities()` runs.
+ *
+ * Narrow footnote, not a supported mode: if `std::is_trivially_destructible_v<T>`
+ * (e.g. a plain POD payload), arena placement degrades to the harmless
+ * "the pool's bytes disappear" case, since skipping a trivial `~T()` has no
+ * observable effect. This is not offered as a supported configuration
+ * because it cannot be enforced at the placement site — a caller who later
+ * changes `T` to own a resource gets silent corruption with no diagnostic.
+ */
+
+namespace pixelroot32::gameplay {
+
+namespace detail {
+
+#if defined(__GNUC__) || defined(__clang__)
+
+/// Index of the lowest set bit in `bits`. Every call site in ObjectPool
+/// guarantees `bits != 0` before calling.
+inline int objectPoolCountTrailingZero(uint32_t bits) {
+    return __builtin_ctz(bits);
+}
+
+#else
+
+/// Portable bit-loop fallback for toolchains without `__builtin_ctz`. Every
+/// call site in ObjectPool guarantees `bits != 0` before calling.
+inline int objectPoolCountTrailingZero(uint32_t bits) {
+    int index = 0;
+    while ((bits & 1u) == 0u) {
+        bits >>= 1u;
+        ++index;
+    }
+    return index;
+}
+
+#endif  // defined(__GNUC__) || defined(__clang__)
+
+}  // namespace detail
+
+/**
+ * @class ObjectPool
+ * @brief Fixed-capacity, zero-heap slot pool over aligned raw storage.
+ *
+ * Slots are `alignas(T) unsigned char storage_[N * sizeof(T)]`, constructed
+ * in place with placement new and recovered with `std::launder` for
+ * standard-correct aliasing (design.md D4). `T` is NOT required to have a
+ * default constructor: `acquire()` forwards its arguments to `T`'s
+ * constructor. Liveness is tracked by a `uint32_t` bitmask with a scan hint
+ * (design.md D5) — `acquire()` finds a free bit with `__builtin_ctz` (or a
+ * portable fallback), and `nextLive()` supports the ascending-index
+ * iteration pattern both hand-rolled precedents in this codebase already
+ * use:
+ *
+ * @code
+ * for (uint16_t i = pool.nextLive(0); i != Pool::kEnd; i = pool.nextLive(i + 1)) {
+ *     T& obj = *pool.at(i);
+ *     // ...
+ * }
+ * @endcode
+ *
+ * Never allocates: no `new`, no `malloc`, no `std::vector`. With
+ * `-fno-exceptions`, a constructor cannot fail, so there is no
+ * partially-constructed-slot case to unwind.
+ *
+ * Copy construction and copy assignment are deleted — a pool's slot
+ * pointers are identity, not value; copying the raw bytes without
+ * re-running every live `T`'s copy constructor would alias two pools over
+ * one set of resources.
+ *
+ * See this file's header-level doc comment for why arena-backed pool
+ * storage is NOT supported (design.md D6).
+ */
+template <typename T, uint16_t N>
+class ObjectPool {
+    static_assert(N >= 1, "ObjectPool capacity must be at least 1");
+
+public:
+    /// Fixed slot capacity of this pool instantiation.
+    static constexpr uint16_t kCapacity = N;
+
+    /// nextLive()/indexOf() end-of-iteration / not-found sentinel.
+    static constexpr uint16_t kEnd = 0xFFFFu;
+
+    ObjectPool() = default;
+
+    /// Destructs every remaining live slot via reset().
+    ~ObjectPool() { reset(); }
+
+    ObjectPool(const ObjectPool&) = delete;
+    ObjectPool& operator=(const ObjectPool&) = delete;
+
+    /**
+     * @brief Constructs a `T` in a free slot, forwarding `args` to `T`'s
+     *        constructor.
+     * @return A pointer to the newly constructed, live object, or `nullptr`
+     *         when the pool is full — every existing live slot is left
+     *         unmodified in that case.
+     *
+     * Never allocates (no `new`, no `malloc`). `T` does NOT need a default
+     * constructor; only a constructor matching `args` is required.
+     */
+    template <typename... Args>
+    T* acquire(Args&&... args) {
+        if (liveCount_ >= N) {
+            return nullptr;
+        }
+        for (uint16_t scanned = 0; scanned < kWordCount; ++scanned) {
+            const uint16_t wordIndex = static_cast<uint16_t>((scanHint_ + scanned) % kWordCount);
+            const uint32_t freeBits = (~liveWords_[wordIndex]) & wordMask(wordIndex);
+            if (freeBits != 0u) {
+                const uint32_t bit =
+                    static_cast<uint32_t>(detail::objectPoolCountTrailingZero(freeBits));
+                const uint16_t index = static_cast<uint16_t>(wordIndex * 32u + bit);
+
+                // Placement new's own return value is the correct pointer to
+                // use immediately — no std::launder needed on this path
+                // (design.md D4). Laundering is only required when a T* is
+                // later recovered from the raw bytes (at()/indexOf()/nextLive()).
+                T* slot = ::new (static_cast<void*>(rawSlot(index))) T(std::forward<Args>(args)...);
+
+                liveWords_[wordIndex] |= (uint32_t{1} << bit);
+                ++liveCount_;
+                scanHint_ = wordIndex;
+                return slot;
+            }
+        }
+        // Unreachable when liveCount_ < N and bookkeeping is consistent;
+        // kept as a defensive fallback rather than an assert.
+        return nullptr;
+    }
+
+    /**
+     * @brief Runs `~T()` on the slot holding `object` and frees it.
+     * @return `true` if a live slot was released; `false` (safe no-op, no
+     *         bookkeeping change, `~T()` NOT invoked again) for `nullptr`, a
+     *         pointer foreign to this pool, or a slot that is already free.
+     */
+    bool release(T* object) {
+        if (object == nullptr) {
+            return false;
+        }
+        const uint16_t index = indexOf(object);
+        if (index == kEnd) {
+            return false;
+        }
+        return releaseAt(index);
+    }
+
+    /**
+     * @brief Runs `~T()` on the slot at `index` and frees it.
+     * @return `true` if the slot was live and is now freed; `false` (safe
+     *         no-op) for an out-of-range index or a slot that is already
+     *         free.
+     */
+    bool releaseAt(uint16_t index) {
+        if (index >= N || !isLive(index)) {
+            return false;
+        }
+        std::launder(reinterpret_cast<T*>(rawSlot(index)))->~T();
+        clearBit(index);
+        --liveCount_;
+
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        if (wordIndex < scanHint_) {
+            scanHint_ = wordIndex;
+        }
+        return true;
+    }
+
+    /**
+     * @brief Runs `~T()` on every live slot, ascending index order, then
+     *        clears all bookkeeping. Safe to call on an empty pool.
+     */
+    void reset() {
+        for (uint16_t i = nextLive(0); i != kEnd; i = nextLive(static_cast<uint16_t>(i + 1))) {
+            std::launder(reinterpret_cast<T*>(rawSlot(i)))->~T();
+        }
+        for (uint16_t w = 0; w < kWordCount; ++w) {
+            liveWords_[w] = 0u;
+        }
+        liveCount_ = 0;
+        scanHint_ = 0;
+    }
+
+    /** @brief Fixed slot capacity (same value as kCapacity). */
+    uint16_t capacity() const { return N; }
+
+    /** @brief Number of slots currently live. */
+    uint16_t size() const { return liveCount_; }
+
+    /** @brief True when size() == capacity(). */
+    bool isFull() const { return liveCount_ == N; }
+
+    /** @brief True when `index` is in range and currently holds a live object. */
+    bool isLive(uint16_t index) const {
+        if (index >= N) {
+            return false;
+        }
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        const uint32_t bit = static_cast<uint32_t>(index % 32u);
+        return (liveWords_[wordIndex] & (uint32_t{1} << bit)) != 0u;
+    }
+
+    /**
+     * @brief Recovers a pointer to the live object at `index`.
+     * @return A `std::launder`-corrected `T*`, or `nullptr` if `index` is
+     *         out of range or dead.
+     */
+    T* at(uint16_t index) {
+        if (!isLive(index)) {
+            return nullptr;
+        }
+        return std::launder(reinterpret_cast<T*>(rawSlot(index)));
+    }
+
+    /**
+     * @brief Finds the slot index owning `object`.
+     * @return The slot index if `object` was returned by this pool's
+     *         `acquire()` and is still live; `kEnd` for a null, foreign, or
+     *         no-longer-live pointer.
+     */
+    uint16_t indexOf(const T* object) const {
+        if (object == nullptr) {
+            return kEnd;
+        }
+        const auto objAddr = reinterpret_cast<std::uintptr_t>(object);
+        const auto baseAddr = reinterpret_cast<std::uintptr_t>(storage_);
+        const auto totalBytes = static_cast<std::uintptr_t>(N) * sizeof(T);
+        if (objAddr < baseAddr || objAddr >= baseAddr + totalBytes) {
+            return kEnd;
+        }
+        const std::uintptr_t offset = objAddr - baseAddr;
+        if (offset % sizeof(T) != 0u) {
+            return kEnd;
+        }
+        const uint16_t index = static_cast<uint16_t>(offset / sizeof(T));
+        return isLive(index) ? index : kEnd;
+    }
+
+    /**
+     * @brief Returns the first live index `>= from`, or `kEnd` when none
+     *        remains.
+     *
+     * Masks off bits below `from` in the first word examined and skips
+     * whole zero words, so iterating with
+     * `for (i = nextLive(0); i != kEnd; i = nextLive(i + 1))` visits exactly
+     * the live indices, in ascending order, each exactly once.
+     */
+    uint16_t nextLive(uint16_t from) const {
+        if (from >= N) {
+            return kEnd;
+        }
+        uint16_t wordIndex = static_cast<uint16_t>(from / 32u);
+        const uint32_t bitOffset = static_cast<uint32_t>(from % 32u);
+        uint32_t word = liveWords_[wordIndex] & (0xFFFFFFFFu << bitOffset);
+
+        while (true) {
+            if (word != 0u) {
+                const uint32_t bit =
+                    static_cast<uint32_t>(detail::objectPoolCountTrailingZero(word));
+                return static_cast<uint16_t>(wordIndex * 32u + bit);
+            }
+            ++wordIndex;
+            if (wordIndex >= kWordCount) {
+                return kEnd;
+            }
+            word = liveWords_[wordIndex];
+        }
+    }
+
+private:
+    static constexpr uint16_t kWordCount = static_cast<uint16_t>((N + 31u) / 32u);
+
+    /// Mask of the bits within `liveWords_[wordIndex]` that correspond to a
+    /// real slot. Always all-ones except for the last word when N is not a
+    /// multiple of 32, where the high bits beyond N-1 have no backing slot
+    /// and must never be treated as "free" by acquire()/nextLive().
+    static constexpr uint32_t wordMask(uint16_t wordIndex) {
+        const uint32_t remaining =
+            static_cast<uint32_t>(N) - static_cast<uint32_t>(wordIndex) * 32u;
+        if (remaining >= 32u) {
+            return 0xFFFFFFFFu;
+        }
+        return (remaining == 0u) ? 0u : ((uint32_t{1} << remaining) - 1u);
+    }
+
+    unsigned char* rawSlot(uint16_t index) {
+        return storage_ + static_cast<size_t>(index) * sizeof(T);
+    }
+    const unsigned char* rawSlot(uint16_t index) const {
+        return storage_ + static_cast<size_t>(index) * sizeof(T);
+    }
+
+    void clearBit(uint16_t index) {
+        const uint16_t wordIndex = static_cast<uint16_t>(index / 32u);
+        const uint32_t bit = static_cast<uint32_t>(index % 32u);
+        liveWords_[wordIndex] &= ~(uint32_t{1} << bit);
+    }
+
+    alignas(T) unsigned char storage_[static_cast<size_t>(N) * sizeof(T)]{};
+    uint32_t liveWords_[kWordCount]{};
+    uint16_t liveCount_ = 0;
+    uint16_t scanHint_ = 0;
+};
+
+}  // namespace pixelroot32::gameplay
+
+#endif  // PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL

--- a/include/gameplay/StateMachine.h
+++ b/include/gameplay/StateMachine.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#pragma once
+
+#include "platforms/PlatformDefaults.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+#include <cstdint>
+
+namespace pixelroot32::gameplay {
+
+using StateId = uint8_t;
+
+/**
+ * @class StateMachine
+ * @brief Non-template finite state machine over a caller-owned, `const` state table.
+ *
+ * One shared `.cpp` compiles the transition/drain logic once, regardless of
+ * how many actor types use it — the owner is type-erased via `void*`, the
+ * same convention as `InteractionComponent` (design.md D1). The state table
+ * itself is NOT owned or copied by the machine: `configure()` binds a
+ * pointer, so the table must outlive the machine. The convention is a
+ * `static const` array at namespace or class-static scope, which lands in
+ * flash/`.rodata` and costs zero SRAM:
+ *
+ * @code
+ * static const StateMachine::State kPlayerStates[] = {
+ *     { onEnterIdle, onUpdateIdle, nullptr, static_cast<StateId>(PlayerState::IDLE) },
+ *     { onEnterRun,  onUpdateRun,  nullptr, static_cast<StateId>(PlayerState::RUN)  },
+ * };
+ *
+ * fsm.configure(this, kPlayerStates, kPlayerStateCount);
+ * fsm.start(static_cast<StateId>(PlayerState::IDLE));
+ * @endcode
+ *
+ * Transitions are immediate and synchronous: `requestState()` fully drains
+ * any chained transition requested from `onEnter`/`onExit` before it
+ * returns, without recursing (design.md D3). `getTimeInState()` is a
+ * saturating `uint32_t` millisecond counter, reset to `0` before `onEnter`
+ * runs on every real transition (design.md D2) — never `math::Scalar`,
+ * which is `float` on native and overflows Q16.16 after 32.7 s on the C3.
+ */
+class StateMachine {
+public:
+    /// No previous/next state (initial entry, teardown, or "unknown").
+    static constexpr StateId kInvalidStateId = 0xFF;
+
+    using EnterFn  = void (*)(void* owner, StateId fromState);
+    using UpdateFn = void (*)(void* owner, unsigned long deltaTime, uint32_t timeInStateMs);
+    using ExitFn   = void (*)(void* owner, StateId toState);
+
+    /// One row of the caller-owned state table. Pointers first (widest,
+    /// strictest alignment), tag last — same packing rule as GameplayEvent (D2).
+    struct State {
+        EnterFn  onEnter  = nullptr;   ///< May be null.
+        UpdateFn onUpdate = nullptr;   ///< May be null.
+        ExitFn   onExit   = nullptr;   ///< May be null.
+        StateId  id       = 0;         ///< Game enum value, cast at this boundary.
+    };
+
+    /**
+     * @brief Binds the machine to a caller-owned state table.
+     * @param owner Opaque pointer forwarded uncast to every callback.
+     * @param table Non-owning pointer to a table that MUST outlive this
+     *        machine (convention: `static const`). NOT copied.
+     * @param stateCount Number of rows in `table`.
+     *
+     * Lookups match by `State::id`, never by row position — reordering the
+     * table is safe as long as every id it declares is still present.
+     */
+    void configure(void* owner, const State* table, uint8_t stateCount);
+
+    /**
+     * @brief Enters `initialState`, firing only its `onEnter(owner, kInvalidStateId)`.
+     *
+     * Valid only from the un-started state (debug assert otherwise; a no-op
+     * in release builds).
+     */
+    void start(StateId initialState);
+
+    /**
+     * @brief Accumulates `deltaTime` into time-in-state (saturating), then
+     *        invokes at most one `onUpdate` — that of the state that was
+     *        current when this call was entered.
+     *
+     * A transition triggered inline by that `onUpdate` does not also run the
+     * newly entered state's `onUpdate` this call. No-op when `!isRunning()`.
+     */
+    void update(unsigned long deltaTime);
+
+    /**
+     * @brief Requests a transition to `nextState`.
+     * @return `false` if `nextState` matches no row in the configured table
+     *         (machine left unchanged); `true` otherwise — including the
+     *         no-op case where `nextState == getCurrentState()`.
+     *
+     * Immediate and synchronous: the transition, and any further transition
+     * requested from `onEnter`/`onExit`, are fully drained before this call
+     * returns. Never recurses — a chained request made while already
+     * transitioning is queued and drained by the initiating call, up to
+     * `kMaxChainedTransitions` iterations (design.md D3).
+     */
+    bool requestState(StateId nextState);
+
+    /**
+     * @brief Forces a real `onExit`/`onEnter` cycle on the current state and
+     *        resets `getTimeInState()` to `0`.
+     *
+     * Distinct from `requestState(getCurrentState())`, which is a no-op —
+     * this is the explicitly-named verb for a genuine re-entry.
+     */
+    void restartState();
+
+    /**
+     * @brief Returns the machine to the un-started state. Fires no callback.
+     *
+     * Teardown only: dispatching `onExit` here could run through an owner
+     * that is already gone (e.g. during a scene reset).
+     */
+    void reset();
+
+    StateId  getCurrentState()  const { return current_; }
+    StateId  getPreviousState() const { return previous_; }
+    uint32_t getTimeInState()   const { return timeInStateMs_; }
+    bool     isRunning()        const { return current_ != kInvalidStateId; }
+
+    /// Saturating count of transition chains clamped at kMaxChainedTransitions.
+    uint8_t  getTransitionOverflowCount() const { return transitionOverflows_; }
+
+private:
+    static constexpr uint8_t kMaxChainedTransitions = 8;
+
+    const State* findState(StateId id) const;
+
+    void*        owner_                = nullptr;
+    const State* states_               = nullptr;
+    uint32_t     timeInStateMs_        = 0;
+    StateId      current_              = kInvalidStateId;
+    StateId      previous_             = kInvalidStateId;
+    StateId      pending_              = kInvalidStateId;
+    uint8_t      stateCount_           = 0;
+    bool         inTransition_         = false;
+    uint8_t      transitionOverflows_  = 0;
+};
+
+}
+
+#endif // PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE

--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,23 @@ build_flags =
 	--coverage
 	-lgcov
 
+; Same suites as [env:native_test], but with every gameplay-framework flag
+; enabled. Keep the two envs separate and both in CI: native_test proves the
+; flags-off contract (no behavior change for existing examples), while this env
+; is the only place the gameplay capabilities' functional assertions actually
+; execute. Without it their test files compile only their #else stub branch and
+; the suites pass without asserting anything.
+[env:native_test_gameplay]
+extends = env:native_test
+build_flags =
+	${env:native_test.build_flags}
+	-D PIXELROOT32_ENABLE_GAMEPLAY_EVENTS=1
+	-D PIXELROOT32_ENABLE_INTERACTION_TRIGGERS=1
+	-D PIXELROOT32_ENABLE_SPATIAL_QUERY=1
+	-D PIXELROOT32_ENABLE_DEPTH_SORT=1
+	-D PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1
+	-D PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=1
+
 ; SIMULATOR TARGETS
 
 [native_full]

--- a/src/gameplay/StateMachine.cpp
+++ b/src/gameplay/StateMachine.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+#include "gameplay/StateMachine.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+#include <cassert>
+#include <cstdint>
+
+namespace pixelroot32::gameplay {
+
+void StateMachine::configure(void* owner, const State* table, uint8_t stateCount) {
+    assert(table != nullptr && "configure: table is null");
+    assert(stateCount > 0 && "configure: stateCount is zero");
+    owner_ = owner;
+    states_ = table;
+    stateCount_ = stateCount;
+}
+
+const StateMachine::State* StateMachine::findState(StateId id) const {
+    for (uint8_t i = 0; i < stateCount_; ++i) {
+        if (states_[i].id == id) return &states_[i];
+    }
+    return nullptr;
+}
+
+void StateMachine::start(StateId initialState) {
+    assert(!isRunning() && "start: machine already started (call reset() first)");
+    if (isRunning()) return;
+
+    const State* row = findState(initialState);
+    assert(row != nullptr && "start: initialState not found in the configured table");
+    if (!row) return;
+
+    previous_ = kInvalidStateId;
+    current_ = initialState;
+    timeInStateMs_ = 0;
+    if (row->onEnter) row->onEnter(owner_, kInvalidStateId);
+}
+
+void StateMachine::update(unsigned long deltaTime) {
+    if (!isRunning()) return;
+
+    // Saturating add (design.md D2): a state "gets stuck at maximum" rather
+    // than "gets younger", which would never satisfy an `>=` time guard.
+    const uint32_t dt = static_cast<uint32_t>(deltaTime);
+    timeInStateMs_ = (timeInStateMs_ > UINT32_MAX - dt) ? UINT32_MAX : timeInStateMs_ + dt;
+
+    // Rule 5: at most one onUpdate, for the state current on entry. If it
+    // transitions inline, the newly entered state's onUpdate does not also
+    // run this call.
+    const State* row = findState(current_);
+    if (row && row->onUpdate) row->onUpdate(owner_, deltaTime, timeInStateMs_);
+}
+
+bool StateMachine::requestState(StateId nextState) {
+    if (findState(nextState) == nullptr) return false;               // unknown id
+    if (nextState == current_) return true;                          // Rule 1: no-op
+    if (inTransition_) { pending_ = nextState; return true; }         // Rule 4: queued
+
+    inTransition_ = true;
+    StateId target = nextState;
+    uint8_t depth = 0;
+    for (; depth < kMaxChainedTransitions; ++depth) {
+        pending_ = kInvalidStateId;   // only requests made THIS iteration count
+
+        const StateId from = current_;
+        const State* fromRow = (from != kInvalidStateId) ? findState(from) : nullptr;
+        if (fromRow && fromRow->onExit) fromRow->onExit(owner_, target);  // sees time-in-state of `from`
+
+        previous_ = from;
+        current_ = target;
+        timeInStateMs_ = 0;   // reset BEFORE onEnter
+
+        const State* targetRow = findState(target);
+        if (targetRow && targetRow->onEnter) targetRow->onEnter(owner_, from);  // sees time-in-state == 0
+
+        if (pending_ == kInvalidStateId) break;                       // settled
+        if (pending_ == current_) { pending_ = kInvalidStateId; break; }  // Rule 1 inside the drain
+        target = pending_;
+    }
+    if (depth == kMaxChainedTransitions && transitionOverflows_ < 0xFF) {
+        ++transitionOverflows_;   // saturating diagnostic
+    }
+    pending_ = kInvalidStateId;
+    inTransition_ = false;
+    return true;
+}
+
+void StateMachine::restartState() {
+    if (!isRunning()) return;
+    assert(!inTransition_ && "restartState: must not be called re-entrantly from onEnter/onExit");
+    if (inTransition_) return;
+
+    const StateId self = current_;
+    const State* row = findState(self);
+
+    inTransition_ = true;
+    if (row && row->onExit) row->onExit(owner_, self);
+    previous_ = self;
+    current_ = self;
+    timeInStateMs_ = 0;
+    if (row && row->onEnter) row->onEnter(owner_, self);
+    // A transition requested from either callback during a restart is
+    // discarded rather than drained — design.md gives restartState() no
+    // chained-transition contract, unlike requestState()'s Rule 4.
+    pending_ = kInvalidStateId;
+    inTransition_ = false;
+}
+
+void StateMachine::reset() {
+    // Teardown only (Rule 6): fires nothing, so it is safe to call even
+    // when the owner is already gone. Configuration (owner_/states_/
+    // stateCount_) is left intact so the machine can start() again without
+    // a fresh configure() call. transitionOverflows_ is a monotonic
+    // diagnostic (mirrors GameplayEventBus::droppedCount_) and is not
+    // cleared by reset() either.
+    current_ = kInvalidStateId;
+    previous_ = kInvalidStateId;
+    pending_ = kInvalidStateId;
+    timeInStateMs_ = 0;
+    inTransition_ = false;
+}
+
+}
+
+#endif // PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE

--- a/src/gameplay/StateMachine.cpp
+++ b/src/gameplay/StateMachine.cpp
@@ -103,11 +103,19 @@ void StateMachine::restartState() {
     current_ = self;
     timeInStateMs_ = 0;
     if (row && row->onEnter) row->onEnter(owner_, self);
-    // A transition requested from either callback during a restart is
-    // discarded rather than drained — design.md gives restartState() no
-    // chained-transition contract, unlike requestState()'s Rule 4.
+
+    // A transition requested from either callback is honored, not dropped:
+    // requestState() already returned true to that caller, so discarding the
+    // request would make that return value a lie. Handing it back to
+    // requestState() reuses Rule 4's bounded, non-recursive drain instead of
+    // duplicating it here; inTransition_ is cleared first so the drain runs
+    // normally, and nesting stays bounded at one extra frame.
+    const StateId queued = pending_;
     pending_ = kInvalidStateId;
     inTransition_ = false;
+    if (queued != kInvalidStateId && queued != current_) {
+        requestState(queued);
+    }
 }
 
 void StateMachine::reset() {

--- a/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
+++ b/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
@@ -1,0 +1,554 @@
+/**
+ * @file test_gameplay_object_pool.cpp
+ * @brief Unit tests for gameplay/ObjectPool module
+ *
+ * Covers the spec requirements for gameplay-object-pool:
+ * - acquire-returns-usable-object-or-null-at-capacity-never-overflows-or-allocates
+ * - t-requires-no-default-constructor-construction-forwards-caller-arguments
+ * - destructor-invocation-on-release-and-reset
+ * - iteration-visits-only-live-slots-in-ascending-index-order
+ * - free-live-bookkeeping-correctness-across-interleaved-acquire-release-cycles
+ * - feature-gated-and-zero-cost-when-disabled
+ *
+ * (Arena-Backed Pool Storage Is Not Supported and Pool Owned By A Scene Must
+ * Be Reset After The Base Scene::init() Call are documented contracts, not
+ * runtime-testable behaviors — see include/gameplay/ObjectPool.h's
+ * header-level doc comment for the former and design.md D6 for both.)
+ *
+ * The functional tests only compile when PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+ * is enabled, since ObjectPool is entirely guarded behind that flag (see
+ * include/gameplay/ObjectPool.h). This file therefore compiles cleanly in
+ * BOTH the default (flag off) and opt-in (flag on) configurations, matching
+ * the "no behavior change for existing examples" goal and the CI matrix from
+ * design.md.
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "platforms/PlatformDefaults.h"
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+#include "gameplay/ObjectPool.h"
+
+#include <cstddef>
+#include <cstdint>
+
+using namespace pixelroot32::gameplay;
+
+namespace {
+
+/**
+ * @brief Mock payload with NO default constructor — only a two-argument
+ *        constructor — so that acquire()'s forwarding is exercised, and
+ *        with static construct/destruct counters plus an ordered destruct
+ *        log so release()/reset()/~ObjectPool() lifetime can be verified.
+ */
+struct TrackedPayload {
+    static constexpr int kMaxLog = 64;
+    static int constructCount;
+    static int destructCount;
+    static int destructOrderLog[kMaxLog];
+    static int destructOrderCount;
+
+    static void resetCounters() {
+        constructCount = 0;
+        destructCount = 0;
+        destructOrderCount = 0;
+    }
+
+    int value;
+    int tag;
+
+    // No default constructor on purpose (spec: "T Requires No Default
+    // Constructor; Construction Forwards Caller Arguments").
+    TrackedPayload(int v, int t) : value(v), tag(t) { ++constructCount; }
+
+    ~TrackedPayload() {
+        ++destructCount;
+        if (destructOrderCount < kMaxLog) {
+            destructOrderLog[destructOrderCount++] = tag;
+        }
+    }
+};
+
+int TrackedPayload::constructCount = 0;
+int TrackedPayload::destructCount = 0;
+int TrackedPayload::destructOrderLog[TrackedPayload::kMaxLog] = {};
+int TrackedPayload::destructOrderCount = 0;
+
+/// Over-aligned mock payload for the alignment scenario (task 3.14).
+struct alignas(16) AlignedPayload {
+    int value;
+    explicit AlignedPayload(int v) : value(v) {}
+};
+
+}  // namespace
+
+// =============================================================================
+// Requirement: Acquire Returns A Usable Object Or Null At Capacity, Never
+// Overflows Or Allocates
+// =============================================================================
+
+void test_acquire_on_nonfull_pool_returns_live_constructed_object(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(11, 0);
+
+    TEST_ASSERT_NOT_NULL(obj);
+    TEST_ASSERT_EQUAL_INT(11, obj->value);
+    TEST_ASSERT_EQUAL_UINT16(1, pool.size());
+    const uint16_t index = pool.indexOf(obj);
+    TEST_ASSERT_TRUE(index != ObjectPool<TrackedPayload, 4>::kEnd);
+    TEST_ASSERT_TRUE(pool.isLive(index));
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::constructCount);
+}
+
+void test_acquire_on_full_pool_returns_null_without_corrupting_live_objects(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* objs[4];
+    for (int i = 0; i < 4; ++i) {
+        objs[i] = pool.acquire(100 + i, i);
+        TEST_ASSERT_NOT_NULL(objs[i]);
+    }
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+
+    TrackedPayload* overflow = pool.acquire(999, 999);
+
+    TEST_ASSERT_NULL(overflow);
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+    // Every previously-live object must still read back its original value —
+    // acquire() on a full pool must not touch any existing slot.
+    for (int i = 0; i < 4; ++i) {
+        TEST_ASSERT_EQUAL_INT(100 + i, objs[i]->value);
+        TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(objs[i])));
+    }
+}
+
+void test_acquire_never_allocates_dynamically(void) {
+    // Structural guarantee, verified by inspection of ObjectPool.h: acquire()
+    // only performs placement-new into alignas(T) raw storage that is a
+    // member of the pool itself — there is no `new`, `malloc`, or any other
+    // dynamic allocator anywhere on the acquire() path (design.md D4). This
+    // test exercises acquire() across empty, partial, and full states to
+    // confirm none of those paths crash or behave as if memory had to be
+    // sourced externally.
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 2> pool;
+
+    TEST_ASSERT_NOT_NULL(pool.acquire(1, 0));
+    TEST_ASSERT_NOT_NULL(pool.acquire(2, 1));
+    TEST_ASSERT_NULL(pool.acquire(3, 2));  // full: no allocation fallback exists
+}
+
+// =============================================================================
+// Requirement: T Requires No Default Constructor; Construction Forwards
+// Caller Arguments
+// =============================================================================
+
+void test_acquire_constructs_t_with_no_default_constructor_via_forwarded_args(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 2> pool;
+
+    // TrackedPayload has no default constructor; this compiling and
+    // constructing correctly IS the requirement.
+    TrackedPayload* obj = pool.acquire(42, 7);
+
+    TEST_ASSERT_NOT_NULL(obj);
+    TEST_ASSERT_EQUAL_INT(42, obj->value);
+    TEST_ASSERT_EQUAL_INT(7, obj->tag);
+}
+
+// =============================================================================
+// Requirement: Destructor Invocation On Release And Reset
+// =============================================================================
+
+void test_release_destroys_exactly_once_and_frees_slot(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(5, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    const bool released = pool.release(obj);
+
+    TEST_ASSERT_TRUE(released);
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::destructCount);
+    TEST_ASSERT_FALSE(pool.isLive(index));
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+}
+
+void test_release_by_index_destroys_exactly_once_and_frees_slot(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* obj = pool.acquire(6, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    const bool released = pool.releaseAt(index);
+
+    TEST_ASSERT_TRUE(released);
+    TEST_ASSERT_EQUAL_INT(1, TrackedPayload::destructCount);
+    TEST_ASSERT_FALSE(pool.isLive(index));
+}
+
+void test_releasing_null_foreign_or_already_free_pointer_is_safe_noop(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    // Null pointer.
+    TEST_ASSERT_FALSE(pool.release(nullptr));
+    TEST_ASSERT_EQUAL_INT(0, TrackedPayload::destructCount);
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+
+    // Foreign pointer: a live TrackedPayload that does not belong to `pool`.
+    TrackedPayload standalone(1, 1);
+    TEST_ASSERT_FALSE(pool.release(&standalone));
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+    TEST_ASSERT_EQUAL_UINT16(ObjectPool<TrackedPayload, 4>::kEnd, pool.indexOf(&standalone));
+
+    // Already-free slot: release a live object, then release it again.
+    TrackedPayload* obj = pool.acquire(2, 2);
+    TEST_ASSERT_TRUE(pool.release(obj));
+    const int destructCountAfterFirstRelease = TrackedPayload::destructCount;
+
+    TEST_ASSERT_FALSE(pool.release(obj));
+    TEST_ASSERT_EQUAL_INT(destructCountAfterFirstRelease, TrackedPayload::destructCount);
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+
+    // Out-of-range index is likewise a safe no-op.
+    TEST_ASSERT_FALSE(pool.releaseAt(999));
+}
+
+void test_reset_destroys_all_live_slots_in_ascending_index_order(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 8> pool;
+
+    // Acquire several, release a non-contiguous subset, leaving a fragmented
+    // mix of live slots — reset() must still destroy the survivors in
+    // ascending INDEX order, not acquisition order.
+    TrackedPayload* p0 = pool.acquire(0, 100);
+    TrackedPayload* p1 = pool.acquire(1, 101);
+    TrackedPayload* p2 = pool.acquire(2, 102);
+    TrackedPayload* p3 = pool.acquire(3, 103);
+    TEST_ASSERT_TRUE(pool.release(p1));  // fragment the middle
+
+    const uint16_t idx0 = pool.indexOf(p0);
+    const uint16_t idx2 = pool.indexOf(p2);
+    const uint16_t idx3 = pool.indexOf(p3);
+    (void)p1;
+
+    TrackedPayload::destructOrderCount = 0;  // ignore p1's destruction above
+    pool.reset();
+
+    TEST_ASSERT_EQUAL_UINT16(0, pool.size());
+    for (uint16_t i = 0; i < pool.capacity(); ++i) {
+        TEST_ASSERT_FALSE(pool.isLive(i));
+    }
+
+    // The three survivors (tags 100, 102, 103 at idx0 < idx2 < idx3) must be
+    // destroyed in that ascending-index order.
+    TEST_ASSERT_TRUE(idx0 < idx2);
+    TEST_ASSERT_TRUE(idx2 < idx3);
+    TEST_ASSERT_EQUAL_INT(3, TrackedPayload::destructOrderCount);
+    TEST_ASSERT_EQUAL_INT(100, TrackedPayload::destructOrderLog[0]);
+    TEST_ASSERT_EQUAL_INT(102, TrackedPayload::destructOrderLog[1]);
+    TEST_ASSERT_EQUAL_INT(103, TrackedPayload::destructOrderLog[2]);
+}
+
+void test_pool_destructor_destroys_remaining_live_slots_on_scope_exit(void) {
+    TrackedPayload::resetCounters();
+    {
+        ObjectPool<TrackedPayload, 4> pool;
+        pool.acquire(1, 0);
+        pool.acquire(2, 1);
+        pool.acquire(3, 2);
+        TEST_ASSERT_EQUAL_INT(0, TrackedPayload::destructCount);
+    }  // ~ObjectPool() must run here, destroying all three live slots.
+    TEST_ASSERT_EQUAL_INT(3, TrackedPayload::destructCount);
+}
+
+// =============================================================================
+// Requirement: Iteration Visits Only Live Slots, In Ascending Index Order
+// =============================================================================
+
+void test_nextlive_visits_exactly_live_indices_in_ascending_order(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 8> pool;
+
+    TrackedPayload* items[8];
+    for (int i = 0; i < 8; ++i) {
+        items[i] = pool.acquire(i, i);
+    }
+    // Release a non-contiguous subset: indices 1, 3, 6.
+    TEST_ASSERT_TRUE(pool.release(items[1]));
+    TEST_ASSERT_TRUE(pool.release(items[3]));
+    TEST_ASSERT_TRUE(pool.release(items[6]));
+
+    uint16_t visited[8];
+    int visitedCount = 0;
+    using Pool = ObjectPool<TrackedPayload, 8>;
+    for (uint16_t i = pool.nextLive(0); i != Pool::kEnd; i = pool.nextLive(static_cast<uint16_t>(i + 1))) {
+        TEST_ASSERT_TRUE(visitedCount < 8);
+        visited[visitedCount++] = i;
+    }
+
+    // Expected surviving indices, strictly ascending: 0, 2, 4, 5, 7.
+    TEST_ASSERT_EQUAL_INT(5, visitedCount);
+    TEST_ASSERT_EQUAL_UINT16(0, visited[0]);
+    TEST_ASSERT_EQUAL_UINT16(2, visited[1]);
+    TEST_ASSERT_EQUAL_UINT16(4, visited[2]);
+    TEST_ASSERT_EQUAL_UINT16(5, visited[3]);
+    TEST_ASSERT_EQUAL_UINT16(7, visited[4]);
+    for (int i = 1; i < visitedCount; ++i) {
+        TEST_ASSERT_TRUE(visited[i - 1] < visited[i]);
+    }
+}
+
+void test_nextlive_on_empty_and_fully_live_pool(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+    using Pool = ObjectPool<TrackedPayload, 4>;
+
+    // Empty pool: no live index anywhere.
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.nextLive(0));
+
+    for (int i = 0; i < 4; ++i) {
+        pool.acquire(i, i);
+    }
+    // Fully live: visits every index 0..3, then kEnd.
+    uint16_t i = pool.nextLive(0);
+    for (uint16_t expected = 0; expected < 4; ++expected) {
+        TEST_ASSERT_EQUAL_UINT16(expected, i);
+        i = pool.nextLive(static_cast<uint16_t>(i + 1));
+    }
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, i);
+}
+
+// =============================================================================
+// Requirement: Free/Live Bookkeeping Correctness Across Interleaved
+// Acquire/Release Cycles
+// =============================================================================
+
+void test_bookkeeping_correct_across_interleaved_acquire_release(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* a = pool.acquire(1, 0);
+    TrackedPayload* b = pool.acquire(2, 1);
+    const uint16_t indexA = pool.indexOf(a);
+    TEST_ASSERT_EQUAL_UINT16(2, pool.size());
+    TEST_ASSERT_FALSE(pool.isFull());
+
+    TEST_ASSERT_TRUE(pool.release(a));
+    TEST_ASSERT_EQUAL_UINT16(1, pool.size());
+    TEST_ASSERT_FALSE(pool.isLive(indexA));  // a's old slot is now dead
+
+    TrackedPayload* c = pool.acquire(3, 2);
+    TrackedPayload* d = pool.acquire(4, 3);
+    TEST_ASSERT_EQUAL_UINT16(3, pool.size());
+
+    TrackedPayload* e = pool.acquire(5, 4);
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+
+    TEST_ASSERT_TRUE(pool.release(c));
+    TEST_ASSERT_FALSE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(3, pool.size());
+
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(b)));
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(d)));
+    TEST_ASSERT_TRUE(pool.isLive(pool.indexOf(e)));
+}
+
+void test_released_slot_is_available_for_reuse_on_full_pool(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+
+    TrackedPayload* items[4];
+    for (int i = 0; i < 4; ++i) {
+        items[i] = pool.acquire(10 + i, i);
+    }
+    TEST_ASSERT_TRUE(pool.isFull());
+
+    TEST_ASSERT_TRUE(pool.release(items[2]));
+    TEST_ASSERT_FALSE(pool.isFull());
+
+    TrackedPayload* reused = pool.acquire(999, 999);
+
+    TEST_ASSERT_NOT_NULL(reused);
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(4, pool.size());
+}
+
+void test_indexof_roundtrips_for_live_object_and_kend_for_foreign_pointer(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 4> pool;
+    using Pool = ObjectPool<TrackedPayload, 4>;
+
+    TrackedPayload* obj = pool.acquire(7, 0);
+    const uint16_t index = pool.indexOf(obj);
+
+    TEST_ASSERT_TRUE(index != Pool::kEnd);
+    TEST_ASSERT_EQUAL_PTR(obj, pool.at(index));
+
+    TrackedPayload standalone(1, 1);
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(&standalone));
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(nullptr));
+}
+
+// =============================================================================
+// Multi-word bitmask boundary check (design.md D5): N = 40 spans two
+// liveWords_ words (word0 = indices 0-31, word1 = indices 32-39, with bits
+// 8-31 of word1 unused padding). This exercises the tail-word mask that
+// prevents acquire()/nextLive() from treating word1's unused high bits as
+// free slots — the exact off-by-one class the bit math is most at risk of.
+// =============================================================================
+
+void test_multiword_bitmask_handles_tail_word_and_boundary_correctly(void) {
+    TrackedPayload::resetCounters();
+    ObjectPool<TrackedPayload, 40> pool;
+    using Pool = ObjectPool<TrackedPayload, 40>;
+
+    TrackedPayload* items[40];
+    for (int i = 0; i < 40; ++i) {
+        items[i] = pool.acquire(i, i);
+        TEST_ASSERT_NOT_NULL(items[i]);
+    }
+    // All 40 slots (including all 8 valid bits of the tail word) are live:
+    // the pool must report full, and a further acquire must return nullptr
+    // rather than treating word1's unused bits 8-31 as free.
+    TEST_ASSERT_TRUE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(40, pool.size());
+    TEST_ASSERT_NULL(pool.acquire(999, 999));
+
+    // Release two adjacent-across-the-word-boundary slots (31 in word0, 32
+    // in word1) and confirm nextLive() steps cleanly across that boundary.
+    TEST_ASSERT_TRUE(pool.release(items[31]));
+    TEST_ASSERT_TRUE(pool.release(items[32]));
+    TEST_ASSERT_FALSE(pool.isFull());
+    TEST_ASSERT_EQUAL_UINT16(38, pool.size());
+
+    TEST_ASSERT_EQUAL_UINT16(30, pool.nextLive(30));
+    TEST_ASSERT_EQUAL_UINT16(33, pool.nextLive(31));  // 31 and 32 both dead
+    TEST_ASSERT_EQUAL_UINT16(33, pool.nextLive(32));
+
+    // The last valid index (39) must still be reachable and never mistaken
+    // for out-of-range or for the kEnd sentinel.
+    TEST_ASSERT_TRUE(pool.isLive(39));
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.nextLive(40));
+
+    // Reacquiring must reuse one of the two freed slots (31 or 32), not
+    // spill into a nonexistent index 40.
+    TrackedPayload* reused = pool.acquire(1000, 1000);
+    TEST_ASSERT_NOT_NULL(reused);
+    const uint16_t reusedIndex = pool.indexOf(reused);
+    TEST_ASSERT_TRUE(reusedIndex == 31 || reusedIndex == 32);
+    TEST_ASSERT_EQUAL_UINT16(39, pool.size());
+}
+
+// =============================================================================
+// D8 byte-budget property assertions (not hardcoded byte counts — native_test
+// runs 64-bit, where pointer width and alignof(T) differ from ESP32-C3).
+// =============================================================================
+
+void test_pool_sizeof_stays_within_declared_budget(void) {
+    using Pool = ObjectPool<TrackedPayload, 8>;
+
+    // Bookkeeping per design.md D5: one uint32_t per 32 slots, plus the
+    // liveCount_/scanHint_ uint16_t counters.
+    constexpr size_t kWordCount = (8 + 31) / 32;
+    constexpr size_t declaredBookkeeping = kWordCount * sizeof(uint32_t) + 2 * sizeof(uint16_t);
+    const size_t declaredStorage = static_cast<size_t>(Pool::kCapacity) * sizeof(TrackedPayload);
+
+    // Storage may need up to (alignof(T) - 1) bytes of leading padding, and
+    // the object as a whole may need up to one machine word of trailing
+    // alignment padding — the same "declared members + one machine word"
+    // property bound test_gameplay_event_bus.cpp uses for GameplayEventBus.
+    const size_t declaredTotal =
+        declaredStorage + declaredBookkeeping + (alignof(TrackedPayload) - 1);
+
+    TEST_ASSERT_TRUE(sizeof(Pool) <= declaredTotal + sizeof(void*));
+}
+
+void test_at_returns_correctly_aligned_pointer_for_overaligned_t(void) {
+    ObjectPool<AlignedPayload, 4> pool;
+
+    AlignedPayload* a = pool.acquire(1);
+    AlignedPayload* b = pool.acquire(2);
+    AlignedPayload* c = pool.acquire(3);
+
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_NOT_NULL(c);
+
+    const uint16_t indices[3] = {pool.indexOf(a), pool.indexOf(b), pool.indexOf(c)};
+
+    for (int i = 0; i < 3; ++i) {
+        AlignedPayload* recovered = pool.at(indices[i]);
+        TEST_ASSERT_NOT_NULL(recovered);
+        const auto addr = reinterpret_cast<std::uintptr_t>(recovered);
+        TEST_ASSERT_EQUAL_UINT32(0u, static_cast<uint32_t>(addr % alignof(AlignedPayload)));
+    }
+}
+
+#else  // !PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+void test_gameplay_object_pool_zero_cost_when_disabled(void) {
+    // With the flag off, ObjectPool<T, N> is not compiled at all — its
+    // entire declaration lives inside the
+    // #if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL guard in
+    // include/gameplay/ObjectPool.h. This translation unit compiling and
+    // passing without referencing the template IS the "zero bytes reserved"
+    // property required by the spec's "Feature-Gated And Zero-Cost When
+    // Disabled" requirement — and it trivially subsumes the narrower
+    // "an uninstantiated (T, N) pairing costs nothing" scenario: with the
+    // flag off, EVERY (T, N) pairing is uninstantiated, and every one of
+    // them costs zero code and zero data.
+    TEST_PASS_MESSAGE(
+        "PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL=0: ObjectPool is not "
+        "compiled, zero bytes reserved for any (T, N) pairing.");
+}
+
+#endif  // PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL
+    RUN_TEST(test_acquire_on_nonfull_pool_returns_live_constructed_object);
+    RUN_TEST(test_acquire_on_full_pool_returns_null_without_corrupting_live_objects);
+    RUN_TEST(test_acquire_never_allocates_dynamically);
+    RUN_TEST(test_acquire_constructs_t_with_no_default_constructor_via_forwarded_args);
+    RUN_TEST(test_release_destroys_exactly_once_and_frees_slot);
+    RUN_TEST(test_release_by_index_destroys_exactly_once_and_frees_slot);
+    RUN_TEST(test_releasing_null_foreign_or_already_free_pointer_is_safe_noop);
+    RUN_TEST(test_reset_destroys_all_live_slots_in_ascending_index_order);
+    RUN_TEST(test_pool_destructor_destroys_remaining_live_slots_on_scope_exit);
+    RUN_TEST(test_nextlive_visits_exactly_live_indices_in_ascending_order);
+    RUN_TEST(test_nextlive_on_empty_and_fully_live_pool);
+    RUN_TEST(test_bookkeeping_correct_across_interleaved_acquire_release);
+    RUN_TEST(test_released_slot_is_available_for_reuse_on_full_pool);
+    RUN_TEST(test_indexof_roundtrips_for_live_object_and_kend_for_foreign_pointer);
+    RUN_TEST(test_multiword_bitmask_handles_tail_word_and_boundary_correctly);
+    RUN_TEST(test_pool_sizeof_stays_within_declared_budget);
+    RUN_TEST(test_at_returns_correctly_aligned_pointer_for_overaligned_t);
+#endif
+    RUN_TEST(test_gameplay_object_pool_zero_cost_when_disabled);
+
+    return UNITY_END();
+}

--- a/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
+++ b/test/unit/test_gameplay_object_pool/test_gameplay_object_pool.cpp
@@ -100,7 +100,11 @@ void test_acquire_on_nonfull_pool_returns_live_constructed_object(void) {
     TEST_ASSERT_EQUAL_INT(11, obj->value);
     TEST_ASSERT_EQUAL_UINT16(1, pool.size());
     const uint16_t index = pool.indexOf(obj);
-    TEST_ASSERT_TRUE(index != ObjectPool<TrackedPayload, 4>::kEnd);
+    // Alias, not the spelled-out template: the comma in <TrackedPayload, 4>
+    // is an argument separator to the preprocessor, so naming the template
+    // inside a Unity macro splits it into two arguments and fails to compile.
+    using Pool = ObjectPool<TrackedPayload, 4>;
+    TEST_ASSERT_TRUE(index != Pool::kEnd);
     TEST_ASSERT_TRUE(pool.isLive(index));
     TEST_ASSERT_EQUAL_INT(1, TrackedPayload::constructCount);
 }
@@ -209,7 +213,8 @@ void test_releasing_null_foreign_or_already_free_pointer_is_safe_noop(void) {
     TrackedPayload standalone(1, 1);
     TEST_ASSERT_FALSE(pool.release(&standalone));
     TEST_ASSERT_EQUAL_UINT16(0, pool.size());
-    TEST_ASSERT_EQUAL_UINT16(ObjectPool<TrackedPayload, 4>::kEnd, pool.indexOf(&standalone));
+    using Pool = ObjectPool<TrackedPayload, 4>;
+    TEST_ASSERT_EQUAL_UINT16(Pool::kEnd, pool.indexOf(&standalone));
 
     // Already-free slot: release a live object, then release it again.
     TrackedPayload* obj = pool.acquire(2, 2);
@@ -494,6 +499,36 @@ void test_at_returns_correctly_aligned_pointer_for_overaligned_t(void) {
         const auto addr = reinterpret_cast<std::uintptr_t>(recovered);
         TEST_ASSERT_EQUAL_UINT32(0u, static_cast<uint32_t>(addr % alignof(AlignedPayload)));
     }
+}
+
+// =============================================================================
+// Requirement: Feature-Gated And Zero-Cost When Disabled
+//
+// Defined in BOTH flag states, mirroring
+// test_gameplay_state_machine.cpp:680/711, because main() RUN_TESTs it
+// unconditionally. Defining it only in the #else branch leaves main()
+// referencing an undeclared function whenever the flag is on.
+// =============================================================================
+
+void test_gameplay_object_pool_zero_cost_when_disabled(void) {
+    // With the flag on, the cost must be exactly the slots and nothing per
+    // slot beyond the shared bitmask. Doubling N must grow the pool by
+    // exactly N * sizeof(T) — proving there is no hidden per-slot header,
+    // no vtable, and no indirection. This is the flag-on complement to
+    // test_pool_sizeof_stays_within_declared_budget's upper bound.
+    using Pool8 = ObjectPool<TrackedPayload, 8>;
+    using Pool16 = ObjectPool<TrackedPayload, 16>;
+
+    // Both N values fall in the same single bitmask word ((N + 31) / 32 == 1),
+    // so bookkeeping is identical and the delta is pure storage.
+    const size_t growth = sizeof(Pool16) - sizeof(Pool8);
+    TEST_ASSERT_EQUAL_UINT32(
+        static_cast<uint32_t>(8 * sizeof(TrackedPayload)),
+        static_cast<uint32_t>(growth));
+
+    // An instantiated pool reserves its slots statically: no heap, no
+    // pointer indirection to storage held elsewhere.
+    TEST_ASSERT_TRUE(sizeof(Pool8) >= 8 * sizeof(TrackedPayload));
 }
 
 #else  // !PIXELROOT32_ENABLE_GAMEPLAY_OBJECT_POOL

--- a/test/unit/test_gameplay_state_machine/test_gameplay_state_machine.cpp
+++ b/test/unit/test_gameplay_state_machine/test_gameplay_state_machine.cpp
@@ -1,0 +1,727 @@
+/**
+ * @file test_gameplay_state_machine.cpp
+ * @brief Unit tests for gameplay/StateMachine module
+ *
+ * Covers the spec requirements for gameplay-state-machine:
+ * - caller-owned-const-table (bind without copying, lookup by id not row order,
+ *   unknown id rejected)
+ * - transition-invokes-onexit-then-onenter (immediate, synchronous, correct args,
+ *   null callback skipped)
+ * - time-in-state-is-a-saturating-uint32-ms-counter
+ * - re-requesting-current-state-is-a-no-op
+ * - restart-state-performs-a-real-exit-enter-cycle
+ * - transitions-requested-from-onenter-or-onexit-are-queued-and-drained
+ *   (no recursion, last-writer-wins, ping-pong terminates with overflow)
+ * - at-most-one-onupdate-invocation-per-update-call
+ * - start-and-reset-semantics
+ * - owner-is-type-erased-via-void-star-with-no-new-virtuals
+ * - feature-gated-and-zero-cost-when-disabled
+ *
+ * The functional tests only compile when PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+ * is enabled, since StateMachine is entirely guarded behind that flag (see
+ * include/gameplay/StateMachine.h). This file therefore compiles cleanly in
+ * BOTH the default (flag off) and opt-in (flag on) configurations, matching
+ * the "no behavior change for existing examples" goal and the CI matrix from
+ * design.md.
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "platforms/PlatformDefaults.h"
+#include "core/Actor.h"
+#include "core/Entity.h"
+
+#include <cstddef>
+#include <type_traits>
+
+// =============================================================================
+// Requirement: Owner Is Type-Erased Via void*, With No New Virtuals On Actor
+// Or Entity
+//
+// This compile-time check is independent of PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+// — Actor/Entity are unconditional engine types — so, mirroring
+// test_interaction_tracker.cpp's placement, it lives outside the flag guard
+// and runs in BOTH configurations. The authoritative proof is that
+// include/core/Actor.h and include/core/Entity.h have ZERO diff lines in
+// this change (verified in the PR diff, not by this test); the minimal
+// concrete subclass below is a compile-time regression guard: if a new PURE
+// virtual were added to either class, it would fail to compile (still
+// abstract).
+// =============================================================================
+namespace {
+
+using pixelroot32::core::Actor;
+using pixelroot32::core::Entity;
+using pixelroot32::core::Rect;
+using pixelroot32::math::Vector2;
+using pixelroot32::math::toScalar;
+
+class MinimalActorSurface : public Actor {
+public:
+    MinimalActorSurface() : Actor(toScalar(0.0f), toScalar(0.0f), 1, 1) {}
+    Rect getHitBox() override { return Rect{position, width, height}; }
+    void onCollision(Actor* other) override { (void)other; }
+    void draw(pixelroot32::graphics::Renderer& renderer) override { (void)renderer; }
+};
+
+static_assert(!std::is_abstract<MinimalActorSurface>::value,
+              "MinimalActorSurface overrides exactly Entity::draw, "
+              "Actor::getHitBox and Actor::onCollision (the pure virtuals "
+              "declared before this PR). If this fails, a new pure virtual "
+              "was added to Actor or Entity by this change, which "
+              "gameplay-state-machine forbids — StateMachine must reference "
+              "its owner via void* without growing Actor's or Entity's vtable.");
+
+}  // namespace
+
+void test_no_new_virtuals_on_actor_or_entity(void) {
+    // Compile-time check above is the real assertion; this runtime test
+    // exists so the invariant shows up in the test report and so the
+    // translation unit is exercised (not just compiled) by the suite.
+    MinimalActorSurface actor;
+    TEST_ASSERT_EQUAL(1, actor.width);
+    TEST_ASSERT_EQUAL(1, actor.height);
+}
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+#include "gameplay/StateMachine.h"
+
+#include <cstdint>
+
+using namespace pixelroot32::gameplay;
+
+namespace {
+
+// Three test states. Deliberately declared with plain numeric ids so a
+// reordered table (below) can prove lookup is by id, not row position.
+enum : StateId { kStateA = 0, kStateB = 1, kStateC = 2, kStateUnregistered = 99 };
+
+/// One ordered call-log entry recorded by the mock owner's callbacks.
+struct LogEntry {
+    enum class Kind : uint8_t { Enter, Update, Exit };
+    Kind    kind;
+    StateId state;
+    StateId other;  ///< fromState for Enter, toState for Exit, kInvalidStateId for Update.
+};
+
+/**
+ * @brief Mock owner recording an ordered call log, with opt-in hooks that let
+ *        a test arm a callback to request a further transition (covers the
+ *        onEnter/onExit-requests-a-transition scenarios without needing a
+ *        distinct state table per scenario).
+ */
+struct MockOwner {
+    static constexpr int kMaxLog = 40;
+
+    StateMachine* fsm = nullptr;
+
+    LogEntry log[kMaxLog]{};
+    int      logCount = 0;
+
+    int           updateCount = 0;
+    unsigned long lastDeltaTime = 0;
+    uint32_t      lastTimeInState = 0;
+    uint32_t      lastEnterTimeInState = 0;  ///< getTimeInState() as observed inside onEnter.
+
+    // One-shot "request a transition the first time this state's callback fires".
+    StateId requestFromEnterOf     = StateMachine::kInvalidStateId;
+    StateId requestFromEnterTarget = StateMachine::kInvalidStateId;
+    bool    requestFromEnterFired  = false;
+
+    StateId requestFromExitOf     = StateMachine::kInvalidStateId;
+    StateId requestFromExitTarget = StateMachine::kInvalidStateId;
+    bool    requestFromExitFired  = false;
+
+    StateId requestFromUpdateOf     = StateMachine::kInvalidStateId;
+    StateId requestFromUpdateTarget = StateMachine::kInvalidStateId;
+    bool    requestFromUpdateFired  = false;
+
+    // Unconditional A<->B ping-pong, armed only for the overflow test.
+    bool pingPongAB = false;
+
+    void record(LogEntry::Kind kind, StateId state, StateId other) {
+        if (logCount < kMaxLog) log[logCount++] = LogEntry{kind, state, other};
+    }
+};
+
+void handleEnter(MockOwner* owner, StateId state, StateId from) {
+    owner->lastEnterTimeInState = owner->fsm->getTimeInState();
+    owner->record(LogEntry::Kind::Enter, state, from);
+
+    if (owner->pingPongAB) {
+        if (state == kStateA) { owner->fsm->requestState(kStateB); return; }
+        if (state == kStateB) { owner->fsm->requestState(kStateA); return; }
+    }
+    if (owner->requestFromEnterOf == state && !owner->requestFromEnterFired) {
+        owner->requestFromEnterFired = true;
+        owner->fsm->requestState(owner->requestFromEnterTarget);
+    }
+}
+
+void handleExit(MockOwner* owner, StateId state, StateId to) {
+    owner->record(LogEntry::Kind::Exit, state, to);
+
+    if (owner->requestFromExitOf == state && !owner->requestFromExitFired) {
+        owner->requestFromExitFired = true;
+        owner->fsm->requestState(owner->requestFromExitTarget);
+    }
+}
+
+void handleUpdate(MockOwner* owner, StateId state, unsigned long dt, uint32_t timeInState) {
+    owner->record(LogEntry::Kind::Update, state, StateMachine::kInvalidStateId);
+    ++owner->updateCount;
+    owner->lastDeltaTime = dt;
+    owner->lastTimeInState = timeInState;
+
+    if (owner->requestFromUpdateOf == state && !owner->requestFromUpdateFired) {
+        owner->requestFromUpdateFired = true;
+        owner->fsm->requestState(owner->requestFromUpdateTarget);
+    }
+}
+
+void onEnterA(void* owner, StateId from) { handleEnter(static_cast<MockOwner*>(owner), kStateA, from); }
+void onExitA(void* owner, StateId to)    { handleExit(static_cast<MockOwner*>(owner), kStateA, to); }
+void onUpdateA(void* owner, unsigned long dt, uint32_t t) { handleUpdate(static_cast<MockOwner*>(owner), kStateA, dt, t); }
+
+void onEnterB(void* owner, StateId from) { handleEnter(static_cast<MockOwner*>(owner), kStateB, from); }
+void onExitB(void* owner, StateId to)    { handleExit(static_cast<MockOwner*>(owner), kStateB, to); }
+void onUpdateB(void* owner, unsigned long dt, uint32_t t) { handleUpdate(static_cast<MockOwner*>(owner), kStateB, dt, t); }
+
+void onEnterC(void* owner, StateId from) { handleEnter(static_cast<MockOwner*>(owner), kStateC, from); }
+// C's onUpdate/onExit are deliberately left null in the table below, to
+// exercise the "null callback is skipped without crashing" scenario.
+
+/// The canonical table, row order matching numeric id order.
+static const StateMachine::State kTestTable[] = {
+    { onEnterA, onUpdateA, onExitA, kStateA },
+    { onEnterB, onUpdateB, onExitB, kStateB },
+    { onEnterC, nullptr,   nullptr, kStateC },
+};
+constexpr uint8_t kTestTableCount = 3;
+
+/// Same three states, deliberately reordered (C, A, B) to prove lookup is by
+/// State::id, never by row position.
+static const StateMachine::State kReorderedTable[] = {
+    { onEnterC, nullptr,   nullptr, kStateC },
+    { onEnterA, onUpdateA, onExitA, kStateA },
+    { onEnterB, onUpdateB, onExitB, kStateB },
+};
+constexpr uint8_t kReorderedTableCount = 3;
+
+}  // namespace
+
+// =============================================================================
+// Requirement: Caller-Owned Const State Table Contract
+// =============================================================================
+
+void test_configure_binds_table_without_copying(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+
+    // The machine must resolve lookups through the exact table pointer bound
+    // by configure() — the only observable proof available without exposing
+    // the private pointer is that lookups against that specific table work
+    // for every id it declares.
+    TEST_ASSERT_TRUE(fsm.requestState(kStateB));
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+}
+
+void test_state_lookup_matches_by_id_not_row_order(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    // kReorderedTable's row order is C, A, B — the numeric ordering of the
+    // ids is not the row order.
+    fsm.configure(&owner, kReorderedTable, kReorderedTableCount);
+    fsm.start(kStateB);
+
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_INT(1, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[0].state);
+}
+
+void test_request_state_unknown_id_rejected(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    owner.logCount = 0;
+
+    const bool result = fsm.requestState(kStateUnregistered);
+
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_INT(0, owner.logCount);
+}
+
+// =============================================================================
+// Requirement: Transition Invokes onExit Then onEnter, Immediately And Synchronously
+// =============================================================================
+
+void test_transition_invokes_onexit_then_onenter_in_order(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    owner.logCount = 0;
+
+    const bool result = fsm.requestState(kStateB);
+
+    // The transition is already complete by the time requestState() returns.
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getPreviousState());
+
+    TEST_ASSERT_EQUAL_INT(2, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[0].other);
+    TEST_ASSERT_TRUE(owner.log[1].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[1].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].other);
+}
+
+void test_null_callback_skipped_without_crash(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateB);
+    owner.logCount = 0;
+
+    // B -> C: C's onEnter is set, but C's onExit/onUpdate are null. Neither
+    // direction should crash or be logged.
+    TEST_ASSERT_TRUE(fsm.requestState(kStateC));
+    TEST_ASSERT_EQUAL_UINT8(kStateC, fsm.getCurrentState());
+    fsm.update(16);  // C's onUpdate is null: must be skipped, not crash.
+    TEST_ASSERT_EQUAL_INT(0, owner.updateCount);
+
+    // C -> A: C's onExit is null and must be skipped without crashing, but
+    // A's onEnter must still fire.
+    TEST_ASSERT_TRUE(fsm.requestState(kStateA));
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getCurrentState());
+
+    bool sawEnterA = false;
+    for (int i = 0; i < owner.logCount; ++i) {
+        if (owner.log[i].kind == LogEntry::Kind::Enter && owner.log[i].state == kStateA) {
+            sawEnterA = true;
+        }
+        // C's onExit is null, so no Exit(C, ...) entry may exist.
+        TEST_ASSERT_FALSE(owner.log[i].kind == LogEntry::Kind::Exit && owner.log[i].state == kStateC);
+    }
+    TEST_ASSERT_TRUE(sawEnterA);
+}
+
+// =============================================================================
+// Requirement: Time-In-State Is A Saturating uint32_t Millisecond Counter
+// =============================================================================
+
+void test_time_in_state_zero_in_on_enter_and_accumulates(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+
+    TEST_ASSERT_EQUAL_UINT32(0, owner.lastEnterTimeInState);
+    TEST_ASSERT_EQUAL_UINT32(0, fsm.getTimeInState());
+
+    fsm.update(100);
+    TEST_ASSERT_EQUAL_UINT32(100, fsm.getTimeInState());
+
+    fsm.update(250);
+    TEST_ASSERT_EQUAL_UINT32(350, fsm.getTimeInState());
+}
+
+void test_time_in_state_saturates_at_uint32_max(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+
+    fsm.update(static_cast<unsigned long>(UINT32_MAX) - 10ul);
+    TEST_ASSERT_EQUAL_UINT32(UINT32_MAX - 10u, fsm.getTimeInState());
+
+    fsm.update(100);
+    TEST_ASSERT_EQUAL_UINT32(UINT32_MAX, fsm.getTimeInState());
+
+    fsm.update(1);
+    TEST_ASSERT_EQUAL_UINT32(UINT32_MAX, fsm.getTimeInState());
+}
+
+// =============================================================================
+// Requirement: Re-Requesting The Current State Is A No-Op
+// Requirement: restartState() Performs A Real Exit/Enter Cycle
+// =============================================================================
+
+void test_request_current_state_is_noop(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    fsm.update(500);
+    owner.logCount = 0;
+
+    const bool result = fsm.requestState(kStateA);
+
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_INT(0, owner.logCount);
+    TEST_ASSERT_EQUAL_UINT32(500, fsm.getTimeInState());
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getCurrentState());
+}
+
+void test_restart_state_performs_real_cycle_and_resets_time(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    fsm.update(500);
+    owner.logCount = 0;
+
+    fsm.restartState();
+
+    TEST_ASSERT_EQUAL_UINT32(0, fsm.getTimeInState());
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_INT(2, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].other);
+    TEST_ASSERT_TRUE(owner.log[1].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].other);
+}
+
+// =============================================================================
+// Requirement: Transitions Requested From onEnter Or onExit Are Queued And
+// Drained Without Recursion
+// =============================================================================
+
+void test_onenter_requesting_transition_produces_no_recursion(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateC);  // Neutral starting point; arm the request only below.
+    owner.requestFromEnterOf = kStateA;
+    owner.requestFromEnterTarget = kStateB;
+    owner.logCount = 0;
+
+    // requestState(A) called from outside the machine: A's onEnter requests
+    // B. Expected order: A's onEnter runs to completion, then A's onExit(B),
+    // then B's onEnter(A) — never a nested/recursive drain.
+    const bool result = fsm.requestState(kStateA);
+
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getPreviousState());
+
+    TEST_ASSERT_EQUAL_INT(3, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_TRUE(owner.log[1].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[1].other);
+    TEST_ASSERT_TRUE(owner.log[2].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[2].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[2].other);
+}
+
+void test_onexit_requested_transition_honored_after_inflight_completes(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    owner.requestFromExitOf = kStateA;
+    owner.requestFromExitTarget = kStateC;
+    owner.logCount = 0;
+
+    // Request A -> B; A's onExit additionally requests C. The in-flight
+    // transition to B must complete (B's onEnter runs) before C is entered.
+    const bool result = fsm.requestState(kStateB);
+
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(kStateC, fsm.getCurrentState());
+
+    TEST_ASSERT_EQUAL_INT(4, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_TRUE(owner.log[1].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[1].state);
+    TEST_ASSERT_TRUE(owner.log[2].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[2].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateC, owner.log[2].other);
+    TEST_ASSERT_TRUE(owner.log[3].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateC, owner.log[3].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[3].other);
+}
+
+void test_last_writer_wins_within_one_drain_iteration(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    // Within the single A->B drain iteration: onExit(A) requests C (X),
+    // onEnter(B) runs afterward and requests A (Y). Y must win.
+    owner.requestFromExitOf = kStateA;
+    owner.requestFromExitTarget = kStateC;
+    owner.requestFromEnterOf = kStateB;
+    owner.requestFromEnterTarget = kStateA;
+    owner.logCount = 0;
+
+    const bool result = fsm.requestState(kStateB);
+
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, fsm.getCurrentState());  // Y, not X.
+
+    for (int i = 0; i < owner.logCount; ++i) {
+        TEST_ASSERT_FALSE(owner.log[i].state == kStateC);  // C is never entered.
+    }
+}
+
+void test_ping_pong_terminates_and_records_overflow(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateC);
+    owner.logCount = 0;
+    owner.pingPongAB = true;
+
+    TEST_ASSERT_EQUAL_UINT8(0, fsm.getTransitionOverflowCount());
+
+    const bool result = fsm.requestState(kStateA);
+
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(1, fsm.getTransitionOverflowCount());
+
+    // Left in a valid, fully-entered state: the last logged call is an Enter
+    // for whatever state the machine settled on.
+    TEST_ASSERT_TRUE(fsm.isRunning());
+    TEST_ASSERT_TRUE(owner.logCount > 0);
+    const LogEntry& last = owner.log[owner.logCount - 1];
+    TEST_ASSERT_TRUE(last.kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(fsm.getCurrentState(), last.state);
+}
+
+// =============================================================================
+// Requirement: At Most One onUpdate Invocation Per update() Call
+// =============================================================================
+
+void test_update_fires_exactly_one_onupdate_even_when_transitioning(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    owner.requestFromUpdateOf = kStateA;
+    owner.requestFromUpdateTarget = kStateB;
+    owner.logCount = 0;
+
+    fsm.update(16);
+
+    TEST_ASSERT_EQUAL_INT(1, owner.updateCount);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+
+    int updateLogEntries = 0;
+    for (int i = 0; i < owner.logCount; ++i) {
+        if (owner.log[i].kind == LogEntry::Kind::Update) ++updateLogEntries;
+    }
+    TEST_ASSERT_EQUAL_INT(1, updateLogEntries);
+}
+
+void test_update_before_start_is_noop(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    TEST_ASSERT_FALSE(fsm.isRunning());
+
+    fsm.update(500);
+
+    TEST_ASSERT_EQUAL_INT(0, owner.logCount);
+    TEST_ASSERT_EQUAL_UINT32(0, fsm.getTimeInState());
+}
+
+// =============================================================================
+// Requirement: start() And reset() Semantics
+// =============================================================================
+
+void test_start_fires_only_initial_onenter(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    TEST_ASSERT_FALSE(fsm.isRunning());
+
+    fsm.start(kStateA);
+
+    TEST_ASSERT_TRUE(fsm.isRunning());
+    TEST_ASSERT_EQUAL_INT(1, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_EQUAL_UINT8(StateMachine::kInvalidStateId, owner.log[0].other);
+}
+
+void test_reset_fires_no_callbacks(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    fsm.update(200);
+    owner.logCount = 0;
+
+    fsm.reset();
+
+    TEST_ASSERT_EQUAL_INT(0, owner.logCount);
+    TEST_ASSERT_FALSE(fsm.isRunning());
+}
+
+// =============================================================================
+// Requirement: Owner Is Type-Erased Via void*
+//
+// (The "no new virtuals on Actor/Entity" half of this requirement is proven
+// by test_no_new_virtuals_on_actor_or_entity above, which runs unconditionally
+// in both flag states — see that test's comment.)
+// =============================================================================
+
+namespace {
+
+void onEnterMinimalActor(void* owner, StateId from) {
+    (void)from;
+    // Proves the callback receives owner as void* and the caller is
+    // responsible for casting it back to its own concrete type.
+    auto* self = static_cast<MinimalActorSurface*>(owner);
+    self->width = 42;
+}
+
+}  // namespace
+
+void test_callbacks_receive_owner_as_void_star(void) {
+    MinimalActorSurface actor;
+    static const StateMachine::State kActorTable[] = {
+        { onEnterMinimalActor, nullptr, nullptr, kStateA },
+    };
+    StateMachine fsm;
+
+    fsm.configure(&actor, kActorTable, 1);
+    fsm.start(kStateA);
+
+    TEST_ASSERT_EQUAL_INT(42, actor.width);
+}
+
+// =============================================================================
+// Requirement: Feature-Gated And Zero-Cost When Disabled
+// =============================================================================
+
+void test_gameplay_state_machine_zero_cost_when_disabled(void) {
+    // Layout: field offsets must strictly ascend in D1's declared row order
+    // (onEnter, onUpdate, onExit, id) — pointers first (widest, strictest
+    // alignment), tag last — without hardcoding an absolute sizeof()
+    // literal (native is 64-bit, ESP32-C3 is 32-bit).
+    TEST_ASSERT_TRUE(offsetof(StateMachine::State, onEnter) < offsetof(StateMachine::State, onUpdate));
+    TEST_ASSERT_TRUE(offsetof(StateMachine::State, onUpdate) < offsetof(StateMachine::State, onExit));
+    TEST_ASSERT_TRUE(offsetof(StateMachine::State, onExit) < offsetof(StateMachine::State, id));
+
+    // No unexpected members: total size must not exceed the sum of the four
+    // declared members plus at most one machine word of alignment padding.
+    const size_t declaredRowSize =
+        sizeof(StateMachine::EnterFn) +
+        sizeof(StateMachine::UpdateFn) +
+        sizeof(StateMachine::ExitFn) +
+        sizeof(StateId);
+    TEST_ASSERT_TRUE(sizeof(StateMachine::State) <= declaredRowSize + sizeof(void*));
+
+    // The StateMachine instance itself must stay within its declared members
+    // (owner_, states_, timeInStateMs_, 6 x 1-byte fields) plus at most one
+    // machine word of padding (design.md D8: 20 B on ESP32-C3, 32 B native).
+    const size_t declaredInstanceSize =
+        sizeof(void*) +        // owner_
+        sizeof(const void*) +  // states_
+        sizeof(uint32_t) +     // timeInStateMs_
+        6 * sizeof(uint8_t);   // current_/previous_/pending_/stateCount_/inTransition_/transitionOverflows_
+    TEST_ASSERT_TRUE(sizeof(StateMachine) <= declaredInstanceSize + sizeof(void*));
+}
+
+#else  // !PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+void test_gameplay_state_machine_zero_cost_when_disabled(void) {
+    // With the flag off, StateMachine is not compiled at all — its entire
+    // declaration lives inside the #if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+    // guard in include/gameplay/StateMachine.h. This translation unit
+    // compiling and passing without referencing the type IS the "zero bytes
+    // reserved" property required by the spec's "Feature-Gated And
+    // Zero-Cost When Disabled" requirement.
+    TEST_PASS_MESSAGE("PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=0: StateMachine is not compiled, zero bytes reserved.");
+}
+
+#endif  // PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+    RUN_TEST(test_no_new_virtuals_on_actor_or_entity);
+
+#if PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE
+    RUN_TEST(test_configure_binds_table_without_copying);
+    RUN_TEST(test_state_lookup_matches_by_id_not_row_order);
+    RUN_TEST(test_request_state_unknown_id_rejected);
+    RUN_TEST(test_transition_invokes_onexit_then_onenter_in_order);
+    RUN_TEST(test_null_callback_skipped_without_crash);
+    RUN_TEST(test_time_in_state_zero_in_on_enter_and_accumulates);
+    RUN_TEST(test_time_in_state_saturates_at_uint32_max);
+    RUN_TEST(test_request_current_state_is_noop);
+    RUN_TEST(test_restart_state_performs_real_cycle_and_resets_time);
+    RUN_TEST(test_onenter_requesting_transition_produces_no_recursion);
+    RUN_TEST(test_onexit_requested_transition_honored_after_inflight_completes);
+    RUN_TEST(test_last_writer_wins_within_one_drain_iteration);
+    RUN_TEST(test_ping_pong_terminates_and_records_overflow);
+    RUN_TEST(test_update_fires_exactly_one_onupdate_even_when_transitioning);
+    RUN_TEST(test_update_before_start_is_noop);
+    RUN_TEST(test_start_fires_only_initial_onenter);
+    RUN_TEST(test_reset_fires_no_callbacks);
+    RUN_TEST(test_callbacks_receive_owner_as_void_star);
+#endif
+    RUN_TEST(test_gameplay_state_machine_zero_cost_when_disabled);
+
+    return UNITY_END();
+}

--- a/test/unit/test_gameplay_state_machine/test_gameplay_state_machine.cpp
+++ b/test/unit/test_gameplay_state_machine/test_gameplay_state_machine.cpp
@@ -410,6 +410,40 @@ void test_restart_state_performs_real_cycle_and_resets_time(void) {
     TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].other);
 }
 
+void test_restart_state_honors_transition_requested_from_its_callbacks(void) {
+    MockOwner owner;
+    StateMachine fsm;
+    owner.fsm = &fsm;
+
+    fsm.configure(&owner, kTestTable, kTestTableCount);
+    fsm.start(kStateA);
+    owner.logCount = 0;
+
+    // Arm A's onEnter to request B. During restartState() that request lands
+    // while a transition is in flight, so it is queued rather than recursing.
+    owner.requestFromEnterOf     = kStateA;
+    owner.requestFromEnterTarget = kStateB;
+
+    fsm.restartState();
+
+    // The queued request must be drained, not silently dropped: requestState()
+    // returned true to the caller inside onEnter, so the machine owes it a
+    // real transition.
+    TEST_ASSERT_EQUAL_UINT8(kStateB, fsm.getCurrentState());
+    TEST_ASSERT_EQUAL_INT(4, owner.logCount);
+    TEST_ASSERT_TRUE(owner.log[0].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[0].state);
+    TEST_ASSERT_TRUE(owner.log[1].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[1].state);
+    TEST_ASSERT_TRUE(owner.log[2].kind == LogEntry::Kind::Exit);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[2].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[2].other);
+    TEST_ASSERT_TRUE(owner.log[3].kind == LogEntry::Kind::Enter);
+    TEST_ASSERT_EQUAL_UINT8(kStateB, owner.log[3].state);
+    TEST_ASSERT_EQUAL_UINT8(kStateA, owner.log[3].other);
+    TEST_ASSERT_EQUAL_UINT32(0, fsm.getTimeInState());
+}
+
 // =============================================================================
 // Requirement: Transitions Requested From onEnter Or onExit Are Queued And
 // Drained Without Recursion
@@ -711,6 +745,7 @@ int main(int argc, char** argv) {
     RUN_TEST(test_time_in_state_saturates_at_uint32_max);
     RUN_TEST(test_request_current_state_is_noop);
     RUN_TEST(test_restart_state_performs_real_cycle_and_resets_time);
+    RUN_TEST(test_restart_state_honors_transition_requested_from_its_callbacks);
     RUN_TEST(test_onenter_requesting_transition_produces_no_recursion);
     RUN_TEST(test_onexit_requested_transition_honored_after_inflight_completes);
     RUN_TEST(test_last_writer_wins_within_one_drain_iteration);


### PR DESCRIPTION
Re-lands PRs #164, #165 and #166 onto the tracker branch, and carries the Phase 2 cross-cutting verification evidence.

## Why this PR exists

The chained merges of #164, #165 and #166 landed on their original base branches instead of `feature/top-down-games`. GitHub retargets a chained PR's base asynchronously, and the four merges ran within 10 seconds of each other — faster than the retarget. Only #163 reached the tracker.

No content was lost. The chain was linear (01 ← 02 ← 03 ← 04), so this branch tip carries all seven Phase 2 commits, including the ObjectPool test fix. The remaining delta is 9 files / 2308 insertions: the original 2306, minus the 33 lines of feature flags that landed with #163, plus the 35 lines of the test fix.

## What ships

Two capabilities, both behind default-off flags:

- `StateMachine` — non-template, `void*` owner, caller-owned const state table. Deliberately not `FiniteStateMachine<T>`: templating on the owner duplicates the whole transition/dispatch body in flash once per owner type.
- `ObjectPool<T, N>` — header-only template. The asymmetry with `StateMachine` is intentional: `T`'s size, alignment and construction are intrinsically what a pool does.

Plus `[env:native_test_gameplay]` in CI, the D8 byte budgets in `docs/architecture/memory-system.md`, and `docs/patterns/game-session-state.md`.

Audit §5.9 (`GameState`/`ScoreTracker`/`LivesSystem`) was dropped from the engine and shipped as documentation only. Across the 15 examples, `score` appears in 5, `lives` in 2, and the full triad in 2; `gameOver` has three incompatible shapes, and `tic_tac_toe` declares two of them in the same struct. Unity, Godot and Bevy ship nothing here; GameMaker shipped `score`/`lives` globals and later deprecated them.

## Verification — task group 5, all five PASS

| Task | Command | Result |
|---|---|---|
| 5.1 | 15× `pio run -e native` | **PASS** — 15/15 examples built with flags at default `0` |
| 5.2 | `pio test -e native_test` | **PASS** — 1594 cases, 1590 succeeded, 4 skipped, 0 errored |
| 5.3 | `pio test -e native_test_gameplay` | **PASS** — 1646 cases, 1642 succeeded, 4 skipped, 0 errored |
| 5.4 | `git diff` path invariant | **PASS** — nothing under `include/core`, `src/core`, `include/physics`, `src/physics`, `examples` |
| 5.5 | 5× flag-isolation builds | **PASS** — 5/5 combinations, 0 errored |

5.5 covered `state_machine_only`, `object_pool_only`, `state_machine_no_physics`, `object_pool_no_physics` and `both_no_physics`, confirming D7 empirically: neither flag needs a companion and no `#error` guard is required.

## The D9 defect, closed and measured

CI previously ran only `pio test -e native_test`, whose `build_flags` define no `PIXELROOT32_ENABLE_GAMEPLAY_*` macro. Every gameplay test compiled only its `#else` stub — including all four Phase 1 suites. The suites passed while asserting nothing.

A green run does not prove otherwise; a suite whose body is `#if`'d out passes trivially. What proves it is how many assertions each suite runs per flag state:

| Suite | flags OFF | flags ON |
|---|---:|---:|
| `test_gameplay_event_bus` | 1 | **6** |
| `test_interaction_tracker` | 2 | **6** |
| `test_spatial_query` | 1 | **8** |
| `test_gameplay_state_machine` | 2 | **21** |
| `test_gameplay_object_pool` | 1 | **18** |

Those functional bodies had never executed in this repository's CI history.

`test_scene_depth_sort` stays at 5 in both states, which is correct rather than a gap: `Scene::depthComparator` / `depthSortEnabled` / `shouldPrecede()` are deliberately not gated behind `PIXELROOT32_ENABLE_DEPTH_SORT` (design D5), so its tests compile either way. Verified by diffing the executed test names across both logs — identical sets.

## Defects this environment caught on day one

The first run of `native_test_gameplay` failed `unit/test_gameplay_object_pool` at compile time with three real errors, fixed in a1a37b7:

1. `TEST_ASSERT_TRUE(index != ObjectPool<TrackedPayload, 4>::kEnd)` — the comma inside the template argument list is an argument separator to the preprocessor, so Unity's macro received two arguments instead of one. Angle brackets do not group macro arguments.
2. The same defect at `TEST_ASSERT_EQUAL_UINT16`, three arguments instead of two.
3. `test_gameplay_object_pool_zero_cost_when_disabled` was defined only in the `#else` branch while `main()` `RUN_TEST`s it unconditionally — an undeclared identifier whenever the flag is on. `test_gameplay_state_machine.cpp` already defines its counterpart in both branches.

Both macro sites now use a local `using Pool = …` alias, already this file's convention. The new flag-on definition asserts a property the existing budget test does not cover: doubling `N` grows `sizeof` by exactly `N * sizeof(T)`, proving no hidden per-slot header, vtable or indirection.

## Known gaps, accepted

`sdd-verify` returned PASS WITH WARNINGS — 0 critical, 2 warnings. Both are `ObjectPool` spec scenarios that are documented but not runtime-tested:

- **Arena-backed pool storage is not supported.** Design D6 argues this is unenforceable in C++ without engine-side wiring this phase deliberately avoids. Documented in the header instead.
- **A Scene-owned pool must be reset after the base `Scene::init()` call.** No in-tree `Scene` consumer exists this phase, so residual risk is low. Worth a real test once a later phase adds one — `design.md` itself notes it is testable with a mock `T` that counts destructor calls.

## Note on CI

`.github/workflows/tests.yml` triggers only on pull requests targeting `main` or `develop`. This chain targets `feature/top-down-games`, so the new `native_test_gameplay` step will not execute until the tracker branch itself goes to `main`. Phase 1 was in the same position. The evidence above was produced by running both environments locally.
