### PR TITLE
docs(gameplay): document the time-in-state ordering hazard in StateMachine::update()

### DIFF
--- a/include/gameplay/StateMachine.h
+++ b/include/gameplay/StateMachine.h
@@ -88,6 +88,25 @@ public:
      *
      * A transition triggered inline by that `onUpdate` does not also run the
      * newly entered state's `onUpdate` this call. No-op when `!isRunning()`.
+     *
+     * @warning Ordering hazard when transitioning from inside `onUpdate`.
+     * `deltaTime` is added to time-in-state BEFORE `onUpdate` is dispatched,
+     * and `requestState()` resets time-in-state to `0`. So a call that
+     * transitions from within `onUpdate` returns with `getTimeInState() == 0`:
+     * that frame's `deltaTime` was attributed to the state being LEFT, and the
+     * state being entered starts from zero having consumed none of it.
+     *
+     * That accounting is deliberate — the time really was spent in the old
+     * state — but it differs from the common hand-rolled shape, where a
+     * `changeState()` zeroes an accumulator and the frame's delta is then
+     * added to the NEW state in the same tick. Code ported from that shape
+     * onto `getTimeInState()` loses one frame's worth of elapsed time per
+     * transition. It is usually invisible (a sub-frame phase shift in an
+     * animation) and therefore easy to ship unnoticed.
+     *
+     * If you need "reset, then accumulate this frame" semantics, either call
+     * `requestState()` BEFORE `update()` rather than from inside `onUpdate`,
+     * or keep your own accumulator and reset it from `onEnter`.
      */
     void update(unsigned long deltaTime);
 
@@ -124,6 +143,11 @@ public:
 
     StateId  getCurrentState()  const { return current_; }
     StateId  getPreviousState() const { return previous_; }
+
+    /// Milliseconds since the current state was entered, saturating at
+    /// `UINT32_MAX`. Read `update()`'s ordering warning before deriving a
+    /// per-frame value (such as an animation index) from this while also
+    /// transitioning from inside `onUpdate`.
     uint32_t getTimeInState()   const { return timeInStateMs_; }
     bool     isRunning()        const { return current_ != kInvalidStateId; }
 


### PR DESCRIPTION
Documents a real ordering hazard in `StateMachine::update()`, found while migrating the first two examples onto the class. Comments only — no behavior change.

**Merge this first.** PR for `flappy_bird` is chained on this branch.

## The hazard

```
update()       :49  timeInStateMs_ += dt      <- added first
               :55  onUpdate(...)             <- dispatched after
requestState() :75  timeInStateMs_ = 0        <- reset before onEnter
```

A call that transitions from inside `onUpdate` therefore returns with `getTimeInState() == 0`. That frame's `deltaTime` was attributed to the state being **left**, and the state being **entered** starts from zero having consumed none of it.

That accounting is deliberate and correct — the time really was spent in the old state. The problem is that it is the mirror image of the common hand-rolled shape, where a `changeState()` zeroes an accumulator and the frame's delta then lands on the **new** state in the same tick. Code ported from that shape onto `getTimeInState()` silently loses one frame per transition.

## Why it needed documenting

The symptom is a sub-frame phase shift in an animation. It does not crash, does not fail a test, and does not look wrong in review.

It nearly shipped here. The first pass at the metroidvania migration derived the player's animation frame from `getTimeInState()` and the equivalence analysis checked out — because that pass still had the hand-written transition switch calling `requestState()` **before** `update()`, from outside `onUpdate`, where the derivation genuinely is exact. The defect only became reachable when the migration was reworked to dispatch transitions through `onUpdate` callbacks as intended.

So a shallow migration concealed a hazard that the real one exposed. That is worth knowing on its own.

## What this adds

- An `@warning` block on `update()`: what happens, why it is correct, why it still bites, and the two workarounds — request the transition **before** `update()` rather than from inside `onUpdate`, or keep your own accumulator and reset it from `onEnter`.
- A cross-reference on `getTimeInState()`, which is where a reader is standing when they make the wrong call.

## Verification

`pio test -e native_test_gameplay -f unit/test_gameplay_state_machine` → **21 test cases, 21 succeeded**.

24 insertions, 0 deletions, 1 file.
