### PR TITLE
refactor(flappy_bird): migrate GameState onto gameplay::StateMachine

### DIFF
--- a/examples/flappy_bird/README.md
+++ b/examples/flappy_bird/README.md
@@ -1,10 +1,11 @@
 # Flappy Bird Example
 
-A **Flappy Bird**–style game: bird is a **`RigidActor`** (gravity + flap impulse), pipes are **`KinematicActor`** pairs that scroll and **recycle** when off-screen. Score and game states (**waiting / playing / game over**) are handled in [`FlappyBirdScene`](src/FlappyBirdScene.h).
+A **Flappy Bird**–style game: bird is a **`RigidActor`** (gravity + flap impulse), pipes are **`KinematicActor`** pairs that scroll and **recycle** when off-screen. Score and game states (**waiting / playing / game over**) are handled in [`FlappyBirdScene`](src/FlappyBirdScene.h), which drives them through the engine's **`gameplay::StateMachine`**.
 
 ## Requirements (build flags)
 
 - **`PIXELROOT32_ENABLE_PHYSICS=1`** — required on **`esp32c3`** in `platformio.ini`.
+- **`PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1`** — required on **every** environment. The scene's `WAITING` / `RUNNING` / `GAME_OVER` machine is a `gameplay::StateMachine` member, and the whole class lives behind this flag (default `0`), so the scene does not compile without it.
 - **`PIXELROOT32_ENABLE_PROFILING`** — enabled on the **`esp32c3`** environment in this project (optional for learning builds).
 - **U8g2 path (hardware)**: **`PIXELROOT32_USE_U8G2`**, **`PIXELROOT32_NO_TFT_ESPI`** on **`esp32c3`**.
 
@@ -29,12 +30,17 @@ This example does **not** ship an `esp32dev` TFT environment — only **`native`
 - **Physics** actors for bird and pipes
 - **Object pool–style** pipe reuse
 - **Small-resolution** rendering path suited for **128×64 OLED** via U8g2
+- **`gameplay::StateMachine`** for the `WAITING` → `RUNNING` → `GAME_OVER` cycle, with the per-state entry work in `onEnter` callbacks: entering `WAITING` resets bird, pipes and score; entering `RUNNING` fires the first flap and reveals the pipes. `GAME_OVER` has no entry side effect — its text is drawn per frame from the current state.
+
+  Transitions are requested directly from `update()` rather than from an `onUpdate` callback. This is deliberate: the frame that leaves `WAITING` must still run the pipe-scroll and scoring block, and `StateMachine::update()` does not cascade `onUpdate` into a newly entered state within the same call. See the comment at the call site in [`FlappyBirdScene.cpp`](src/FlappyBirdScene.cpp).
 
 ## Documentation links
 
 - [Physics API](../../docs/api/physics.md)
 - [Core API](../../docs/api/core.md)
 - [Platform / drivers](../../docs/api/platform.md)
+- [Memory system — gameplay flags and byte budgets](../../docs/architecture/memory-system.md) — RAM cost of `PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE`
+- [`gameplay/StateMachine.h`](../../include/gameplay/StateMachine.h) — the full contract, including the time-in-state ordering warning on `update()`
 
 ## Build
 

--- a/examples/flappy_bird/platformio.ini
+++ b/examples/flappy_bird/platformio.ini
@@ -16,7 +16,7 @@ extra_configs = lib/platformio.ini
 extends = base_native
 lib_deps =
 	symlink://../../
-build_flags = 
+build_flags =
     ${base_native.build_flags}
 	-D PHYSICAL_DISPLAY_WIDTH=128
 	-D PHYSICAL_DISPLAY_HEIGHT=64
@@ -24,6 +24,7 @@ build_flags =
 	-D Y_OFF_SET=24
 	-D LOGICAL_WIDTH=72
 	-D LOGICAL_HEIGHT=40
+	-D PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1
     -Isrc
     -Iinclude
     -I.pio/libdeps/native/PixelRoot32-Game-Engine/include
@@ -60,3 +61,4 @@ build_flags =
 	-D Y_OFF_SET=24
 	-D LOGICAL_WIDTH=72
 	-D LOGICAL_HEIGHT=40
+	-D PIXELROOT32_ENABLE_GAMEPLAY_STATE_MACHINE=1

--- a/examples/flappy_bird/src/FlappyBirdScene.cpp
+++ b/examples/flappy_bird/src/FlappyBirdScene.cpp
@@ -21,6 +21,22 @@ using pixelroot32::math::toScalar;
 using pixelroot32::math::Scalar;
 using pixelroot32::math::Vector2;
 
+// Game-state table for pixelroot32::gameplay::StateMachine. Only onEnter
+// carries real work: WAITING resets the score/position (the old
+// resetGame() body) and RUNNING fires the first jump and reveals the pipes
+// (the old WAITING-branch transition side effect). GAME_OVER has no
+// entry/exit work of its own — the "GAME OVER"/"RESTART" text is a
+// per-frame draw() query, not a one-time entry action — so its row leaves
+// every callback null. Defined class-static (not namespace-scope) so its
+// rows can take the address of the private callback member functions
+// above — still `static const`, so it lands in flash/.rodata per
+// StateMachine.h's documented convention.
+const pixelroot32::gameplay::StateMachine::State FlappyBirdScene::kFlappyStates[3] = {
+    { &FlappyBirdScene::onEnterWaiting, nullptr, nullptr, static_cast<pixelroot32::gameplay::StateId>(GameState::WAITING) },
+    { &FlappyBirdScene::onEnterRunning, nullptr, nullptr, static_cast<pixelroot32::gameplay::StateId>(GameState::RUNNING) },
+    { nullptr,                          nullptr, nullptr, static_cast<pixelroot32::gameplay::StateId>(GameState::GAME_OVER) },
+};
+
 FlappyBirdScene::FlappyBirdScene() = default;
 FlappyBirdScene::~FlappyBirdScene() = default;
 
@@ -31,10 +47,11 @@ void FlappyBirdScene::init() {
     bird = std::make_unique<BirdActor>(Vector2(toScalar(BIRD_START_X), toScalar(screenHeight / 2.0f)));
     bird->isVisible = true; // Always visible
     addEntity(bird.get());
-    
+
     createPipes();
-    
-    resetGame();
+
+    fsm.configure(this, kFlappyStates, sizeof(kFlappyStates) / sizeof(kFlappyStates[0]));
+    fsm.start(static_cast<pixelroot32::gameplay::StateId>(GameState::WAITING));
 }
 
 void FlappyBirdScene::createPipes() {
@@ -50,57 +67,82 @@ void FlappyBirdScene::createPipes() {
     addEntity(bottomPipe.get());
 }
 
-void FlappyBirdScene::resetGame() {
-    bird->reset(Vector2(toScalar(BIRD_START_X), toScalar(screenHeight / 2.0f)));
+GameState FlappyBirdScene::currentState() const {
+    return static_cast<GameState>(fsm.getCurrentState());
+}
+
+void FlappyBirdScene::onEnterWaiting(void* owner, pixelroot32::gameplay::StateId fromState) {
+    (void)fromState;
+    auto* self = static_cast<FlappyBirdScene*>(owner);
+
+    self->bird->reset(Vector2(toScalar(BIRD_START_X), toScalar(self->screenHeight / 2.0f)));
 
     // Calculate pipe gap position
-    int maxGapY = screenHeight - PIPE_GAP - 10;
+    int maxGapY = self->screenHeight - PIPE_GAP - 10;
     int minGapY = 10;
     if (maxGapY <= minGapY) maxGapY = minGapY + 1;
     int pipeGapY = random(minGapY, maxGapY);
-    
-    topPipe->position = Vector2(toScalar(screenWidth), toScalar(0));
-    topPipe->setSize(PIPE_WIDTH, pipeGapY);
-    topPipe->markPassed();
-    topPipe->markPassed();
 
-    bottomPipe->position = Vector2(toScalar(screenWidth), toScalar(pipeGapY + PIPE_GAP));
-    bottomPipe->setSize(PIPE_WIDTH, screenHeight - (pipeGapY + PIPE_GAP));
+    self->topPipe->position = Vector2(toScalar(self->screenWidth), toScalar(0));
+    self->topPipe->setSize(PIPE_WIDTH, pipeGapY);
+    self->topPipe->markPassed();
+    self->topPipe->markPassed();
 
-    currentState = flappy::GameState::WAITING;
-    score = 0;
-    std::snprintf(scoreStr, sizeof(scoreStr), "0");
+    self->bottomPipe->position = Vector2(toScalar(self->screenWidth), toScalar(pipeGapY + PIPE_GAP));
+    self->bottomPipe->setSize(PIPE_WIDTH, self->screenHeight - (pipeGapY + PIPE_GAP));
+
+    self->score = 0;
+    std::snprintf(self->scoreStr, sizeof(self->scoreStr), "0");
 }
 
+void FlappyBirdScene::onEnterRunning(void* owner, pixelroot32::gameplay::StateId fromState) {
+    (void)fromState;
+    auto* self = static_cast<FlappyBirdScene*>(owner);
+    self->bird->jump();
+    self->topPipe->isVisible = true;
+    self->bottomPipe->isVisible = true;
+}
+
+// Physics (Scene::update) and the pipe scroll/scoring/bounds-check block
+// below both gate on fsm.getCurrentState() directly rather than on
+// fsm.update()/onUpdate, and requestState() is called directly from here
+// rather than from inside an onUpdate callback. This mirrors the original
+// code's two-snapshot shape on purpose: the physics gate reads the
+// PRE-input state (skipping physics on the very frame WAITING transitions
+// to RUNNING, same as before), while the gameplay-logic gate below reads
+// the POST-input state, so it still runs on that same transition frame.
+// StateMachine::update() deliberately does not cascade onUpdate into a
+// newly-entered state within the same call (see StateMachine.h's ordering
+// warning) — routing this through onUpdate would delay the pipe
+// scroll/scoring/bounds-check by one frame on the WAITING->RUNNING
+// transition frame, a behavior change this migration must avoid. Per that
+// same warning, getTimeInState() is never read here either.
 void FlappyBirdScene::update(unsigned long deltaTime) {
-    if (currentState == flappy::GameState::RUNNING) {
+    if (currentState() == GameState::RUNNING) {
         pixelroot32::core::Scene::update(deltaTime);
     }
-    
+
     auto& input = engine.getInputManager();
 
     if (input.isButtonPressed(BTN_JUMP)) {
-        if (currentState == flappy::GameState::WAITING) {
-            currentState = flappy::GameState::RUNNING;
+        if (currentState() == GameState::WAITING) {
+            fsm.requestState(static_cast<pixelroot32::gameplay::StateId>(GameState::RUNNING));
+        } else if (currentState() == GameState::RUNNING) {
             bird->jump();
-            topPipe->isVisible = true;
-            bottomPipe->isVisible = true;
-        } else if (currentState == flappy::GameState::RUNNING) {
-            bird->jump();
-        } else if (currentState == flappy::GameState::GAME_OVER) {
-            resetGame();
+        } else if (currentState() == GameState::GAME_OVER) {
+            fsm.requestState(static_cast<pixelroot32::gameplay::StateId>(GameState::WAITING));
         }
     }
 
-    if (currentState == flappy::GameState::RUNNING) {
+    if (currentState() == GameState::RUNNING) {
         if (bird->isDead()) {
-            currentState = flappy::GameState::GAME_OVER;
+            fsm.requestState(static_cast<pixelroot32::gameplay::StateId>(GameState::GAME_OVER));
         }
 
         int maxGapY = screenHeight - PIPE_GAP - 10;
         int minGapY = 10;
         if (maxGapY <= minGapY) maxGapY = minGapY + 1;
-        
+
         int newGapY = random(minGapY, maxGapY);
         if (topPipe->resetIfOffScreen(screenWidth, screenHeight, newGapY)) {
             bottomPipe->position.x = topPipe->position.x;
@@ -114,9 +156,9 @@ void FlappyBirdScene::update(unsigned long deltaTime) {
             std::snprintf(scoreStr, sizeof(scoreStr), "%d", score);
         }
 
-        if (static_cast<float>(bird->position.y) < 0 || 
+        if (static_cast<float>(bird->position.y) < 0 ||
             static_cast<float>(bird->position.y) + bird->height > screenHeight) {
-            currentState = flappy::GameState::GAME_OVER;
+            fsm.requestState(static_cast<pixelroot32::gameplay::StateId>(GameState::GAME_OVER));
         }
     }
 }
@@ -127,9 +169,9 @@ void FlappyBirdScene::draw(pixelroot32::graphics::Renderer& renderer) {
     pixelroot32::core::Scene::draw(renderer);
     renderer.drawText(scoreStr, screenWidth - SCORE_X_OFFSET, SCORE_Y_OFFSET, Color::White, 1);
 
-    if (currentState == flappy::GameState::WAITING) {
+    if (currentState() == GameState::WAITING) {
         renderer.drawTextCentered("START", 25, Color::White, 1);
-    } else if (currentState == flappy::GameState::GAME_OVER) {
+    } else if (currentState() == GameState::GAME_OVER) {
         renderer.drawTextCentered("GAME OVER", 20, Color::White, 1);
         renderer.drawTextCentered("RESTART", 45, Color::White, 1);
     }

--- a/examples/flappy_bird/src/FlappyBirdScene.h
+++ b/examples/flappy_bird/src/FlappyBirdScene.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <core/Scene.h>
+#include <gameplay/StateMachine.h>
 #include <graphics/Renderer.h>
 #include <math/Vector2.h>
 #include <platforms/EngineConfig.h>
@@ -30,7 +31,14 @@ namespace flappy {
         void draw(pixelroot32::graphics::Renderer& renderer) override;
 
     private:
-        GameState currentState;
+        /// Bound to a caller-owned, static const table (see .cpp). Only
+        /// onEnter carries real work here (score/position reset entering
+        /// WAITING; first jump + pipe reveal entering RUNNING) — the
+        /// WAITING->RUNNING, RUNNING->GAME_OVER, and GAME_OVER->WAITING
+        /// transition conditions stay as direct fsm.requestState() calls
+        /// from update(), not from onUpdate. See update()'s implementation
+        /// comment in the .cpp for why.
+        pixelroot32::gameplay::StateMachine fsm;
 
         std::unique_ptr<BirdActor> bird;
         std::unique_ptr<PipeActor> topPipe;
@@ -41,8 +49,32 @@ namespace flappy {
         int screenHeight;       ///< Display height
         char scoreStr[8];       ///< Score string buffer
 
-        void resetGame();
         void createPipes();
+
+        /** @brief Current game state, read back from the state machine. */
+        GameState currentState() const;
+
+        // StateMachine::State callbacks (see kFlappyStates in the .cpp).
+        // `owner` is always `this` — configure() binds it once in init().
+        // Static so they match StateMachine::EnterFn's C function pointer
+        // signature; each recovers the instance via
+        // `static_cast<FlappyBirdScene*>(owner)`.
+
+        /** @brief WAITING entry: resets the bird position, regenerates the
+         *  pipe gap, repositions both pipes, and zeroes the score — the old
+         *  resetGame() body, now the state's real entry side effect. */
+        static void onEnterWaiting(void* owner, pixelroot32::gameplay::StateId fromState);
+
+        /** @brief RUNNING entry: fires the first jump and reveals the pipes
+         *  — the old WAITING-branch transition side effect. */
+        static void onEnterRunning(void* owner, pixelroot32::gameplay::StateId fromState);
+
+        /// State table bound in init(). Defined out-of-line in the .cpp
+        /// (class-static, not namespace-scope, so its rows can take the
+        /// address of the private callbacks above) — still `static const`,
+        /// so it lands in flash/.rodata per StateMachine.h's documented
+        /// convention.
+        static const pixelroot32::gameplay::StateMachine::State kFlappyStates[3];
     };
 
 } // namespace flappy


### PR DESCRIPTION
Migrates `flappy_bird`'s `GameState { WAITING, RUNNING, GAME_OVER }` onto `pixelroot32::gameplay::StateMachine`.

**Chained on `gameplay-adoption/02-statemachine-time-contract`** — merge that one first. GitHub retargets a chained PR's base asynchronously, so verify this PR's base has become `feature/top-down-games` before merging it.

## What changed

`examples/flappy_bird/src/FlappyBirdScene.{h,cpp}` and the example's `platformio.ini`. Nothing under `include/`, `src/` or `test/`.

Two of the three states carry real entry work, pulled out of an inline input-handling branch and into the table where it belongs:

- **`onEnterWaiting`** — the entire old `resetGame()` body: bird position, regenerated pipe gap, both pipes repositioned, score zeroed. Now fires on `start()` and on `GAME_OVER → WAITING` alike, instead of being called from two separate places.
- **`onEnterRunning`** — first jump plus revealing both pipes. Previously inline in the jump-input branch.
- **`GAME_OVER`** — every callback null. There is no one-time side effect; its "GAME OVER"/"RESTART" text is a per-frame `draw()` query. Reported as-is rather than invented.

## Why the transition conditions stayed out of `onUpdate`

This is the interesting part, and it is a behavior trap a mechanical port would have walked into.

The original `update()` reads the game state **twice per frame, from two different snapshots**:

```cpp
:76  if (currentState == RUNNING) Scene::update(dt);   // PRE-input snapshot
:82  ... input handling can flip WAITING -> RUNNING ...
:95  if (currentState == RUNNING) { /* scroll, score, bounds */ }   // POST-input
```

On the frame `WAITING → RUNNING` happens, physics is skipped but the gameplay block still runs. Routing that block into `onUpdate(RUNNING)` would delay it by one frame, because `StateMachine::update()` deliberately does not cascade `onUpdate` into a newly entered state within the same call (Rule 5).

So `requestState()` is called directly from `update()`, gated on `getCurrentState()`, mirroring the original two-snapshot shape exactly. `getTimeInState()` is never read, and `update()` is never called, for the same reason. This is documented in a comment at the call site.

## Cost

```
3 files, +112 / -36  ->  net +76 lines
```

## Verdict: it pays here, partially

Better than the metroidvania migration (sibling PR), which cost +100 lines for zero real per-state entry work. Here two states get genuine `onEnter` logic centralized out of scattered input branches, at lower cost.

But `GAME_OVER` contributes nothing to the machine's value, so the ratio is 2 of 3 states justified. The honest summary is "meaningfully better than metroidvania", not "obviously worth it in isolation".

## What the two migrations together revealed

They use **disjoint halves** of the API:

| | metroidvania | flappy_bird |
|---|---|---|
| Real `onEnter` work | 0/4 states | 2/3 states |
| `onUpdate` callbacks | 3 states | none |
| calls `update()` | yes | **never** |
| reads `getTimeInState()` | no (reverted) | no |

metroidvania wants the per-state update dispatcher and has no real entry work. flappy_bird wants entry hooks and never calls `update()` at all. Neither uses the whole class.

The sharpest signal: **`getTimeInState()` is used by neither adopter**, despite carrying its own design decision (D2 — saturating `uint32_t` milliseconds, explicitly not `math::Scalar`, which is `float` on native and overflows Q16.16 after 32.7 s), its own spec requirement, and three dedicated tests. The single attempt to use it had to be reverted after hitting the ordering hazard documented in the sibling PR.

Two data points do not justify redesigning anything. But `StateMachine` bundles two separable concerns — a state variable with entry/exit hooks, and a per-state update dispatcher with time tracking — and so far real code wants one or the other, not both. Worth weighing before Phase 3 adds more primitives on the same shape.

## Verification

`cd examples/flappy_bird && pio run -e native` → **SUCCESS**, zero new warnings under `-Wall -Wextra`. The two warnings in the log are pre-existing engine warnings unrelated to this change.
