### PR TITLE
docs(gameplay): document the GridSpace flag and close the phase 3 verification

### DIFF
--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -101,6 +101,14 @@ When subsystems are disabled via `PIXELROOT32_ENABLE_*` flags, their memory allo
 
 Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field order is `owner_`, `states_`, `timeInStateMs_`, then the six 1-byte fields, exactly as budgeted; no drift from the design.
 
+**Gameplay Framework Phase 3 flag (opt-in, default `0`):** one capability in `pixelroot32::gameplay`, header-only with no `.cpp` file, so there is no additional code cost when the flag is off. It is the first gameplay header to include `math/` (`Vector2`, `MathUtil`), but — like the Phase 2 flags above — it carries **no `#error` guard**: `math/` is always available regardless of `PIXELROOT32_ENABLE_PHYSICS` or any other flag:
+
+| Flag | Default | RAM Cost When Enabled | Subsystem Added |
+|------|---------|------------------------|------------------|
+| `PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1` | `0` | 0 B SRAM | `gameplay::GridSpace.h` — grid-to-world/world-to-grid coordinate conversion (`GridSpec`, `cellToWorldX/Y`, `cellToWorld`, `worldToCellX/Y`, `containsCell`) |
+
+**`GridSpec` byte budget:** every shipped consumer (`examples/snake`, `examples/tic_tac_toe`) declares its grid as `inline constexpr GridSpec`. `constexpr` implies `const`, so the six-`int` aggregate lands in `.rodata`/flash, never `.data`/`.bss` — **0 B SRAM**, at every optimization level, independent of whether the optimizer also folds the constant away entirely. `sizeof(GridSpec) == 24 B` (six `int`s — `int` is 4 B under both the ESP32-C3's ILP32 and native's LP64), identical on both targets. A non-`constexpr` (runtime) `GridSpec` would cost 24 B SRAM instead; no shipped consumer uses one.
+
 **`ObjectPool<T, N>` byte budget:** `N * sizeof(T)` for the aligned slot storage, plus target-independent bookkeeping (a `uint32_t liveWords_[(N+31)/32]` bitmask plus two `uint16_t` counters, `liveCount_` and `scanHint_`) — identical on ESP32-C3 and native because every bookkeeping field is a fixed-width type:
 
 | `N` (pool capacity) | `liveWords_` | counters (`liveCount_` + `scanHint_`) | **bookkeeping total** | per-slot equivalent |

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -101,7 +101,7 @@ When subsystems are disabled via `PIXELROOT32_ENABLE_*` flags, their memory allo
 
 Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field order is `owner_`, `states_`, `timeInStateMs_`, then the six 1-byte fields, exactly as budgeted; no drift from the design.
 
-**Gameplay Framework Phase 3 flag (opt-in, default `0`):** one capability in `pixelroot32::gameplay`, header-only with no `.cpp` file, so there is no additional code cost when the flag is off. It is the first gameplay header to include `math/` (`Vector2`, `MathUtil`), but — like the Phase 2 flags above — it carries **no `#error` guard**: `math/` is always available regardless of `PIXELROOT32_ENABLE_PHYSICS` or any other flag:
+**Gameplay Framework Phase 3 flag (opt-in, default `0`):** one capability in `pixelroot32::gameplay`, header-only with no `.cpp` file, so there is no additional code cost when the flag is off. It depends on `math/` (`Vector2`, `MathUtil`) but carries **no `#error` guard**, on the same terms as `DepthCompare.h` and `GameplayEvent.h`, which already depend on `math/Scalar.h`: `math/` is always available regardless of `PIXELROOT32_ENABLE_PHYSICS` or any other flag:
 
 | Flag | Default | RAM Cost When Enabled | Subsystem Added |
 |------|---------|------------------------|------------------|

--- a/docs/patterns/grid-cell-occupancy.md
+++ b/docs/patterns/grid-cell-occupancy.md
@@ -1,0 +1,118 @@
+# Pattern: Cell Occupancy ("Can I Enter This Cell?")
+
+> **Zero new engine code.** This page composes two primitives that already
+> ship — `pixelroot32::gameplay::GridSpace` (`include/gameplay/GridSpace.h`)
+> and `pixelroot32::physics::TileAttributes` (`include/physics/TileAttributes.h`)
+> — into the answer to a question every grid-based game eventually asks:
+> given a cell (or a world position), is it safe to move there?
+
+Neither primitive answers this question on its own:
+
+- `GridSpace` converts between cell indices and world positions
+  (`cellToWorld*` / `worldToCell*`) and bounds-checks a cell index against a
+  grid's declared extent (`containsCell`). It has no concept of what is
+  *in* a cell.
+- `TileAttributes` looks up per-tile behavior flags (`getTileFlags`) and
+  interprets them (`isSolidTile`, `isOneWayTile`, `isSensorTile`). It has no
+  concept of a game's own grid origin or extent — it operates on tile
+  indices directly.
+
+Composing them is the whole recipe.
+
+## Requirements
+
+`GridSpace.h` is gated behind `PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE`
+(default `0`) — see
+[Memory system — gameplay flags and byte budgets](../architecture/memory-system.md)
+for its byte cost (0 B SRAM for a `constexpr` grid). `TileAttributes.h` has
+no gating flag; it is always available.
+
+## The composition
+
+```cpp
+#include "gameplay/GridSpace.h"
+#include "physics/TileAttributes.h"
+
+using pixelroot32::gameplay::GridSpec;
+using pixelroot32::gameplay::containsCell;
+using pixelroot32::gameplay::worldToCellX;
+using pixelroot32::gameplay::worldToCellY;
+using pixelroot32::physics::TileBehaviorLayer;
+using pixelroot32::physics::TileFlags;
+using pixelroot32::physics::getTileFlags;
+using pixelroot32::physics::isSolidTile;
+
+/// True if (cellX, cellY) is inside the grid's declared extent AND the tile
+/// there is not solid.
+bool isCellWalkable(int cellX, int cellY,
+                     const GridSpec& grid,
+                     const TileBehaviorLayer& layer) {
+    if (!containsCell(cellX, cellY, grid)) {
+        return false;
+    }
+    const uint8_t flags = getTileFlags(layer, cellX, cellY);
+    return !isSolidTile(static_cast<TileFlags>(flags));
+}
+
+/// Same question, asked from a world-space position (e.g. where an actor
+/// wants to move next) instead of an already-known cell index. Works for
+/// both target coordinate systems: pass ints for a raw pixel position, or
+/// a math::Scalar for an Actor::position-style value (the Scalar overloads
+/// of worldToCellX/Y floor first, then reuse the same int primitive).
+template <typename Coord>
+bool isPositionWalkable(Coord worldX, Coord worldY,
+                         const GridSpec& grid,
+                         const TileBehaviorLayer& layer) {
+    return isCellWalkable(worldToCellX(worldX, grid),
+                           worldToCellY(worldY, grid),
+                           grid, layer);
+}
+```
+
+## Why the bounds check comes first
+
+`getTileFlags` already returns `TILE_NONE` (0, i.e. not solid) for an
+out-of-bounds `(x, y)` — see its doc comment in `TileAttributes.h`. That
+alone is not enough to say "walkable": it means *no attribute data exists
+there*, not *nothing is there*. A cell past the edge of a level is absent
+from the tile data (so `getTileFlags` reports it as clear) but is still not
+a place gameplay should let anything stand. `containsCell` catches that case
+against the *game's own declared grid extent* — which is not required to be
+the same as the tile layer's `width`/`height`. A game may want a smaller
+walkable area than its tile data covers (a UI band reserved at the top of
+the screen, for example — see the note below), and `GridSpec`'s `cols`/`rows`
+is where that narrower extent lives.
+
+## Worked example: a UI band narrower than the tile data
+
+Suppose a game reserves the top two rows of the screen for a score display
+and does not want gameplay to ever place anything there, even though the
+underlying tile layer has attribute data for every row:
+
+```cpp
+// The tile layer covers the full screen height...
+TileBehaviorLayer levelLayer{levelData, /*width=*/20, /*height=*/24};
+
+// ...but the game's own grid only considers rows below the UI band walkable.
+inline constexpr GridSpec kPlayGrid{0, /*originY=*/2 * CELL_SIZE,
+                                     CELL_SIZE, CELL_SIZE,
+                                     /*cols=*/20, /*rows=*/22};
+static_assert(gameplay::gridSpecIsValid(kPlayGrid),
+              "kPlayGrid exceeds Scalar's range or has an invalid cell size.");
+```
+
+`containsCell(cellX, cellY, kPlayGrid)` now rejects the UI rows regardless of
+what `levelLayer` says about them, without `TileAttributes` needing any
+concept of "UI band" at all — the two primitives stay decoupled, and the
+game-specific rule (which rows are playable) lives in the grid declaration,
+not in a third helper.
+
+## What this pattern deliberately does not ship
+
+No `isCellWalkable` / `isPositionWalkable` function exists in the engine
+itself. Whether "walkable" means `!isSolidTile(...)`, or also excludes
+`isOneWayTile`/`isSensorTile` results, or folds in a per-game rule (an
+occupied-by-another-actor check, say) is a decision specific to each game's
+movement rules — exactly the same reasoning that keeps `snapToGrid` out of
+`GridSpace` itself. Copy the composition above and adapt the flag check to
+what your game actually needs.

--- a/examples/snake/README.md
+++ b/examples/snake/README.md
@@ -5,6 +5,7 @@ Classic **Snake** on a grid: discrete movement (no physics engine), **pre-alloca
 ## Requirements (build flags)
 
 - **`PIXELROOT32_ENABLE_AUDIO=1`** — set in [`lib/platformio.ini`](lib/platformio.ini) `base` template so all environments inherit it.
+- **`PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1`** — required, not optional. `GameConstants.h` declares `kSnakeGrid` as a `gameplay::GridSpec`, and the whole `GridSpace.h` header lives behind this flag (default `0`), so the example does not compile without it.
 
 Display size is **240×240** in the project `platformio.ini` (see **`PHYSICAL_DISPLAY_*`**).
 
@@ -32,12 +33,15 @@ Pin choices for I2S / DAC are in **`src/platforms/esp32_dev.h`** (edit there if 
 - **Scene** + **Entity** background + pooled **`SnakeSegmentActor`**
 - **Grid logic** and timers (`moveInterval`, `lastMoveTime`)
 - **Audio** subsystem integration (`AudioEngine`, platform backends)
+- Cell/world conversion via **`gameplay::GridSpace`**: segment positions, hit boxes, and food spawn points are all placed through `kSnakeGrid` (`GameConstants.h`) instead of hand-rolled `* CELL_SIZE` / `/ CELL_SIZE` arithmetic. The food-eaten check compares cells (`worldToCellX/Y`), not pixel-aligned equality, so it also works if food is ever spawned off the cell grid.
 
 ## Documentation links
 
 - [Audio API](../../docs/api/audio.md)
 - [Core API](../../docs/api/core.md)
 - [Input API](../../docs/api/input.md)
+- [Memory system — gameplay flags and byte budgets](../../docs/architecture/memory-system.md) — RAM cost of `PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE`
+- [`gameplay/GridSpace.h`](../../include/gameplay/GridSpace.h) — the full grid conversion API
 
 ## Build
 

--- a/examples/tic_tac_toe/README.md
+++ b/examples/tic_tac_toe/README.md
@@ -8,6 +8,7 @@ On **`esp32cyd`**, **`PIXELROOT32_ENABLE_TOUCH`** and **`onUnconsumedTouchEvent`
 
 - **`PIXELROOT32_ENABLE_TOUCH=1`** on **`native`** and **`esp32cyd`** (see `platformio.ini`) so touch code paths compile where used.
 - ESP32 Dev preset does **not** set touch in `platformio.ini` — use GPIO **DPAD + A** (or equivalent) as in `GameConstants.h` (`BTN_UP`, `BTN_DOWN`, `BTN_PREV`, `BTN_NEXT`, `BTN_SELECT`).
+- **`PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1`** — required, not optional. `GameConstants.h` declares `kBoardGrid` as a `gameplay::GridSpec`, and the whole `GridSpace.h` header lives behind this flag (default `0`), so the example does not compile without it.
 
 `PIXELROOT32_ENABLE_UI_SYSTEM` defaults to **on** in the engine ([`PlatformDefaults.h`](../../include/platforms/PlatformDefaults.h)).
 
@@ -36,12 +37,15 @@ Touches that the UI does not consume are handled in **`onUnconsumedTouchEvent`**
 - **`TouchEvent`** pipeline for board placement
 - **AI**: `computeAIMove`, win detection, draw state
 - **Custom palette** and vector draw for marks (no tilemap required for the board)
+- Cell/world conversion via **`gameplay::GridSpace`**: board centring, grid lines, cursor position, and mark drawing are all placed through `kBoardGrid` (`GameConstants.h`) instead of hand-rolled `* CELL_SIZE` / `/ CELL_SIZE` arithmetic. `touchToCell()` maps a raw touch position to a board cell with `worldToCellX/Y` + `containsCell`, which correctly rejects touches inside `kTouchHitSlop` that land outside the board (a truncating conversion would have silently accepted some of them).
 
 ## Documentation links
 
 - [UI API](../../docs/api/ui.md)
 - [Input API](../../docs/api/input.md)
 - [Core API](../../docs/api/core.md)
+- [Memory system — gameplay flags and byte budgets](../../docs/architecture/memory-system.md) — RAM cost of `PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE`
+- [`gameplay/GridSpace.h`](../../include/gameplay/GridSpace.h) — the full grid conversion API
 
 ## Build
 


### PR DESCRIPTION
Documents the grid-space flag and runs the cross-cutting verification that closes the `gameplay-framework-phase3-grid` change.

**PR 4 of 4, the last in the chain.** Chained on #173 → #172 → #171. **Merge #171, #172, #173, then this.**

**Zero code changes.** Four documentation files, nothing under `include/`, `src/`, `test/`, or any example's source.

## Review this first

The verification table below. The documentation is straightforward; the verification is the part that decides whether the three PRs beneath this one should merge.

## Verification results

Every figure below came from an actual command run serially on this machine.

| Check | Result |
|---|---|
| `pio test -e native_test` (flags off) | **1595 cases, 4 skipped, 1591 succeeded, 0 failed** |
| `pio test -e native_test_gameplay` (flags on) | **1664 cases, 4 skipped, 1660 succeeded, 0 failed** |
| All 15 examples build for `native` | **15/15 SUCCESS** |
| Flag independence | **7/7** gameplay flags compile alone |
| Migration gate | **net +5** ≤ +8 → **PASSES** |
| `.bss` on snake + tic_tac_toe | byte-identical |
| `kSnakeGrid` / `kBoardGrid` symbols at `-Os` | **absent** from both binaries |
| Zero diff under `core/`, `physics/`, `math/` | confirmed across the whole chain |

The seven gameplay flags exercised independently: `GAMEPLAY_GRID_SPACE`, `GAMEPLAY_EVENTS`, `GAMEPLAY_STATE_MACHINE`, `GAMEPLAY_OBJECT_POOL`, `DEPTH_SORT`, `INTERACTION_TRIGGERS`, `SPATIAL_QUERY` — the complete set declared in `PlatformDefaults.h`.

The `constexpr` grids leaving no symbol behind at `-Os` is the byte-budget claim actually holding: **0 B SRAM**, verified rather than asserted.

## Two things that did not fully check out

Both are reported rather than smoothed over.

### The RISC-V instruction check was NOT performed

The design's byte budget claims no `div`/`rem` instruction survives on the ESP32-C3, because the divisor propagates from a `constexpr` grid and GCC replaces the division with `mulh`+shift.

**That check could not be run.** Neither snake nor tic_tac_toe has an `esp32c3` environment in this repo — they ship `native` (x86-64) and `esp32dev` (Xtensa). Counting `div` instructions in an x86-64 binary says nothing about RV32IMC codegen.

The claim remains plausible and is standard constant-folding behavior, but it is **unverified on the target it is about**. Anyone wanting it confirmed needs a C3 build of one of these examples.

### `.data` differs by 80 bytes

Not byte-identical, which the budget claims literally. A symbol-level `nm` diff shows all 682 named data symbols identical in both binaries, which points at link-order/padding noise in the build tree rather than a code change — and the delta is **negative** (80 bytes smaller), so it is not a growth regression in any case.

Worth a second opinion before merge, but it is not a blocker on its own.

## Documentation added

| File | Content |
|---|---|
| `docs/architecture/memory-system.md` | Byte-budget row for the flag, matching the Phase 1/2 table format |
| `docs/patterns/grid-cell-occupancy.md` | Recipe composing `GridSpace` with the existing `TileAttributes` API |
| `examples/snake/README.md` | Flag requirement + what the migration changed |
| `examples/tic_tac_toe/README.md` | Same |

### The recipe uses only what already ships

`docs/patterns/grid-cell-occupancy.md` answers "can I enter this cell?" by composing `gameplay::containsCell` + `gameplay::worldToCellX/Y` with the existing `physics::getTileFlags` + `physics::isSolidTile`. **Zero new engine code.**

Its main helper block was extracted from the markdown and compiled standalone (`g++ -std=c++17 -fsyntax-only`) — it is copy-pasteable as written, including the `static_cast<TileFlags>` that `getTileFlags`' `uint8_t` return requires.

### Both READMEs had the defect this task exists to catch

Both had a "Requirements (build flags)" section that became **factually incomplete** the moment their examples started requiring `PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1`. This is the third time this exact defect has appeared — metroidvania and flappy_bird both needed the same correction after the Phase 2 FSM migration. Fixed in both.

## One factual error corrected

Commit `297ce3b`. The first draft claimed `GridSpace.h` is "the first gameplay header to include `math/`". It is not — `DepthCompare.h` and `GameplayEvent.h` already include `math/Scalar.h`. The surrounding point still stands (no `#error` guard is needed, because `math/` is unconditionally available), so it now states that as the shared precedent it is.

## Chain summary

With this PR, the change is complete:

| PR | Content |
|---|---|
| #171 | `GridSpace.h` + 18-case dual-compiling suite + flag wiring |
| #172 | snake migration — 15 hand-rolled conversions removed |
| #173 | tic_tac_toe migration — 13 removed, gate closed at +5 |
| **#174** | byte-budget docs, cell-occupancy recipe, cross-cutting verification |

**28 hand-rolled cell/world conversions removed across two examples, for +5 net lines.**

## Interactive verification: PASSED

This environment cannot drive GUI input, so both examples were play-tested by a human:

- [x] **snake** — eats food and grows, dies on the wall without entering the top UI band, dies on itself
- [x] **tic_tac_toe** — touch places a mark in the correct cell; a touch just outside the board within the 8 px hit slop places none

Those cover the two behavior-adjacent changes in the chain: snake's food check moving to cell equality (#172) and tic_tac_toe's `touchToCell` fold onto floor division (#173).

The only verification still outstanding for the whole change is the RISC-V `div`/`rem` inspection described above, which needs a C3 build target that neither example currently has.
