### PR TITLE
feat(bomberman): bombs, fuses and chain reactions (2/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ PlatformIO will automatically download and install the library and its dependenc
    cd PixelRoot32-Game-Engine/examples/hello_world
    ```
 
-   Each folder (`hello_world`, `animated_tilemap`, `snake`, `flappy_bird`, `metroidvania`, `tic_tac_toe`, `space_invaders`, `brick_breaker`, `physics`, `camera`, `dual_palette`, `sprites`, `music_demo`, `2048`) is a **standalone PlatformIO project** with its own `platformio.ini`.
+   Each folder (`hello_world`, `animated_tilemap`, `snake`, `flappy_bird`, `metroidvania`, `tic_tac_toe`, `space_invaders`, `brick_breaker`, `physics`, `camera`, `dual_palette`, `sprites`, `music_demo`, `2048`, `bomberman`) is a **standalone PlatformIO project** with its own `platformio.ini`.
 
 2. **Open that example folder in VS Code** (File → Open Folder) and select your environment (`env:esp32dev`, `env:esp32cyd`, `env:esp32c3`, or `env:native`).
 3. **Build and Upload** using PlatformIO.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ The engine revision for each example is defined in **`lib_deps`** inside that ex
 | [tic_tac_toe](tic_tac_toe/) | UI, GPIO vs touch, minimax AI, vector-drawn board, **`MusicPlayer`** / melody data | `native`, `esp32dev`, `esp32cyd` |
 | [2048](2048/) | 2048 puzzle game: grid rendering, touch swipes, D-pad controls, score tracking, **AI auto-play** (expectimax algorithm), audio SFX | `native`, `esp32cyd` |
 | [flappy_bird](flappy_bird/) | Physics flappy clone, U8g2 OLED, ESP32-C3 (**no audio** in this sample) | `native`, `esp32c3` |
+| [bomberman](bomberman/) | Bomberman clone: interpolated grid movement, deterministic seeded board generation, bounded chain-reaction explosions, PRNG enemy AI, HUD + text overlays, `AudioEngine` | `native`, `esp32dev` |
 
 
 ## Suggested learning order
@@ -40,7 +41,7 @@ The engine revision for each example is defined in **`lib_deps`** inside that ex
 2. **sprites** or **dual_palette** — graphics and color models.  
 3. **camera** or **metroidvania** / **animated_tilemap** — scrolling, tilemaps, caching (read **animated_tilemap** for the fullest tilemap write-up).  
 4. **physics** — bodies, sensors, touch.  
-5. **snake** / **tic_tac_toe** / **2048** / **brick_breaker** / **music_demo** / **space_invaders** — **audio** (events, single-track music, or **multi-track** reference). **flappy_bird** — physics + OLED, no audio subsystem.
+5. **snake** / **tic_tac_toe** / **2048** / **brick_breaker** / **music_demo** / **space_invaders** / **bomberman** — **audio** (events, single-track music, or **multi-track** reference). **flappy_bird** — physics + OLED, no audio subsystem.
 
 ## Engine documentation
 

--- a/examples/bomberman/README.md
+++ b/examples/bomberman/README.md
@@ -1,0 +1,146 @@
+# Bomberman Example
+
+A classic **Bomberman**-style game on a **13×11** grid: place bombs, chain
+explosions, destroy soft walls, dodge four PRNG-driven enemies, collect
+power-ups, and reach the exit once every enemy is dead. Movement is
+**interpolated** between cells (not a teleport-per-cell like some of the
+other grid examples), and every timed rule — movement, bomb fuses,
+explosions, the level clock — runs on a **fixed 20 ms logic step**, decoupled
+from the rendered frame rate.
+
+## Requirements (build flags)
+
+Set in [`lib/platformio.ini`](lib/platformio.ini)'s `[base]` template, so
+every environment inherits them:
+
+- **`PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1`** — required, not optional.
+  `BombermanConstants.h` declares `kBoardGrid` as a `gameplay::GridSpec`, and
+  the whole `GridSpace.h` header lives behind this flag (default `0`), so the
+  example does not compile without it.
+- **`PIXELROOT32_ENABLE_AUDIO=1`** — needed for the four sound events below.
+- **`PIXELROOT32_ENABLE_PHYSICS=0`** — the physics system is never used;
+  every blocking/collision check here is a board lookup, not a physics query.
+- **`PIXELROOT32_ENABLE_PARTICLES=0`** — not used.
+- **`PIXELROOT32_ENABLE_UI_SYSTEM=0`** — HUD and overlays are drawn directly
+  with `Renderer::drawText`/`drawTextCentered`, not the UI widget system.
+
+Display size is **240×240** in the project `platformio.ini` (see
+`PHYSICAL_DISPLAY_*`).
+
+## Platforms
+
+| Environment | Display | Audio backend |
+|-------------|---------|----------------|
+| **`native`** | SDL2, 240×240 | `SDL2_AudioBackend` in [`src/platforms/native.h`](src/platforms/native.h) |
+| **`esp32dev`** | **ST7789** 240×240 | `ESP32_I2S_AudioBackend` in [`src/platforms/esp32_dev.h`](src/platforms/esp32_dev.h) |
+
+Pin choices (ST7789 SPI, I2S audio, D-pad + two buttons) are in
+`src/platforms/esp32_dev.h` — edit there if your wiring differs.
+
+## Controls
+
+| Action | `native` (keyboard) | `esp32dev` (GPIO) |
+|--------|----------------------|--------------------|
+| Move | Arrow keys | D-pad |
+| Place bomb | Space | Button A |
+| Restart (from Game Over / Stage Clear) | Enter | Button B |
+
+Movement has a fixed priority — **Up > Down > Left > Right** — when more than
+one direction is held at once, so input is never ambiguous and never
+diagonal. Holding a direction into a wall, a bomb, or the board edge simply
+leaves the player in place; it is never a death.
+
+## How audio is triggered
+
+`BombermanScene::logicStep()` builds `pixelroot32::audio::AudioEvent` values
+and calls `engine.getAudioEngine().playEvent(...)`, the same pattern the
+`snake` example uses. Four events, each tied to one exact pipeline moment:
+
+- **Bomb placed** — the step a bomb placement actually succeeds (not every
+  press of the bomb button; a press rejected by the bomb limit or an
+  already-bombed cell stays silent).
+- **Explosion** — the step any bomb(s) actually detonate, whether from a
+  timer or a chain reaction (one event per step, even if several bombs chain
+  together on that step).
+- **Player death** — one shared event for every death cause: explosion
+  contact, enemy contact, or the countdown reaching zero.
+- **Stage clear** — the step victory is reached (last enemy already dead,
+  player steps onto the revealed exit).
+
+## Features
+
+- **Deterministic board generation.** `BombermanBoard.cpp` builds the board
+  from a seed using the engine's seeded PRNG (`math::set_seed` /
+  `math::rand_int`) — never `std::rand`. Hard walls sit on the border and at
+  every even-x/even-y interior cell; every other cell is on a connected
+  corridor lattice by construction (no reachability check needed, since soft
+  walls are all destructible and never permanently block a corridor cell).
+  The player's start cell and its two adjacent cells are guaranteed free of
+  soft walls.
+- **Interpolated grid movement.** The player moves at 12 logic steps per
+  cell, enemies at 20. Both use the same small `GridMove` struct
+  (`src/GridMove.h`) but each actor writes its own advance loop — the
+  player stays put when blocked and reads held input; an enemy re-picks a
+  direction and reads the seeded PRNG. The two loops are deliberately not
+  merged into a shared controller; they disagree on enough policy (blocking
+  behavior, direction source, and the pass-through rule below) that sharing
+  more than the struct would need extra flags for every difference.
+- **Own-bomb pass-through.** A player can always leave the cell they just
+  bombed; that bomb becomes solid again the instant they arrive in a new
+  cell. Enemies have no such exemption — every bomb is solid to them.
+- **Chain reactions.** An explosion reaching another bomb detonates it
+  immediately, in the same logic step, via a small bounded queue (at most
+  8 entries — the size of the bomb pool) instead of recursion, so a ring of
+  mutually-adjacent bombs still resolves in a fixed number of iterations.
+- **Hidden content lives in the tile type, not a side table.** The three
+  soft-wall variants (plain, hiding the exit, hiding a power-up) render and
+  block identically until destroyed — there is only one array that could
+  disagree with what is drawn.
+- **Cell/world conversion via `gameplay::GridSpace`.** The board's
+  `constexpr GridSpec` places the playfield below a reserved status band
+  (`containsCell` rejects that band automatically, so no gameplay rule needs
+  to know the HUD exists) — no hand-rolled `* 16` / `/ 16` arithmetic
+  anywhere in the game logic.
+- **Plain-enum state, not the engine's generic state-machine primitive.**
+  The level's five states (Loading, Playing, ExitUnlocked, StageClear,
+  GameOver) are one plain `enum class`, driven by a fixed nine-stage update
+  pipeline that runs the same conditions in the same order every logic step.
+  Player, bomb, and tile "state" are likewise derived from a couple of
+  existing fields rather than stored as separate enums.
+- **Entity budget guardrail.** A `static_assert` (compile-time) plus a
+  post-init `assert` (development builds only — it compiles out under
+  `NDEBUG` on `esp32dev` release builds) both guard against the entity pool
+  silently dropping an actor once its fixed array is full.
+- **HUD and overlays.** Lives, enemies remaining, current fire power / max
+  bombs (`F n B n`), and the countdown are drawn every frame straight from
+  the live game state — there is no cached copy that could go stale. Game
+  Over and Stage Clear are a **text overlay drawn on top of the board**, not
+  a separate screen or `Scene`.
+- **Level countdown.** A `TIME` value counts down once per logic step
+  (never per rendered frame); reaching zero costs one life through the exact
+  same path as an explosion or an enemy contact. The 180-second starting
+  value is a first estimate, not a value tuned against a timed play session.
+
+## Documentation links
+
+- [Audio API](../../docs/api/audio.md)
+- [Core API](../../docs/api/core.md)
+- [Input API](../../docs/api/input.md)
+- [Memory system — gameplay flags and byte budgets](../../docs/architecture/memory-system.md)
+- [Grid cell occupancy pattern](../../docs/patterns/grid-cell-occupancy.md) — the status-band-above-the-grid layout this example uses
+- [`gameplay/GridSpace.h`](../../include/gameplay/GridSpace.h) — the full grid conversion API
+
+## Build
+
+From **`examples/bomberman`**:
+
+```bash
+pio run -e native
+pio run -e esp32dev
+```
+
+## Upload (ESP32)
+
+```bash
+pio run -e esp32dev --target upload
+```

--- a/examples/bomberman/src/BoardRenderer.cpp
+++ b/examples/bomberman/src/BoardRenderer.cpp
@@ -9,9 +9,10 @@ namespace gfx = pr32::graphics;
 namespace core = pr32::core;
 namespace math = pr32::math;
 
-BoardRenderer::BoardRenderer(const TileType (&board)[kCells])
+BoardRenderer::BoardRenderer(const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs],
+                              const uint8_t (&blastSteps)[kCells])
     : core::Entity(math::Vector2::ZERO(), DISPLAY_WIDTH, DISPLAY_HEIGHT, core::EntityType::GENERIC),
-      board_(board) {
+      board_(board), bombs_(bombs), blastSteps_(blastSteps) {
     setRenderLayer(0);
 }
 
@@ -47,8 +48,43 @@ void BoardRenderer::draw(gfx::Renderer& renderer) {
                 renderer.drawFilledRectangle(px + 4, py + 4, 8, 8, gfx::Color::Purple);
             }
             // TileType::Empty draws nothing. PowerUpFire/PowerUpBomb draw
-            // passes are added in Phase 4.
+            // passes are added with power-up pickup, in later work.
         }
+    }
+
+    // Explosion cells, drawn before the bomb/actor layers so a player (or,
+    // later, an enemy) dying in a blasted cell shows the explosion for at
+    // least one frame instead of hiding whatever was just eliminated
+    // there.
+    for (int i = 0; i < kCells; ++i) {
+        if (blastSteps_[i] == 0) {
+            continue;
+        }
+        const int x = i % kCols;
+        const int y = i / kCols;
+        const int px = gameplay::cellToWorldX(x, kBoardGrid);
+        const int py = gameplay::cellToWorldY(y, kBoardGrid);
+        renderer.drawFilledRectangle(px + 2, py + 2, kCellSize - 4, kCellSize - 4, gfx::Color::Yellow);
+        renderer.drawFilledCircle(px + kCellSize / 2, py + kCellSize / 2, 4, gfx::Color::Orange);
+    }
+
+    // Bombs: a body that alternates colour every 5 steps during the final
+    // flash window, plus a short fuse line.
+    for (int i = 0; i < kMaxBombs; ++i) {
+        const Bomb& b = bombs_[i];
+        if (!b.active) {
+            continue;
+        }
+        const int px = gameplay::cellToWorldX(b.cellX, kBoardGrid);
+        const int py = gameplay::cellToWorldY(b.cellY, kBoardGrid);
+        const int cx = px + kCellSize / 2;
+        const int cy = py + kCellSize / 2;
+        bool flash = false;
+        if (b.fuseSteps <= kBombFlashSteps) {
+            flash = ((b.fuseSteps / 5) % 2) == 0;
+        }
+        renderer.drawFilledCircle(cx, cy, 6, flash ? gfx::Color::LightRed : gfx::Color::Black);
+        renderer.drawLine(cx, cy - 6, cx + 3, cy - 10, gfx::Color::White);
     }
 }
 

--- a/examples/bomberman/src/BoardRenderer.cpp
+++ b/examples/bomberman/src/BoardRenderer.cpp
@@ -46,9 +46,14 @@ void BoardRenderer::draw(gfx::Renderer& renderer) {
             } else if (t == TileType::Exit) {
                 renderer.drawRectangle(px, py, kCellSize, kCellSize, gfx::Color::Purple);
                 renderer.drawFilledRectangle(px + 4, py + 4, 8, 8, gfx::Color::Purple);
+            } else if (t == TileType::PowerUpFire) {
+                renderer.drawFilledCircle(px + kCellSize / 2, py + kCellSize / 2, 5, gfx::Color::LightRed);
+                renderer.drawCircle(px + kCellSize / 2, py + kCellSize / 2, 6, gfx::Color::Yellow);
+            } else if (t == TileType::PowerUpBomb) {
+                renderer.drawFilledCircle(px + kCellSize / 2, py + kCellSize / 2, 5, gfx::Color::Blue);
+                renderer.drawCircle(px + kCellSize / 2, py + kCellSize / 2, 6, gfx::Color::Cyan);
             }
-            // TileType::Empty draws nothing. PowerUpFire/PowerUpBomb draw
-            // passes are added with power-up pickup, in later work.
+            // TileType::Empty draws nothing.
         }
     }
 

--- a/examples/bomberman/src/BoardRenderer.h
+++ b/examples/bomberman/src/BoardRenderer.h
@@ -14,8 +14,9 @@ namespace bomberman {
  *
  * Holds references to the scene's board/bomb/blastSteps arrays — never
  * copies — so a regenerated level or a fresh bomb pool is visible without
- * re-adding or reconstructing this entity. Item draw passes are added in
- * later work.
+ * re-adding or reconstructing this entity. Power-up tiles are drawn as part
+ * of the same per-cell pass as walls/exit; enemies and the player draw
+ * themselves as layer-1 actors, added separately.
  */
 class BoardRenderer : public pixelroot32::core::Entity {
 public:

--- a/examples/bomberman/src/BoardRenderer.h
+++ b/examples/bomberman/src/BoardRenderer.h
@@ -2,28 +2,33 @@
 #include "core/Entity.h"
 #include "graphics/Renderer.h"
 #include "BombermanBoard.h"
+#include "BombermanBombs.h"
 #include "BombermanConstants.h"
 
 namespace bomberman {
 
 /**
  * @class BoardRenderer
- * @brief Layer-0 entity: screen clear, status band, board frame, and every
- *        tile currently on the board.
+ * @brief Layer-0 entity: screen clear, status band, board frame, every
+ *        tile currently on the board, active bombs, and explosion cells.
  *
- * Holds a reference to the scene's board array — never a copy — so a
- * regenerated level is visible without re-adding or reconstructing this
- * entity. Bomb, explosion, and item draw passes are added in later phases.
+ * Holds references to the scene's board/bomb/blastSteps arrays — never
+ * copies — so a regenerated level or a fresh bomb pool is visible without
+ * re-adding or reconstructing this entity. Item draw passes are added in
+ * later work.
  */
 class BoardRenderer : public pixelroot32::core::Entity {
 public:
-    explicit BoardRenderer(const TileType (&board)[kCells]);
+    BoardRenderer(const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs],
+                  const uint8_t (&blastSteps)[kCells]);
 
     void update(unsigned long deltaTime) override;
     void draw(pixelroot32::graphics::Renderer& renderer) override;
 
 private:
     const TileType (&board_)[kCells];
+    const Bomb (&bombs_)[kMaxBombs];
+    const uint8_t (&blastSteps_)[kCells];
 };
 
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanBombs.cpp
+++ b/examples/bomberman/src/BombermanBombs.cpp
@@ -1,0 +1,144 @@
+#include "BombermanBombs.h"
+
+namespace bomberman {
+
+bool bombAt(const Bomb (&bombs)[kMaxBombs], int cellX, int cellY) {
+    for (int i = 0; i < kMaxBombs; ++i) {
+        if (bombs[i].active && bombs[i].cellX == cellX && bombs[i].cellY == cellY) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int activeBombCount(const Bomb (&bombs)[kMaxBombs]) {
+    int count = 0;
+    for (int i = 0; i < kMaxBombs; ++i) {
+        if (bombs[i].active) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+bool placeBomb(Bomb (&bombs)[kMaxBombs], int cellX, int cellY, int range) {
+    if (bombAt(bombs, cellX, cellY)) {
+        return false;
+    }
+    for (int i = 0; i < kMaxBombs; ++i) {
+        if (!bombs[i].active) {
+            bombs[i].cellX = static_cast<uint8_t>(cellX);
+            bombs[i].cellY = static_cast<uint8_t>(cellY);
+            bombs[i].fuseSteps = static_cast<uint8_t>(kBombFuseSteps);
+            bombs[i].range = static_cast<uint8_t>(range);
+            bombs[i].active = true;
+            return true;
+        }
+    }
+    return false;  // pool full
+}
+
+void tickFuses(Bomb (&bombs)[kMaxBombs], uint8_t (&detonationQueue)[kMaxBombs], int& queueTail) {
+    for (int i = 0; i < kMaxBombs; ++i) {
+        if (!bombs[i].active) {
+            continue;
+        }
+        if (bombs[i].fuseSteps > 0) {
+            --bombs[i].fuseSteps;
+        }
+        if (bombs[i].fuseSteps == 0) {
+            bombs[i].active = false;
+            if (queueTail < kMaxBombs) {  // bounded at the write site
+                detonationQueue[queueTail++] = static_cast<uint8_t>(i);
+            }
+        }
+    }
+}
+
+namespace {
+
+/// Walks one direction from (cx, cy) out to `range` cells, painting
+/// blastSteps and applying destruction/chain-triggering per the header's
+/// propagation rules. `tail` is bounded against kMaxBombs at the write
+/// site — never assumed safe purely because the caller promised it.
+void paintArm(int cx, int cy, int dx, int dy, int range,
+              TileType (&board)[kCells], uint8_t (&blastSteps)[kCells],
+              uint8_t (&detonationQueue)[kMaxBombs], int& tail,
+              Bomb (&bombs)[kMaxBombs], TileType hiddenPowerUp) {
+    int x = cx;
+    int y = cy;
+    for (int step = 0; step < range; ++step) {
+        x += dx;
+        y += dy;
+        if (!gameplay::containsCell(x, y, kBoardGrid)) {
+            return;  // the border is always HardWall; unreachable in practice
+        }
+        const int idx = cellIndex(x, y);
+        const TileType t = board[idx];
+
+        if (t == TileType::HardWall) {
+            return;  // stops the arm; the cell is untouched
+        }
+        if (isSoftWall(t)) {
+            board[idx] = destroyedInto(t, hiddenPowerUp);
+            blastSteps[idx] = static_cast<uint8_t>(kExplosionSteps);
+            return;  // destroyed, then the arm stops
+        }
+
+        bool chained = false;
+        for (int i = 0; i < kMaxBombs; ++i) {
+            if (bombs[i].active && bombs[i].cellX == x && bombs[i].cellY == y) {
+                bombs[i].active = false;
+                if (tail < kMaxBombs) {  // bounded at the write site
+                    detonationQueue[tail++] = static_cast<uint8_t>(i);
+                }
+                chained = true;
+                break;
+            }
+        }
+        blastSteps[idx] = static_cast<uint8_t>(kExplosionSteps);
+        if (chained) {
+            // The chained bomb produces its own independent cross on a
+            // later iteration of the drain loop; this arm stops here so
+            // the two crosses never repaint the same cells against each
+            // other.
+            return;
+        }
+        // Otherwise: Empty, or a cell whose bomb already detonated earlier
+        // in this same drain — paint it and let the arm continue.
+    }
+}
+
+}  // namespace
+
+int resolveDetonations(uint8_t (&detonationQueue)[kMaxBombs], int queueTail,
+                        Bomb (&bombs)[kMaxBombs],
+                        TileType (&board)[kCells],
+                        uint8_t (&blastSteps)[kCells],
+                        TileType hiddenPowerUp) {
+    int head = 0;
+    int tail = (queueTail < kMaxBombs) ? queueTail : kMaxBombs;  // bounded at the write site
+
+    static constexpr int kArmDX[4] = {0, 0, -1, 1};
+    static constexpr int kArmDY[4] = {-1, 1, 0, 0};
+
+    while (head < tail) {
+        const Bomb b = bombs[detonationQueue[head++]];  // copy: paintArm mutates other slots
+        blastSteps[cellIndex(b.cellX, b.cellY)] = static_cast<uint8_t>(kExplosionSteps);
+        for (int d = 0; d < 4; ++d) {
+            paintArm(b.cellX, b.cellY, kArmDX[d], kArmDY[d], b.range,
+                     board, blastSteps, detonationQueue, tail, bombs, hiddenPowerUp);
+        }
+    }
+    return tail;
+}
+
+void tickExplosions(uint8_t (&blastSteps)[kCells]) {
+    for (int i = 0; i < kCells; ++i) {
+        if (blastSteps[i] > 0) {
+            --blastSteps[i];
+        }
+    }
+}
+
+}  // namespace bomberman

--- a/examples/bomberman/src/BombermanBombs.h
+++ b/examples/bomberman/src/BombermanBombs.h
@@ -1,0 +1,90 @@
+#pragma once
+#include <cstdint>
+#include "BombermanBoard.h"
+#include "BombermanConstants.h"
+
+namespace bomberman {
+
+/**
+ * @file BombermanBombs.h
+ * @brief Bomb pool, fuse ticking, and cross-shaped chain-reaction
+ *        detonation.
+ *
+ * Pure data and pure functions over plain arrays — nothing here touches an
+ * Actor or a Scene, so this whole file is callable and inspectable without
+ * a live game, exactly like BombermanBoard.h's generateLevel().
+ */
+
+/// One pool slot. `range` is snapshotted from the placing player's fire
+/// power at placement time and never re-read at detonation, so a Fire
+/// pickup collected after a bomb is dropped does not retroactively change
+/// that bomb's blast radius.
+struct Bomb {
+    uint8_t cellX = 0;
+    uint8_t cellY = 0;
+    uint8_t fuseSteps = 0;
+    uint8_t range = 0;
+    bool active = false;
+};
+static_assert(sizeof(Bomb) == 5,
+              "Bomb must stay a tight 5-byte record; the 8-slot pool below assumes this.");
+
+/// True iff an active bomb currently occupies (cellX, cellY). Correctly
+/// reports false for a cell whose bomb already detonated (active == false),
+/// even while that cell's blastSteps entry is still counting down.
+bool bombAt(const Bomb (&bombs)[kMaxBombs], int cellX, int cellY);
+
+/// Number of currently active (not yet detonated) bombs in the pool.
+int activeBombCount(const Bomb (&bombs)[kMaxBombs]);
+
+/// Writes a new bomb into the first free pool slot at (cellX, cellY) with
+/// the given blast range and a full fuse. Returns false, changing nothing,
+/// if the pool has no free slot or a bomb is already active at that cell.
+/// This function knows nothing about any player's own max-simultaneous-bomb
+/// limit — that is caller-side policy (see PlayerActor::tryPlaceBomb), kept
+/// separate so this pool operation stays reusable by any placer.
+bool placeBomb(Bomb (&bombs)[kMaxBombs], int cellX, int cellY, int range);
+
+/// Advances every active bomb's fuse by one step. A bomb whose fuse reaches
+/// zero this call is deactivated and its pool index appended to
+/// `detonationQueue` — the seed for resolveDetonations() below. This is the
+/// only place a bomb's OWN timer enqueues it, and it clears `active` in the
+/// same statement that appends the index, which is half of the
+/// never-enqueued-twice invariant resolveDetonations() depends on.
+/// `queueTail` should be 0 on entry (a fresh call always starts a fresh
+/// detonation batch — nothing in this codebase carries a queue across two
+/// calls), and every write into `detonationQueue` is bounded against
+/// kMaxBombs at the write site, not merely trusted from the caller.
+void tickFuses(Bomb (&bombs)[kMaxBombs], uint8_t (&detonationQueue)[kMaxBombs], int& queueTail);
+
+/// Drains `detonationQueue` (already seeded by tickFuses) to a fixed point,
+/// painting each detonating bomb's cross into `board`/`blastSteps` and
+/// chain-triggering any OTHER active bomb an arm reaches. Returns the total
+/// number of bombs that detonated this call.
+///
+/// TERMINATION ARGUMENT. A pool slot enters detonationQueue in exactly two
+/// places in this file: in tickFuses (a fuse reaching zero) and inside this
+/// function's arm walk (a chain trigger) — and both do so only in the same
+/// statement that clears that slot's own `active` flag, and only when it
+/// was previously active. Once `active` is false, neither site will enqueue
+/// that slot again, so each of the kMaxBombs pool slots can enter the queue
+/// at most once across the whole call. Therefore the queue's write cursor
+/// never exceeds kMaxBombs, and the `while (head < tail)` drain loop below
+/// runs at most kMaxBombs iterations for ANY topology — including a ring of
+/// kMaxBombs mutually-adjacent bombs, where every slot chains into exactly
+/// one neighbour and the queue still fills at most once per slot. No
+/// recursion, no unbounded growth, no bomb ever processed twice.
+int resolveDetonations(uint8_t (&detonationQueue)[kMaxBombs], int queueTail,
+                        Bomb (&bombs)[kMaxBombs],
+                        TileType (&board)[kCells],
+                        uint8_t (&blastSteps)[kCells],
+                        TileType hiddenPowerUp);
+
+/// Decrements every nonzero blastSteps cell by one step. Cells reaching
+/// zero simply stop being lethal/drawn from the next call onward — the
+/// tile itself was already finalized by resolveDetonations() at
+/// propagation time (destroyedInto() runs once, when an arm hits the cell,
+/// not when blastSteps expires).
+void tickExplosions(uint8_t (&blastSteps)[kCells]);
+
+}  // namespace bomberman

--- a/examples/bomberman/src/BombermanConstants.h
+++ b/examples/bomberman/src/BombermanConstants.h
@@ -95,4 +95,9 @@ constexpr int kDefaultFirePower = 2;
 constexpr int kDefaultMaxBombs = 1;
 constexpr int kStartingLives = 3;
 
+/* Power-up increments. A Fire pickup adds this many cells to the blast arm
+ * length; a Bomb pickup adds one to the simultaneous-bomb limit (that half
+ * has no separate constant -- it is always exactly +1). */
+constexpr int kFirePowerIncrement = 1;
+
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanConstants.h
+++ b/examples/bomberman/src/BombermanConstants.h
@@ -100,4 +100,14 @@ constexpr int kStartingLives = 3;
  * has no separate constant -- it is always exactly +1). */
 constexpr int kFirePowerIncrement = 1;
 
+/* Level countdown. Ticks once per logic step, inside the same pipeline
+ * stage as the bomb fuses (BombermanScene::logicStep()); reaching zero
+ * costs the player one life through the exact same path as an explosion or
+ * an enemy contact -- there is no separate "time's up" state. 180 seconds
+ * is a first estimate sized to comfortably cover destroying both
+ * power-up-bearing walls, collecting both power-ups, clearing four enemies,
+ * and reaching the exit at 240ms/cell; it is a playability guess, not a
+ * measured value, since no live play session tuned it. */
+constexpr std::uint16_t kInitialCountdownSeconds = 180;
+
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanConstants.h
+++ b/examples/bomberman/src/BombermanConstants.h
@@ -80,4 +80,19 @@ constexpr int kEnemySafeDistance = 6;   // Manhattan distance from the player's 
 constexpr int kPlayerStartCellX = 1;
 constexpr int kPlayerStartCellY = 1;
 
+/* Bomb pool. Fixed-size, no dynamic allocation: 8 slots is headroom, not a
+ * requirement — with exactly one Bomb power-up per level the reachable
+ * maximum a single player can carry is small, but sizing the pool larger
+ * than that gives the chain-reaction queue in BombermanBombs.cpp a bound
+ * that stays correct if a later change adds more Bomb power-ups. */
+constexpr int kMaxBombs = 8;
+
+/* Player starting stats. Fire power is the blast arm length in cells;
+ * max bombs is the number of simultaneously active bombs the player may
+ * have out at once. Both are fixed constants in this slice — power-ups
+ * that raise them are later work. */
+constexpr int kDefaultFirePower = 2;
+constexpr int kDefaultMaxBombs = 1;
+constexpr int kStartingLives = 3;
+
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -1,6 +1,8 @@
 #include "BombermanScene.h"
 #include "core/Engine.h"
+#include "audio/AudioTypes.h"
 #include <cassert>
+#include <cstdio>
 #include <ctime>
 
 namespace pr32 = pixelroot32;
@@ -11,6 +13,7 @@ namespace bomberman {
 
 namespace gfx = pr32::graphics;
 namespace core = pr32::core;
+namespace audio = pr32::audio;
 
 BombermanScene::BombermanScene()
     : board_{},
@@ -25,7 +28,10 @@ BombermanScene::BombermanScene()
       accumulatorMs_(0),
       seed_(0),
       lives_(kStartingLives),
-      bombPressLatched_(false) {
+      countdownSeconds_(kInitialCountdownSeconds),
+      countdownSubSteps_(0),
+      bombPressLatched_(false),
+      restartPressLatched_(false) {
     // enemies_ is default-initialized above (omitted here): every slot
     // starts dead at (0,0) via EnemyActor's default constructor and is not
     // registered with the scene until startLevel() decides how many of
@@ -74,6 +80,9 @@ void BombermanScene::startLevel() {
         addEntity(&enemies_[i]);
     }
 
+    countdownSeconds_ = kInitialCountdownSeconds;
+    countdownSubSteps_ = 0;
+
     accumulatorMs_ = 0;
     // A press held across the death that triggered this restart must not
     // drop a bomb on the fresh board's first step.
@@ -89,9 +98,16 @@ void BombermanScene::startLevel() {
 
 void BombermanScene::update(unsigned long deltaTime) {
     // Latch here, at frame scope, while the press edge is still live. The
-    // loop below may run no logic step at all this frame.
-    if (engine.getInputManager().isButtonPressed(BTN_BOMB)) {
+    // loop below may run no logic step at all this frame. Both button
+    // presses this example ever reads (bomb, restart) are latched exactly
+    // this way -- isButtonPressed() is never called from inside logicStep(),
+    // which runs on the fixed 20 ms clock instead of the frame clock.
+    auto& input = engine.getInputManager();
+    if (input.isButtonPressed(BTN_BOMB)) {
         bombPressLatched_ = true;
+    }
+    if (input.isButtonPressed(BTN_RESTART)) {
+        restartPressLatched_ = true;
     }
 
     accumulatorMs_ += deltaTime;
@@ -111,8 +127,16 @@ void BombermanScene::update(unsigned long deltaTime) {
 
 void BombermanScene::logicStep() {
     if (state_ == LevelState::StageClear || state_ == LevelState::GameOver) {
-        // Terminal state: freeze the simulation. Both end states stop the
-        // pipeline the same way; only how they were reached differs.
+        // Terminal state: freeze the simulation, except for a restart
+        // request. restartPressLatched_ was set in update(), at frame
+        // scope, while the press edge was live -- reading it here (instead
+        // of calling isButtonPressed() directly) keeps every press read in
+        // this codebase on the frame clock, never the logic-step clock.
+        if (restartPressLatched_) {
+            restartPressLatched_ = false;
+            lives_ = kStartingLives;
+            startLevel();
+        }
         return;
     }
 
@@ -125,7 +149,15 @@ void BombermanScene::logicStep() {
     // frame edge instead, consumed exactly once here.
     const bool bombPressed = bombPressLatched_;
     bombPressLatched_ = false;
-    player_.logicStep(board_, bombs_, input, bombPressed);
+    if (player_.logicStep(board_, bombs_, input, bombPressed)) {
+        audio::AudioEvent bombPlacedSound;
+        bombPlacedSound.type = audio::WaveType::PULSE;
+        bombPlacedSound.frequency = 220.0f;
+        bombPlacedSound.duration = 0.08f;
+        bombPlacedSound.volume = 0.5f;
+        bombPlacedSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(bombPlacedSound);
+    }
 
     // Stage 3: enemy movement. Each alive enemy re-decides its own
     // direction independently, straight-else-PRNG; see EnemyActor.cpp.
@@ -136,16 +168,48 @@ void BombermanScene::logicStep() {
     }
 
     // Stage 4: bomb fuses tick down, seeding this step's detonation queue
-    // with any bomb whose fuse just reached zero.
+    // with any bomb whose fuse just reached zero. The level countdown ticks
+    // in this same stage, on the identical fixed 20 ms clock -- never from
+    // update()'s deltaTime -- so it is exactly as reproducible as the fuses
+    // it shares a pipeline stage with.
     uint8_t detonationQueue[kMaxBombs] = {};
     int queueTail = 0;
     tickFuses(bombs_, detonationQueue, queueTail);
+
+    if (countdownSeconds_ > 0) {
+        ++countdownSubSteps_;
+        if (countdownSubSteps_ >= kStepsPerSecond) {
+            countdownSubSteps_ = 0;
+            --countdownSeconds_;
+            if (countdownSeconds_ == 0) {
+                // Expiry costs a life via the exact same funnel as an
+                // explosion or an enemy contact. handlePlayerDeath() may
+                // call startLevel(), which resets board_/bombs_/blastSteps_
+                // -- so this returns immediately rather than letting stages
+                // 5+ below run resolveDetonations()/tickExplosions() against
+                // a detonation queue seeded for a board that no longer
+                // exists.
+                handlePlayerDeath();
+                return;
+            }
+        }
+    }
 
     // Stage 5: the queue -- including any bomb a blast arm chain-triggers
     // along the way -- drains to a fixed point within this same call. See
     // resolveDetonations()'s termination comment for why that is
     // guaranteed to happen in at most kMaxBombs iterations.
-    resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
+    const int detonatedCount =
+        resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
+    if (detonatedCount > 0) {
+        audio::AudioEvent explosionSound;
+        explosionSound.type = audio::WaveType::NOISE;
+        explosionSound.frequency = 90.0f;
+        explosionSound.duration = 0.3f;
+        explosionSound.volume = 0.7f;
+        explosionSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(explosionSound);
+    }
 
     // Stage 6: explosion cells count down toward reverting to their
     // post-destruction tile.
@@ -211,6 +275,13 @@ void BombermanScene::logicStep() {
     }
     if (state_ == LevelState::ExitUnlocked && board_[playerCell] == TileType::Exit) {
         state_ = LevelState::StageClear;
+        audio::AudioEvent stageClearSound;
+        stageClearSound.type = audio::WaveType::TRIANGLE;
+        stageClearSound.frequency = 660.0f;
+        stageClearSound.duration = 0.6f;
+        stageClearSound.volume = 0.7f;
+        stageClearSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(stageClearSound);
     }
 }
 
@@ -221,6 +292,17 @@ void BombermanScene::killEnemy(int index) {
 }
 
 void BombermanScene::handlePlayerDeath() {
+    // The single funnel for every death cause (explosion contact, enemy
+    // contact, countdown expiry) -- one audio event fires here regardless
+    // of which one triggered it.
+    audio::AudioEvent deathSound;
+    deathSound.type = audio::WaveType::SAW;
+    deathSound.frequency = 300.0f;
+    deathSound.duration = 0.4f;
+    deathSound.volume = 0.7f;
+    deathSound.duty = 0.5f;
+    engine.getAudioEngine().playEvent(deathSound);
+
     --lives_;
     if (lives_ > 0) {
         // lives_ lives outside startLevel() entirely, so it carries the
@@ -233,9 +315,33 @@ void BombermanScene::handlePlayerDeath() {
 
 void BombermanScene::draw(gfx::Renderer& renderer) {
     // BoardRenderer (layer 0), then PlayerActor + live EnemyActors
-    // (layer 1) -- Scene::draw() sorts by render layer. HUD text and
-    // overlays are later work.
+    // (layer 1) -- Scene::draw() sorts by render layer. HUD text and the
+    // game-over/stage-clear overlay are drawn on top, here, same idiom as
+    // the board's status band (BoardRenderer draws the band's background;
+    // this draws the text that sits on it).
     Scene::draw(renderer);
+
+    char buffer[24];
+
+    std::snprintf(buffer, sizeof(buffer), "LIVES %d  ENEMIES %d", lives_, enemiesAlive_);
+    renderer.drawText(buffer, 4, 6, gfx::Color::White, 1);
+
+    std::snprintf(buffer, sizeof(buffer), "F%d B%d  TIME %03u", player_.firePower(), player_.maxBombs(),
+                  static_cast<unsigned>(countdownSeconds_));
+    renderer.drawText(buffer, 4, 22, gfx::Color::White, 1);
+
+    // Text overlay, not a separate screen or Scene: both terminal states
+    // draw a dark band across the middle of the board with centered text
+    // over whatever the board looks like at the moment of the transition.
+    if (state_ == LevelState::GameOver) {
+        renderer.drawFilledRectangle(0, 104, DISPLAY_WIDTH, 32, gfx::Color::Black);
+        renderer.drawTextCentered("GAME OVER", 112, gfx::Color::Red, 1);
+        renderer.drawTextCentered("PRESS RESTART", 124, gfx::Color::Red, 1);
+    } else if (state_ == LevelState::StageClear) {
+        renderer.drawFilledRectangle(0, 104, DISPLAY_WIDTH, 32, gfx::Color::Black);
+        renderer.drawTextCentered("STAGE CLEAR", 112, gfx::Color::Cyan, 1);
+        renderer.drawTextCentered("PRESS RESTART", 124, gfx::Color::Cyan, 1);
+    }
 }
 
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -126,14 +126,23 @@ void BombermanScene::update(unsigned long deltaTime) {
 }
 
 void BombermanScene::logicStep() {
+    // The restart press is consumed here, once per logic step, in EVERY
+    // state -- not only in the terminal branch below. Latching in update()
+    // is what keeps the read on the frame clock; clearing it unconditionally
+    // is what keeps it from going stale. A press made during normal play is
+    // meaningless, so it is discarded rather than left armed: leaving it set
+    // would mean one stray press at any point in a session sits pending and
+    // then fires on the very first step after the game ends, skipping the
+    // game-over and stage-clear states entirely. The bomb latch below is
+    // safe for the same reason -- it is consumed every step, never only in
+    // the state that happens to act on it.
+    const bool restartPressed = restartPressLatched_;
+    restartPressLatched_ = false;
+
     if (state_ == LevelState::StageClear || state_ == LevelState::GameOver) {
         // Terminal state: freeze the simulation, except for a restart
-        // request. restartPressLatched_ was set in update(), at frame
-        // scope, while the press edge was live -- reading it here (instead
-        // of calling isButtonPressed() directly) keeps every press read in
-        // this codebase on the frame clock, never the logic-step clock.
-        if (restartPressLatched_) {
-            restartPressLatched_ = false;
+        // request.
+        if (restartPressed) {
             lives_ = kStartingLives;
             startLevel();
         }

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -22,7 +22,8 @@ BombermanScene::BombermanScene()
       state_(LevelState::Loading),
       accumulatorMs_(0),
       seed_(0),
-      lives_(kStartingLives) {
+      lives_(kStartingLives),
+      bombPressLatched_(false) {
     addEntity(&renderer_);
     addEntity(&player_);
 }
@@ -51,6 +52,9 @@ void BombermanScene::startLevel() {
 
     player_.resetTo(kPlayerStartCellX, kPlayerStartCellY);
     accumulatorMs_ = 0;
+    // A press held across the death that triggered this restart must not
+    // drop a bomb on the fresh board's first step.
+    bombPressLatched_ = false;
 
     state_ = LevelState::Playing;
 
@@ -61,6 +65,12 @@ void BombermanScene::startLevel() {
 }
 
 void BombermanScene::update(unsigned long deltaTime) {
+    // Latch here, at frame scope, while the press edge is still live. The
+    // loop below may run no logic step at all this frame.
+    if (engine.getInputManager().isButtonPressed(BTN_BOMB)) {
+        bombPressLatched_ = true;
+    }
+
     accumulatorMs_ += deltaTime;
     int steps = 0;
     while (accumulatorMs_ >= static_cast<unsigned long>(kLogicStepMs) && steps < kMaxLogicStepsPerFrame) {
@@ -87,10 +97,14 @@ void BombermanScene::logicStep() {
 
     auto& input = engine.getInputManager();
 
-    // Input + player movement, including bomb placement (the player's own
-    // action, read inside PlayerActor::logicStep) and bomb-aware blocking
-    // (the own-bomb pass-through exemption).
-    player_.logicStep(board_, bombs_, input);
+    // Input + player movement, including bomb placement and bomb-aware
+    // blocking (the own-bomb pass-through exemption). Movement reads held
+    // buttons straight from the InputManager -- a level state is correct to
+    // sample per logic step. The bomb press is the latched frame edge
+    // instead, consumed exactly once here.
+    const bool bombPressed = bombPressLatched_;
+    bombPressLatched_ = false;
+    player_.logicStep(board_, bombs_, input, bombPressed);
 
     // Bomb fuses tick down, seeding this step's detonation queue with any
     // bomb whose fuse just reached zero.

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -19,11 +19,17 @@ BombermanScene::BombermanScene()
       hiddenPowerUp_(TileType::PowerUpFire),
       renderer_(board_, bombs_, blastSteps_),
       player_(kPlayerStartCellX, kPlayerStartCellY),
+      enemyCount_(0),
+      enemiesAlive_(0),
       state_(LevelState::Loading),
       accumulatorMs_(0),
       seed_(0),
       lives_(kStartingLives),
       bombPressLatched_(false) {
+    // enemies_ is default-initialized above (omitted here): every slot
+    // starts dead at (0,0) via EnemyActor's default constructor and is not
+    // registered with the scene until startLevel() decides how many of
+    // this level's slots actually play.
     addEntity(&renderer_);
     addEntity(&player_);
 }
@@ -36,6 +42,15 @@ void BombermanScene::init() {
 void BombermanScene::startLevel() {
     state_ = LevelState::Loading;
 
+    // Enemy count varies per generated level (BombermanBoard.cpp may spawn
+    // fewer than kEnemyCount if the map has too few eligible cells), so
+    // unlike the renderer/player, enemies are removed and re-added here
+    // rather than added once in the constructor. On the very first call
+    // (from init()), enemyCount_ is still 0 and this loop is a no-op.
+    for (int i = 0; i < enemyCount_; ++i) {
+        removeEntity(&enemies_[i]);
+    }
+
     seed_ = static_cast<uint32_t>(std::time(nullptr));
     const LevelLayout layout = generateLevel(seed_, kEnemyCount, kSoftWallPercent);
     for (int i = 0; i < kCells; ++i) {
@@ -46,11 +61,19 @@ void BombermanScene::startLevel() {
     for (int i = 0; i < kMaxBombs; ++i) {
         bombs_[i] = Bomb{};
     }
-    // layout.enemyCells / layout.enemyCount are already computed here, but
-    // this slice has no EnemyActor yet to place them in — wired in later
-    // work.
 
     player_.resetTo(kPlayerStartCellX, kPlayerStartCellY);
+
+    enemyCount_ = layout.enemyCount;
+    enemiesAlive_ = enemyCount_;
+    for (int i = 0; i < enemyCount_; ++i) {
+        const int cell = layout.enemyCells[i];
+        const int x = cell % kCols;
+        const int y = cell / kCols;
+        enemies_[i].resetTo(x, y);
+        addEntity(&enemies_[i]);
+    }
+
     accumulatorMs_ = 0;
     // A press held across the death that triggered this restart must not
     // drop a bomb on the fresh board's first step.
@@ -61,7 +84,7 @@ void BombermanScene::startLevel() {
     // Guardrail: catches an entity that was dropped or double-added.
     // Compiles out under NDEBUG (esp32dev release builds); the
     // static_assert in BombermanConstants.h is the half that always holds.
-    assert(entityCount == 2 && "An entity was dropped or double-added.");
+    assert(entityCount == 2 + enemyCount_ && "An entity was dropped or double-added.");
 }
 
 void BombermanScene::update(unsigned long deltaTime) {
@@ -80,56 +103,121 @@ void BombermanScene::update(unsigned long deltaTime) {
     }
     if (steps == kMaxLogicStepsPerFrame) {
         // Drop the backlog rather than let a long frame (SD flush, serial
-        // log) burst dozens of steps and teleport the player through a
-        // wall. deltaTime never reaches a rule function below this point.
+        // log) burst dozens of steps and teleport actors through a wall.
+        // deltaTime never reaches a rule function below this point.
         accumulatorMs_ = 0;
     }
 }
 
 void BombermanScene::logicStep() {
-    if (lives_ <= 0) {
-        // Every life is spent. A full game-over state with its own overlay
-        // is later work; this slice only needs "dying at zero lives does
-        // not restart", which freezing the simulation here satisfies
-        // without inventing that state early.
+    if (state_ == LevelState::StageClear || state_ == LevelState::GameOver) {
+        // Terminal state: freeze the simulation. Both end states stop the
+        // pipeline the same way; only how they were reached differs.
         return;
     }
 
     auto& input = engine.getInputManager();
 
-    // Input + player movement, including bomb placement and bomb-aware
-    // blocking (the own-bomb pass-through exemption). Movement reads held
-    // buttons straight from the InputManager -- a level state is correct to
-    // sample per logic step. The bomb press is the latched frame edge
-    // instead, consumed exactly once here.
+    // Stage 1+2: input + player movement, including bomb placement and
+    // bomb-aware blocking (the own-bomb pass-through exemption). Movement
+    // reads held buttons straight from the InputManager -- a level state is
+    // correct to sample per logic step. The bomb press is the latched
+    // frame edge instead, consumed exactly once here.
     const bool bombPressed = bombPressLatched_;
     bombPressLatched_ = false;
     player_.logicStep(board_, bombs_, input, bombPressed);
 
-    // Bomb fuses tick down, seeding this step's detonation queue with any
-    // bomb whose fuse just reached zero.
+    // Stage 3: enemy movement. Each alive enemy re-decides its own
+    // direction independently, straight-else-PRNG; see EnemyActor.cpp.
+    for (int i = 0; i < enemyCount_; ++i) {
+        if (enemies_[i].isAlive()) {
+            enemies_[i].logicStep(board_, bombs_);
+        }
+    }
+
+    // Stage 4: bomb fuses tick down, seeding this step's detonation queue
+    // with any bomb whose fuse just reached zero.
     uint8_t detonationQueue[kMaxBombs] = {};
     int queueTail = 0;
     tickFuses(bombs_, detonationQueue, queueTail);
 
-    // The queue — including any bomb a blast arm chain-triggers along the
-    // way — drains to a fixed point within this same call. See
+    // Stage 5: the queue -- including any bomb a blast arm chain-triggers
+    // along the way -- drains to a fixed point within this same call. See
     // resolveDetonations()'s termination comment for why that is
     // guaranteed to happen in at most kMaxBombs iterations.
     resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
 
-    // Explosion cells count down toward reverting to their
+    // Stage 6: explosion cells count down toward reverting to their
     // post-destruction tile.
     tickExplosions(blastSteps_);
 
-    // Instant elimination: the player's LOGICAL cell — never the
-    // interpolated visual position — is what every rule reads.
-    if (blastSteps_[cellIndex(player_.cellX(), player_.cellY())] > 0) {
-        handlePlayerDeath();
+    // Stage 7: power-up pickup. Reads the player's LOGICAL cell every step;
+    // idempotent once the tile is cleared to Empty on the same step it is
+    // applied, so re-checking a cell the player is simply standing on (no
+    // longer a power-up) is a correctly-shaped no-op.
+    const int playerCell = cellIndex(player_.cellX(), player_.cellY());
+    if (board_[playerCell] == TileType::PowerUpFire) {
+        player_.applyFirePowerUp();
+        board_[playerCell] = TileType::Empty;
+    } else if (board_[playerCell] == TileType::PowerUpBomb) {
+        player_.applyBombPowerUp();
+        board_[playerCell] = TileType::Empty;
     }
 
-    // The full nine-stage pipeline (enemies, power-ups, victory) is
-    // assembled incrementally in later work.
+    // Stage 8a: explosion contact against enemies. Checked before the
+    // player's own explosion contact so an enemy killed by the same blast
+    // that also kills the player is already gone by the time anything else
+    // looks at enemiesAlive_ this step.
+    for (int i = 0; i < enemyCount_; ++i) {
+        if (enemies_[i].isAlive() &&
+            blastSteps_[cellIndex(enemies_[i].cellX(), enemies_[i].cellY())] > 0) {
+            killEnemy(i);
+        }
+    }
+
+    // Stage 8b: explosion contact against the player. The player's own
+    // death always takes priority over anything stage 9 might otherwise
+    // conclude this same step -- returning here skips both the
+    // player-enemy contact check below and the victory check, since
+    // startLevel()/GameOver have already redefined what "this step" means.
+    if (blastSteps_[playerCell] > 0) {
+        handlePlayerDeath();
+        return;
+    }
+
+    // Stage 8c: player-enemy contact. Compares only the LOGICAL cells after
+    // BOTH movements have resolved this step (never the interpolated path
+    // between them), matching the update order's literal wording. A same-
+    // step SWAP -- the player and an enemy exchanging cells in one step --
+    // is therefore pass-through, not a collision: their post-movement cells
+    // differ, so this check never fires for it. This is a deliberate
+    // choice, not an oversight: a swept/segment check would need continuous
+    // collision math this example otherwise has no reason to carry.
+    for (int i = 0; i < enemyCount_; ++i) {
+        if (enemies_[i].isAlive() && enemies_[i].cellX() == player_.cellX() &&
+            enemies_[i].cellY() == player_.cellY()) {
+            handlePlayerDeath();
+            return;
+        }
+    }
+
+    // Stage 9: victory check. Both conditions are plain `if`s, not
+    // `else if` -- so the case where the LAST enemy dies (stage 8a, this
+    // same call) while the player is ALREADY standing on the revealed exit
+    // cell resolves straight through to StageClear in this very call,
+    // instead of requiring the player to step off and back onto the exit.
+    if (state_ == LevelState::Playing && enemiesAlive_ == 0) {
+        state_ = LevelState::ExitUnlocked;
+    }
+    if (state_ == LevelState::ExitUnlocked && board_[playerCell] == TileType::Exit) {
+        state_ = LevelState::StageClear;
+    }
+}
+
+void BombermanScene::killEnemy(int index) {
+    enemies_[index].kill();
+    removeEntity(&enemies_[index]);
+    --enemiesAlive_;
 }
 
 void BombermanScene::handlePlayerDeath() {
@@ -138,15 +226,15 @@ void BombermanScene::handlePlayerDeath() {
         // lives_ lives outside startLevel() entirely, so it carries the
         // decremented value over instead of resetting.
         startLevel();
+    } else {
+        state_ = LevelState::GameOver;
     }
-    // else: lives_ reached zero. logicStep()'s guard above freezes the
-    // simulation from the next call onward.
 }
 
 void BombermanScene::draw(gfx::Renderer& renderer) {
-    // BoardRenderer (layer 0) then PlayerActor (layer 1), in that order —
-    // Scene::draw() sorts by render layer. HUD text and overlays are
-    // later work.
+    // BoardRenderer (layer 0), then PlayerActor + live EnemyActors
+    // (layer 1) -- Scene::draw() sorts by render layer. HUD text and
+    // overlays are later work.
     Scene::draw(renderer);
 }
 

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -14,11 +14,15 @@ namespace core = pr32::core;
 
 BombermanScene::BombermanScene()
     : board_{},
-      renderer_(board_),
+      bombs_{},
+      blastSteps_{},
+      hiddenPowerUp_(TileType::PowerUpFire),
+      renderer_(board_, bombs_, blastSteps_),
       player_(kPlayerStartCellX, kPlayerStartCellY),
       state_(LevelState::Loading),
       accumulatorMs_(0),
-      seed_(0) {
+      seed_(0),
+      lives_(kStartingLives) {
     addEntity(&renderer_);
     addEntity(&player_);
 }
@@ -35,9 +39,15 @@ void BombermanScene::startLevel() {
     const LevelLayout layout = generateLevel(seed_, kEnemyCount, kSoftWallPercent);
     for (int i = 0; i < kCells; ++i) {
         board_[i] = layout.board[i];
+        blastSteps_[i] = 0;
+    }
+    hiddenPowerUp_ = layout.hiddenPowerUp;
+    for (int i = 0; i < kMaxBombs; ++i) {
+        bombs_[i] = Bomb{};
     }
     // layout.enemyCells / layout.enemyCount are already computed here, but
-    // this slice has no EnemyActor yet to place them in — wired in Phase 4.
+    // this slice has no EnemyActor yet to place them in — wired in later
+    // work.
 
     player_.resetTo(kPlayerStartCellX, kPlayerStartCellY);
     accumulatorMs_ = 0;
@@ -67,20 +77,62 @@ void BombermanScene::update(unsigned long deltaTime) {
 }
 
 void BombermanScene::logicStep() {
+    if (lives_ <= 0) {
+        // Every life is spent. A full game-over state with its own overlay
+        // is later work; this slice only needs "dying at zero lives does
+        // not restart", which freezing the simulation here satisfies
+        // without inventing that state early.
+        return;
+    }
+
     auto& input = engine.getInputManager();
 
-    // Stages 1 (input) + 2 (player movement): PlayerActor reads held input
-    // directly, since there is nothing else in this slice to arbitrate
-    // against. The full nine-stage pipeline (enemies, bombs, explosions,
-    // blocks, power-ups, collisions, victory) is assembled incrementally
-    // in later phases.
-    player_.logicStep(board_, input);
+    // Input + player movement, including bomb placement (the player's own
+    // action, read inside PlayerActor::logicStep) and bomb-aware blocking
+    // (the own-bomb pass-through exemption).
+    player_.logicStep(board_, bombs_, input);
+
+    // Bomb fuses tick down, seeding this step's detonation queue with any
+    // bomb whose fuse just reached zero.
+    uint8_t detonationQueue[kMaxBombs] = {};
+    int queueTail = 0;
+    tickFuses(bombs_, detonationQueue, queueTail);
+
+    // The queue — including any bomb a blast arm chain-triggers along the
+    // way — drains to a fixed point within this same call. See
+    // resolveDetonations()'s termination comment for why that is
+    // guaranteed to happen in at most kMaxBombs iterations.
+    resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
+
+    // Explosion cells count down toward reverting to their
+    // post-destruction tile.
+    tickExplosions(blastSteps_);
+
+    // Instant elimination: the player's LOGICAL cell — never the
+    // interpolated visual position — is what every rule reads.
+    if (blastSteps_[cellIndex(player_.cellX(), player_.cellY())] > 0) {
+        handlePlayerDeath();
+    }
+
+    // The full nine-stage pipeline (enemies, power-ups, victory) is
+    // assembled incrementally in later work.
+}
+
+void BombermanScene::handlePlayerDeath() {
+    --lives_;
+    if (lives_ > 0) {
+        // lives_ lives outside startLevel() entirely, so it carries the
+        // decremented value over instead of resetting.
+        startLevel();
+    }
+    // else: lives_ reached zero. logicStep()'s guard above freezes the
+    // simulation from the next call onward.
 }
 
 void BombermanScene::draw(gfx::Renderer& renderer) {
     // BoardRenderer (layer 0) then PlayerActor (layer 1), in that order —
-    // Scene::draw() sorts by render layer. HUD text and overlays are added
-    // in Phase 5.
+    // Scene::draw() sorts by render layer. HUD text and overlays are
+    // later work.
     Scene::draw(renderer);
 }
 

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -61,6 +61,16 @@ private:
     uint32_t seed_;
     int lives_;
 
+    /// Level countdown: seconds remaining plus how many logic steps have
+    /// elapsed into the current second. Both tick inside logicStep()'s
+    /// bomb/timer stage, on the fixed 20 ms clock -- never from
+    /// update()'s deltaTime -- so the countdown is exactly as reproducible
+    /// as every other timer in this game (fuses, explosion decay). Reaching
+    /// zero costs the player one life through handlePlayerDeath(), the same
+    /// funnel explosion and enemy contact already use.
+    uint16_t countdownSeconds_;
+    uint8_t countdownSubSteps_;
+
     /// Frame-scoped bomb press, latched for the fixed-step loop to consume.
     /// InputManager recomputes its press edge once per engine frame, but the
     /// accumulator below runs zero, one, or two logic steps in that same
@@ -72,6 +82,13 @@ private:
     /// neither lost on a zero-step frame nor acted on twice on a two-step
     /// one.
     bool bombPressLatched_;
+
+    /// Same latch pattern as bombPressLatched_ above, for the restart
+    /// button read during GameOver/StageClear. Both isButtonPressed() reads
+    /// in this codebase live in update(), at frame scope -- logicStep()
+    /// only ever consumes an already-latched bool, never the raw edge, so
+    /// the fixed-step clock never observes a press directly.
+    bool restartPressLatched_;
 
     /// (Re)generates the board, resets the bomb pool/explosion mask, resets
     /// the player, and redeploys enemies to match the freshly generated
@@ -87,12 +104,16 @@ private:
 
     /// The fixed nine-stage logic pipeline, driven by update()'s
     /// accumulator: (1) input, (2) player movement, (3) enemy movement,
-    /// (4) bomb fuse tick, (5) chain-reaction drain, (6) explosion decay,
-    /// (7) power-up pickup, (8) collision detection (explosion contact for
-    /// both enemies and the player, then player-enemy contact), (9) victory
-    /// check. A "cycle" in this codebase always means one fixed 20 ms logic
-    /// step (BombermanConstants.h's kLogicStepMs) -- never a rendered frame,
-    /// which runs at a different, variable rate.
+    /// (4) bomb fuse tick (the level countdown ticks in this same stage),
+    /// (5) chain-reaction drain, (6) explosion decay, (7) power-up pickup,
+    /// (8) collision detection (explosion contact for both enemies and the
+    /// player, then player-enemy contact), (9) victory check. A "cycle" in
+    /// this codebase always means one fixed 20 ms logic step
+    /// (BombermanConstants.h's kLogicStepMs) -- never a rendered frame,
+    /// which runs at a different, variable rate. While the level is in a
+    /// terminal state (StageClear/GameOver) this function only checks for a
+    /// latched restart press and otherwise returns immediately -- the nine
+    /// stages above never run against a frozen level.
     void logicStep();
 
     /// Removes an enemy from play: marks it dead, unregisters it from the

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -45,6 +45,18 @@ private:
     uint32_t seed_;
     int lives_;
 
+    /// Frame-scoped bomb press, latched for the fixed-step loop to consume.
+    /// InputManager recomputes its press edge once per engine frame, but the
+    /// accumulator below runs zero, one, or two logic steps in that same
+    /// frame. Reading the edge from inside a logic step therefore drops any
+    /// press that lands on a zero-step frame -- at a 20 ms step and a frame
+    /// faster than 50 Hz, that is a routine occurrence, not a rare one. The
+    /// latch is set where the edge is live (update(), frame scope) and
+    /// cleared by the first logic step that consumes it, so a press is
+    /// neither lost on a zero-step frame nor acted on twice on a two-step
+    /// one.
+    bool bombPressLatched_;
+
     /// (Re)generates the board, resets the bomb pool/explosion mask, and
     /// resets the player. Deliberately does NOT call the base Scene::init(),
     /// since Scene::resetState() clears every entity and this scene's

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -83,11 +83,17 @@ private:
     /// one.
     bool bombPressLatched_;
 
-    /// Same latch pattern as bombPressLatched_ above, for the restart
-    /// button read during GameOver/StageClear. Both isButtonPressed() reads
-    /// in this codebase live in update(), at frame scope -- logicStep()
-    /// only ever consumes an already-latched bool, never the raw edge, so
-    /// the fixed-step clock never observes a press directly.
+    /// Same latch pattern as bombPressLatched_ above, for the restart button
+    /// acted on during GameOver/StageClear. Both isButtonPressed() reads in
+    /// this codebase live in update(), at frame scope -- logicStep() only
+    /// ever consumes an already-latched bool, never the raw edge, so the
+    /// fixed-step clock never observes a press directly.
+    ///
+    /// Consumed on EVERY logic step, not only in the states that act on it.
+    /// A latch cleared only by the state that uses it is a latch that goes
+    /// stale: a press during normal play would stay armed for the rest of
+    /// the session and then fire on the first step after the game ended,
+    /// skipping the very state it was meant to be read in.
     bool restartPressLatched_;
 
     /// (Re)generates the board, resets the bomb pool/explosion mask, resets

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -7,20 +7,15 @@
 #include "BombermanBoard.h"
 #include "BombermanBombs.h"
 #include "BombermanConstants.h"
+#include "EnemyActor.h"
 #include "PlayerActor.h"
 
 namespace bomberman {
 
 /**
  * @class BombermanScene
- * @brief Scene shell: fixed-step drain, board init, player + bomb/chain
- *        logic, and lives/restart on explosion death.
- *
- * Enemy actors, the HUD, and the full five-state level enum (Loading,
- * Playing, ExitUnlocked, StageClear, GameOver) are assembled in later
- * work. This slice only needs Loading -> Playing, plus a simple frozen
- * state once lives run out, since nothing here yet needs the other three
- * states.
+ * @brief Scene shell: fixed-step drain, the full nine-stage logic pipeline,
+ *        board/bomb/enemy state, and the level lifecycle.
  */
 class BombermanScene : public pixelroot32::core::Scene {
 public:
@@ -31,7 +26,18 @@ public:
     void draw(pixelroot32::graphics::Renderer& renderer) override;
 
 private:
-    enum class LevelState : uint8_t { Loading, Playing };
+    /// Level lifecycle, five states. This is a PLAIN enum, not the engine's
+    /// generic per-class state-machine primitive, and that is deliberate:
+    /// every transition below is a condition checked in a fixed order once
+    /// per logic step (see logicStep()), not a per-state callback dispatched
+    /// by some external driver. A generic state-machine type would only be
+    /// buying a dispatch table this game barely uses -- exactly one state
+    /// (Loading) does any real one-time entry work, and that work is
+    /// already a single named function (startLevel()) called from exactly
+    /// two call sites. Before reaching for a state-machine primitive here,
+    /// re-derive that tradeoff from scratch; it does not hold for this
+    /// shape of update loop.
+    enum class LevelState : uint8_t { Loading, Playing, ExitUnlocked, StageClear, GameOver };
 
     TileType board_[kCells];
     Bomb bombs_[kMaxBombs];
@@ -39,6 +45,16 @@ private:
     TileType hiddenPowerUp_;
     BoardRenderer renderer_;
     PlayerActor player_;
+
+    /// Fixed pool of enemy slots, sized to kMaxEnemies (BombermanConstants.h)
+    /// and constructed once, here, never destroyed. Only the first
+    /// enemyCount_ slots are ever added to the scene or touched by
+    /// logicStep()/draw() for the CURRENT level; the rest sit unused and
+    /// unregistered, exactly like the entity guardrail's static_assert
+    /// assumes.
+    EnemyActor enemies_[kMaxEnemies];
+    int enemyCount_;    ///< Total enemies spawned this level (may be < kEnemyCount; see BombermanBoard.cpp step 6).
+    int enemiesAlive_;  ///< Live count; ExitUnlocked is entered the step this reaches 0.
 
     LevelState state_;
     unsigned long accumulatorMs_;
@@ -57,25 +73,37 @@ private:
     /// one.
     bool bombPressLatched_;
 
-    /// (Re)generates the board, resets the bomb pool/explosion mask, and
-    /// resets the player. Deliberately does NOT call the base Scene::init(),
-    /// since Scene::resetState() clears every entity and this scene's
-    /// entities are added once, in the constructor, and never re-added —
-    /// matching the snake/2048 examples. Deliberately does NOT touch
-    /// `lives_`: that field lives outside this function entirely so a
-    /// death-with-lives-remaining restart carries the decremented value
-    /// over instead of resetting it.
+    /// (Re)generates the board, resets the bomb pool/explosion mask, resets
+    /// the player, and redeploys enemies to match the freshly generated
+    /// layout's (possibly different) enemy count. Deliberately does NOT
+    /// call the base Scene::init(), since Scene::resetState() clears every
+    /// entity and the renderer/player are added once, in the constructor,
+    /// and never re-added. Enemies ARE removed and re-added here, because
+    /// their count varies per generated level, unlike the renderer/player.
+    /// Deliberately does NOT touch `lives_`: that field lives outside this
+    /// function entirely so a death-with-lives-remaining restart carries
+    /// the decremented value over instead of resetting it.
     void startLevel();
 
-    /// The fixed-step logic pipeline, driven by update()'s accumulator:
-    /// player input/movement/placement, bomb fuse tick, chain-reaction
-    /// drain, explosion decay, then explosion-contact death. Enemy
-    /// movement, power-ups, and victory are added in later work.
+    /// The fixed nine-stage logic pipeline, driven by update()'s
+    /// accumulator: (1) input, (2) player movement, (3) enemy movement,
+    /// (4) bomb fuse tick, (5) chain-reaction drain, (6) explosion decay,
+    /// (7) power-up pickup, (8) collision detection (explosion contact for
+    /// both enemies and the player, then player-enemy contact), (9) victory
+    /// check. A "cycle" in this codebase always means one fixed 20 ms logic
+    /// step (BombermanConstants.h's kLogicStepMs) -- never a rendered frame,
+    /// which runs at a different, variable rate.
     void logicStep();
 
-    /// One life lost to an explosion. Restarts the level if lives remain;
-    /// otherwise leaves the board frozen — logicStep()'s own guard stops
-    /// processing once lives_ reaches zero.
+    /// Removes an enemy from play: marks it dead, unregisters it from the
+    /// scene's entity list (so it stops drawing and stops being iterated by
+    /// future logic steps), and decrements the live count that
+    /// exit-gating/victory reads.
+    void killEnemy(int index);
+
+    /// One life lost to an explosion or an enemy. Restarts the level if
+    /// lives remain (decremented value carried over); otherwise enters
+    /// GameOver, which logicStep()'s own top-of-function guard freezes.
     void handlePlayerDeath();
 };
 

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -5,6 +5,7 @@
 #include "platforms/EngineConfig.h"
 #include "BoardRenderer.h"
 #include "BombermanBoard.h"
+#include "BombermanBombs.h"
 #include "BombermanConstants.h"
 #include "PlayerActor.h"
 
@@ -12,12 +13,14 @@ namespace bomberman {
 
 /**
  * @class BombermanScene
- * @brief Scene shell: fixed-step drain, board init, and player spawn.
+ * @brief Scene shell: fixed-step drain, board init, player + bomb/chain
+ *        logic, and lives/restart on explosion death.
  *
- * The bomb pool, explosion resolution, enemy actors, HUD, and the full
- * five-state level enum (Loading, Playing, ExitUnlocked, StageClear,
- * GameOver) are assembled in later phases. This slice only needs
- * Loading -> Playing, since nothing yet transitions past Playing.
+ * Enemy actors, the HUD, and the full five-state level enum (Loading,
+ * Playing, ExitUnlocked, StageClear, GameOver) are assembled in later
+ * work. This slice only needs Loading -> Playing, plus a simple frozen
+ * state once lives run out, since nothing here yet needs the other three
+ * states.
  */
 class BombermanScene : public pixelroot32::core::Scene {
 public:
@@ -31,23 +34,37 @@ private:
     enum class LevelState : uint8_t { Loading, Playing };
 
     TileType board_[kCells];
+    Bomb bombs_[kMaxBombs];
+    uint8_t blastSteps_[kCells];
+    TileType hiddenPowerUp_;
     BoardRenderer renderer_;
     PlayerActor player_;
 
     LevelState state_;
     unsigned long accumulatorMs_;
     uint32_t seed_;
+    int lives_;
 
-    /// (Re)generates the board and resets the player. Deliberately does
-    /// NOT call the base Scene::init(), since Scene::resetState() clears
-    /// every entity and this scene's entities are added once, in the
-    /// constructor, and never re-added — matching the snake/2048 examples.
+    /// (Re)generates the board, resets the bomb pool/explosion mask, and
+    /// resets the player. Deliberately does NOT call the base Scene::init(),
+    /// since Scene::resetState() clears every entity and this scene's
+    /// entities are added once, in the constructor, and never re-added —
+    /// matching the snake/2048 examples. Deliberately does NOT touch
+    /// `lives_`: that field lives outside this function entirely so a
+    /// death-with-lives-remaining restart carries the decremented value
+    /// over instead of resetting it.
     void startLevel();
 
-    /// The fixed-step logic pipeline, driven by update()'s accumulator.
-    /// Only player movement exists at this phase; bombs, explosions,
-    /// enemies, collisions, and victory are added in later phases.
+    /// The fixed-step logic pipeline, driven by update()'s accumulator:
+    /// player input/movement/placement, bomb fuse tick, chain-reaction
+    /// drain, explosion decay, then explosion-contact death. Enemy
+    /// movement, power-ups, and victory are added in later work.
     void logicStep();
+
+    /// One life lost to an explosion. Restarts the level if lives remain;
+    /// otherwise leaves the board frozen — logicStep()'s own guard stops
+    /// processing once lives_ reaches zero.
+    void handlePlayerDeath();
 };
 
 }  // namespace bomberman

--- a/examples/bomberman/src/EnemyActor.cpp
+++ b/examples/bomberman/src/EnemyActor.cpp
@@ -1,0 +1,152 @@
+#include "EnemyActor.h"
+#include "math/MathUtil.h"
+#include "math/Vector2.h"
+
+namespace pr32 = pixelroot32;
+
+namespace bomberman {
+
+namespace gfx = pr32::graphics;
+namespace core = pr32::core;
+namespace math = pr32::math;
+
+namespace {
+constexpr int kDirX[4] = {0, 0, -1, 1};   // Up, Down, Left, Right
+constexpr int kDirY[4] = {-1, 1, 0, 0};
+}  // namespace
+
+EnemyActor::EnemyActor(int startCellX, int startCellY)
+    : core::Actor(gameplay::cellToWorld(startCellX, startCellY, kBoardGrid), kCellSize, kCellSize) {
+    resetTo(startCellX, startCellY);
+}
+
+void EnemyActor::logicStep(const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs]) {
+    // Duplicated advance loop, deliberately -- see the class doc comment in
+    // EnemyActor.h and PlayerActor::logicStep()'s own doc comment for why
+    // this is not collapsed into one shared function with the player's.
+    if (!alive_) {
+        return;
+    }
+
+    if (mv.progress > 0) {
+        // A step is already in flight: finish it. Direction is never
+        // re-decided in here -- only at the instant a step completes, below.
+        ++mv.progress;
+        if (mv.progress >= kEnemyStepsPerCell) {
+            mv.cellX = mv.toX;
+            mv.cellY = mv.toY;
+            mv.progress = 0;
+        }
+        updateInterpolatedPosition();
+        return;
+    }
+
+    // At rest: this is "on arrival" for every call after the first, and the
+    // initial direction draw for the very first call after spawn (dirX_ ==
+    // dirY_ == 0 makes the straight-ahead check below fail, so the first
+    // decision always falls through to the PRNG draw).
+    if (dirX_ != 0 || dirY_ != 0) {
+        const int sx = mv.cellX + dirX_;
+        const int sy = mv.cellY + dirY_;
+        if (canEnter(sx, sy, board, bombs)) {
+            mv.toX = sx;
+            mv.toY = sy;
+            mv.progress = 1;
+            updateInterpolatedPosition();
+            return;
+        }
+    }
+
+    // Blocked (or no direction committed yet): collect every currently
+    // enterable direction and draw one, uniformly, from the seeded PRNG.
+    // Reverse is included on purpose -- excluding it would deadlock an
+    // enemy in a dead-end corridor, which this board's corridor lattice
+    // produces routinely.
+    int valid[4];
+    int validCount = 0;
+    for (int i = 0; i < 4; ++i) {
+        const int nx = mv.cellX + kDirX[i];
+        const int ny = mv.cellY + kDirY[i];
+        if (canEnter(nx, ny, board, bombs)) {
+            valid[validCount++] = i;
+        }
+    }
+
+    if (validCount == 0) {
+        // Fully boxed in (walls/bombs on all four sides): stand still and
+        // re-evaluate next step. Not an error, not a crash.
+        dirX_ = 0;
+        dirY_ = 0;
+        updateInterpolatedPosition();
+        return;
+    }
+
+    const int32_t picked = math::rand_int(0, validCount - 1);
+    const int dir = valid[picked];
+    dirX_ = kDirX[dir];
+    dirY_ = kDirY[dir];
+    mv.toX = mv.cellX + dirX_;
+    mv.toY = mv.cellY + dirY_;
+    mv.progress = 1;
+    updateInterpolatedPosition();
+}
+
+bool EnemyActor::canEnter(int nx, int ny, const TileType (&board)[kCells],
+                            const Bomb (&bombs)[kMaxBombs]) const {
+    if (!gameplay::containsCell(nx, ny, kBoardGrid)) {
+        return false;
+    }
+    const TileType t = board[cellIndex(nx, ny)];
+    if (t == TileType::HardWall || isSoftWall(t)) {
+        return false;
+    }
+    // No exemption of any kind -- every bomb is solid to an enemy.
+    return !bombAt(bombs, nx, ny);
+}
+
+void EnemyActor::updateInterpolatedPosition() {
+    const int fromPx = gameplay::cellToWorldX(mv.cellX, kBoardGrid);
+    const int fromPy = gameplay::cellToWorldY(mv.cellY, kBoardGrid);
+    const int toPx = gameplay::cellToWorldX(mv.toX, kBoardGrid);
+    const int toPy = gameplay::cellToWorldY(mv.toY, kBoardGrid);
+    const int x = fromPx + (toPx - fromPx) * mv.progress / kEnemyStepsPerCell;
+    const int y = fromPy + (toPy - fromPy) * mv.progress / kEnemyStepsPerCell;
+    position = math::Vector2(x, y);
+}
+
+void EnemyActor::draw(gfx::Renderer& renderer) {
+    if (!alive_) {
+        return;
+    }
+    const int x = static_cast<int>(position.x);
+    const int y = static_cast<int>(position.y);
+    const int cx = x + kCellSize / 2;
+    const int cy = y + kCellSize / 2;
+    renderer.drawFilledCircle(cx, cy, 6, gfx::Color::Magenta);
+    renderer.drawFilledCircle(cx - 2, cy - 1, 1, gfx::Color::White);
+    renderer.drawFilledCircle(cx + 2, cy - 1, 1, gfx::Color::White);
+}
+
+core::Rect EnemyActor::getHitBox() {
+    return {position, width, height};
+}
+
+void EnemyActor::onCollision(core::Actor* other) {
+    // Physics is off in this example; movement/collision is resolved by
+    // board lookups (canEnter()) and BombermanScene's own logical-cell
+    // checks, so the engine never calls this. Implemented only because
+    // Actor::onCollision is pure virtual.
+    (void)other;
+}
+
+void EnemyActor::resetTo(int startCellX, int startCellY) {
+    mv.cellX = mv.toX = startCellX;
+    mv.cellY = mv.toY = startCellY;
+    mv.progress = 0;
+    dirX_ = 0;
+    dirY_ = 0;
+    alive_ = true;
+    updateInterpolatedPosition();
+}
+
+}  // namespace bomberman

--- a/examples/bomberman/src/EnemyActor.h
+++ b/examples/bomberman/src/EnemyActor.h
@@ -1,0 +1,81 @@
+#pragma once
+#include "core/Actor.h"
+#include "graphics/Renderer.h"
+#include "BombermanBoard.h"
+#include "BombermanBombs.h"
+#include "BombermanConstants.h"
+#include "GridMove.h"
+
+namespace bomberman {
+
+/**
+ * @class EnemyActor
+ * @brief Interpolated grid movement driven by a straight-else-PRNG AI: keep
+ *        going in the current direction while it stays enterable, otherwise
+ *        pick a new one from whatever is currently open.
+ *
+ * logicStep() is called once per fixed logic step from
+ * BombermanScene::logicStep(), same as PlayerActor::logicStep(). This class
+ * has no pointer, reference, or field naming the player anywhere -- the AI
+ * below reads only the board and the bomb pool, never player state.
+ *
+ * Deliberately does NOT share an advance loop with PlayerActor even though
+ * both embed a GridMove and both interpolate the same way: the two differ
+ * in blocking policy (the player stays put when blocked; this actor
+ * re-picks a direction), in direction source (held input vs. seeded PRNG),
+ * and the player's own-bomb pass-through exemption has no counterpart here
+ * -- an enemy treats every bomb as solid, with no exception. Collapsing the
+ * two loops early would remove the very comparison this example exists to
+ * produce.
+ */
+class EnemyActor : public pixelroot32::core::Actor {
+public:
+    /// Default-constructs at cell (0,0), dead. Exists only so
+    /// BombermanScene's fixed `EnemyActor enemies_[kMaxEnemies]` pool
+    /// array-initializes without a per-slot argument list; every slot that
+    /// is actually going to play gets a real resetTo() from
+    /// BombermanScene::startLevel() before it is added to the scene.
+    EnemyActor() : EnemyActor(0, 0) { alive_ = false; }
+    EnemyActor(int startCellX, int startCellY);
+
+    /// Advances interpolation and, only at the instant a step completes
+    /// (never mid-step), re-decides direction: continue straight if the
+    /// current direction is still enterable, else draw one seeded PRNG
+    /// value over whatever directions currently ARE enterable, else stand
+    /// still if none are (fully boxed in).
+    void logicStep(const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs]);
+
+    void draw(pixelroot32::graphics::Renderer& renderer) override;
+    pixelroot32::core::Rect getHitBox() override;
+    void onCollision(pixelroot32::core::Actor* other) override;
+
+    int cellX() const { return mv.cellX; }
+    int cellY() const { return mv.cellY; }
+    bool isAlive() const { return alive_; }
+
+    /// Puts the enemy at rest in a fresh cell, alive, with no committed
+    /// direction yet (the first logicStep() call after this draws the
+    /// initial direction from the same seeded PRNG as any later redecision).
+    void resetTo(int startCellX, int startCellY);
+
+    /// Marks the enemy dead. Movement and collision checks skip a dead
+    /// enemy; BombermanScene also removes it from the scene's entity list
+    /// so it stops drawing, which is the only other thing a dead enemy
+    /// could still do.
+    void kill() { alive_ = false; }
+
+private:
+    GridMove mv;
+    int dirX_ = 0;
+    int dirY_ = 0;
+    bool alive_ = true;
+
+    /// Board + bomb-pool blocking check only -- no exemption of any kind,
+    /// unlike PlayerActor::canEnter(). An enemy treats every bomb as a
+    /// solid obstacle, including one it could theoretically have "just
+    /// left", because enemies never place bombs.
+    bool canEnter(int nx, int ny, const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs]) const;
+    void updateInterpolatedPosition();
+};
+
+}  // namespace bomberman

--- a/examples/bomberman/src/PlayerActor.cpp
+++ b/examples/bomberman/src/PlayerActor.cpp
@@ -15,7 +15,7 @@ PlayerActor::PlayerActor(int startCellX, int startCellY)
     resetTo(startCellX, startCellY);
 }
 
-void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+bool PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
                              const input::InputManager& inputManager, bool bombPressed) {
     // This advance loop is a deliberate, near-duplicate of
     // EnemyActor::logicStep()'s. They are not merged into one shared
@@ -39,8 +39,9 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
     // this function runs on the fixed logic step, which is a different
     // clock. Held movement below is a level state, so sampling it per step
     // is correct as-is.
+    bool bombPlaced = false;
     if (bombPressed) {
-        tryPlaceBomb(bombs);
+        bombPlaced = tryPlaceBomb(bombs);
     }
 
     if (mv.progress > 0) {
@@ -63,7 +64,7 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
             }
         }
         updateInterpolatedPosition();
-        return;
+        return bombPlaced;
     }
 
     // At rest: held input may start a new step. Fixed priority
@@ -95,6 +96,7 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
     }
 
     updateInterpolatedPosition();
+    return bombPlaced;
 }
 
 bool PlayerActor::canEnter(int nx, int ny, const TileType (&board)[kCells],

--- a/examples/bomberman/src/PlayerActor.cpp
+++ b/examples/bomberman/src/PlayerActor.cpp
@@ -17,6 +17,16 @@ PlayerActor::PlayerActor(int startCellX, int startCellY)
 
 void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
                              const input::InputManager& inputManager, bool bombPressed) {
+    // This advance loop is a deliberate, near-duplicate of
+    // EnemyActor::logicStep()'s. They are not merged into one shared
+    // controller: this one stays put when blocked and reads held input,
+    // while the enemy's re-picks a direction and reads the seeded PRNG, and
+    // only this one has the own-bomb pass-through exemption below. Sharing
+    // just the five-field GridMove struct is the entire real overlap; a
+    // controller that also owned blocking policy or the arrival callback
+    // would need three behaviour hooks to configure it back into these two
+    // shapes, which is worse than the loop it would replace.
+
     // Bomb placement is handled first, before movement advances below. That
     // guarantees a bomb dropped this step always lands in the cell that
     // was logical at the START of this call, even on a call where movement

--- a/examples/bomberman/src/PlayerActor.cpp
+++ b/examples/bomberman/src/PlayerActor.cpp
@@ -16,14 +16,20 @@ PlayerActor::PlayerActor(int startCellX, int startCellY)
 }
 
 void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
-                             const input::InputManager& inputManager) {
-    // Bomb placement is read first, before movement advances below. That
+                             const input::InputManager& inputManager, bool bombPressed) {
+    // Bomb placement is handled first, before movement advances below. That
     // guarantees a bomb dropped this step always lands in the cell that
     // was logical at the START of this call, even on a call where movement
     // also happens to complete an in-flight step — "placement uses the
     // FROM-cell" stays true by construction instead of depending on
     // statement order elsewhere.
-    if (inputManager.isButtonPressed(BTN_BOMB)) {
+    //
+    // `bombPressed` arrives already latched by the caller rather than being
+    // read from inputManager here: the press edge is a frame-scoped fact and
+    // this function runs on the fixed logic step, which is a different
+    // clock. Held movement below is a level state, so sampling it per step
+    // is correct as-is.
+    if (bombPressed) {
         tryPlaceBomb(bombs);
     }
 

--- a/examples/bomberman/src/PlayerActor.cpp
+++ b/examples/bomberman/src/PlayerActor.cpp
@@ -15,17 +15,36 @@ PlayerActor::PlayerActor(int startCellX, int startCellY)
     resetTo(startCellX, startCellY);
 }
 
-void PlayerActor::logicStep(const TileType (&board)[kCells], const input::InputManager& inputManager) {
+void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+                             const input::InputManager& inputManager) {
+    // Bomb placement is read first, before movement advances below. That
+    // guarantees a bomb dropped this step always lands in the cell that
+    // was logical at the START of this call, even on a call where movement
+    // also happens to complete an in-flight step — "placement uses the
+    // FROM-cell" stays true by construction instead of depending on
+    // statement order elsewhere.
+    if (inputManager.isButtonPressed(BTN_BOMB)) {
+        tryPlaceBomb(bombs);
+    }
+
     if (mv.progress > 0) {
-        // A step is already in flight: finish it, ignore input this step.
+        // A step is already in flight: finish it, ignore movement input
+        // this step.
         ++mv.progress;
         if (mv.progress >= kPlayerStepsPerCell) {
             // The LOGICAL cell flips here, and only here.
             mv.cellX = mv.toX;
             mv.cellY = mv.toY;
             mv.progress = 0;
-            // onArrive() hook point: nothing to do yet in this slice. Phase
-            // 3 clears the bomb pass-through exemption here.
+
+            // onArrive(): the own-bomb exemption is valid only while it
+            // names the player's current logical cell. Leaving the bombed
+            // cell makes that bomb solid again from this instant. A no-op
+            // if no exemption is active, or if the arrival cell still
+            // matches it.
+            if (exemptValid_ && (mv.cellX != exemptX_ || mv.cellY != exemptY_)) {
+                exemptValid_ = false;
+            }
         }
         updateInterpolatedPosition();
         return;
@@ -50,7 +69,7 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], const input::InputM
     if (dx != 0 || dy != 0) {
         const int nx = mv.cellX + dx;
         const int ny = mv.cellY + dy;
-        if (canEnter(nx, ny, board)) {
+        if (canEnter(nx, ny, board, bombs)) {
             mv.toX = nx;
             mv.toY = ny;
             mv.progress = 1;
@@ -62,14 +81,39 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], const input::InputM
     updateInterpolatedPosition();
 }
 
-bool PlayerActor::canEnter(int nx, int ny, const TileType (&board)[kCells]) const {
+bool PlayerActor::canEnter(int nx, int ny, const TileType (&board)[kCells],
+                            const Bomb (&bombs)[kMaxBombs]) const {
     if (!gameplay::containsCell(nx, ny, kBoardGrid)) {
         return false;
     }
     const TileType t = board[cellIndex(nx, ny)];
-    // Bomb blocking and the own-bomb pass-through exemption are added in
-    // Phase 3 (3.3); this phase only ever has board tiles to consult.
-    return t != TileType::HardWall && !isSoftWall(t);
+    if (t == TileType::HardWall || isSoftWall(t)) {
+        return false;
+    }
+    if (bombAt(bombs, nx, ny)) {
+        // A bomb blocks unless it is the one cell the player is currently
+        // exempt from. The exemption clears the instant the player's
+        // logical cell changes (see onArrive() above), so this can only
+        // ever admit the cell the player is standing on right now, never a
+        // bomb anywhere else.
+        return exemptValid_ && nx == exemptX_ && ny == exemptY_;
+    }
+    return true;
+}
+
+bool PlayerActor::tryPlaceBomb(Bomb (&bombs)[kMaxBombs]) {
+    if (activeBombCount(bombs) >= maxBombs_) {
+        return false;
+    }
+    if (!placeBomb(bombs, mv.cellX, mv.cellY, firePower_)) {
+        return false;
+    }
+    // The bomb was just written into (mv.cellX, mv.cellY) above; exempt
+    // that same cell so the two can never disagree.
+    exemptValid_ = true;
+    exemptX_ = mv.cellX;
+    exemptY_ = mv.cellY;
+    return true;
 }
 
 void PlayerActor::updateInterpolatedPosition() {
@@ -108,6 +152,9 @@ void PlayerActor::resetTo(int startCellX, int startCellY) {
     mv.cellX = mv.toX = startCellX;
     mv.cellY = mv.toY = startCellY;
     mv.progress = 0;
+    exemptValid_ = false;
+    exemptX_ = 0;
+    exemptY_ = 0;
     updateInterpolatedPosition();
 }
 

--- a/examples/bomberman/src/PlayerActor.h
+++ b/examples/bomberman/src/PlayerActor.h
@@ -3,6 +3,7 @@
 #include "graphics/Renderer.h"
 #include "input/InputManager.h"
 #include "BombermanBoard.h"
+#include "BombermanBombs.h"
 #include "BombermanConstants.h"
 #include "GridMove.h"
 
@@ -10,7 +11,8 @@ namespace bomberman {
 
 /**
  * @class PlayerActor
- * @brief Interpolated grid movement driven by held input.
+ * @brief Interpolated grid movement driven by held input, bomb placement,
+ *        and the own-bomb pass-through exemption.
  *
  * logicStep() is called once per fixed logic step from
  * BombermanScene::logicStep() — never from Entity::update(unsigned long),
@@ -21,19 +23,20 @@ namespace bomberman {
  * both embed a GridMove and both interpolate the same way: the two differ
  * in blocking policy (the player stays put when blocked; the enemy
  * re-picks a direction), in direction source (held input vs. seeded PRNG),
- * and — from Phase 3 on — in the pass-through exemption, which is
- * player-only. Collapsing the two loops early would remove the very
- * comparison this example exists to produce.
+ * and in the pass-through exemption below, which is player-only.
+ * Collapsing the two loops early would remove the very comparison this
+ * example exists to produce.
  */
 class PlayerActor : public pixelroot32::core::Actor {
 public:
     PlayerActor(int startCellX, int startCellY);
 
-    /// Advances interpolation and, when at rest, starts a new step toward
-    /// a held direction if the target cell is enterable. Board-only
-    /// blocking at this phase; bomb blocking and the own-bomb pass-through
-    /// exemption are added in Phase 3.
-    void logicStep(const TileType (&board)[kCells], const pixelroot32::input::InputManager& input);
+    /// Reads bomb-placement input, then advances interpolation and, when
+    /// at rest, starts a new step toward a held direction if the target
+    /// cell is enterable (board tiles and bombs, minus the own-bomb
+    /// pass-through exemption).
+    void logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+                   const pixelroot32::input::InputManager& input);
 
     void draw(pixelroot32::graphics::Renderer& renderer) override;
     pixelroot32::core::Rect getHitBox() override;
@@ -41,15 +44,47 @@ public:
 
     int cellX() const { return mv.cellX; }
     int cellY() const { return mv.cellY; }
+    int firePower() const { return firePower_; }
+    int maxBombs() const { return maxBombs_; }
 
-    /// Puts the player at rest in a fresh cell (level restart).
+    /// Puts the player at rest in a fresh cell (level restart). Also
+    /// clears the own-bomb exemption, since a fresh level has no bombs.
     void resetTo(int startCellX, int startCellY);
 
 private:
     GridMove mv;
+    int firePower_ = kDefaultFirePower;
+    int maxBombs_ = kDefaultMaxBombs;
 
-    bool canEnter(int nx, int ny, const TileType (&board)[kCells]) const;
+    // Own-bomb pass-through: the one bomb-occupied cell that does NOT
+    // block the player, valid only while it names the player's current
+    // logical cell. Three rules, no fourth:
+    //   1. Placing a bomb sets this to the player's logical cell
+    //      (tryPlaceBomb()).
+    //   2. canEnter() lets a bomb-occupied target through only if it
+    //      equals this cell.
+    //   3. The instant the logical cell changes (onArrive, inside
+    //      logicStep()), this clears unless the arrival cell still
+    //      matches it.
+    // The logical cell changes at exactly one instant (step completion),
+    // so there is no window where this is half-valid: mid-interpolation,
+    // the logical cell is still the FROM-cell, and input toward a new step
+    // is ignored anyway while a step is in flight.
+    bool exemptValid_ = false;
+    int exemptX_ = 0;
+    int exemptY_ = 0;
+
+    bool canEnter(int nx, int ny, const TileType (&board)[kCells], const Bomb (&bombs)[kMaxBombs]) const;
     void updateInterpolatedPosition();
+
+    /// Attempts to place a bomb in the player's current logical cell
+    /// (mv.cellX, mv.cellY — the FROM-cell if a step is mid-flight, since
+    /// that value never changes outside onArrive()). Delegates the pool
+    /// write to placeBomb() and, on success, sets the exemption using the
+    /// SAME cell just written, so the two can never disagree. No-op,
+    /// returns false, if the player is already at their own max-bombs
+    /// limit or the pool write itself fails.
+    bool tryPlaceBomb(Bomb (&bombs)[kMaxBombs]);
 };
 
 }  // namespace bomberman

--- a/examples/bomberman/src/PlayerActor.h
+++ b/examples/bomberman/src/PlayerActor.h
@@ -41,7 +41,12 @@ public:
     /// runs on the fixed logic step -- the caller latches the edge across
     /// that gap. Held direction is a level state and is read from `input`
     /// directly, which is correct to sample per step.
-    void logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+    ///
+    /// Returns true iff a bomb was actually placed this call (the press was
+    /// latched AND the pool/limit checks in tryPlaceBomb() both passed) --
+    /// the caller uses this to fire the bomb-placed audio event exactly once
+    /// per successful placement, never on a press that was rejected.
+    bool logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
                    const pixelroot32::input::InputManager& input, bool bombPressed);
 
     void draw(pixelroot32::graphics::Renderer& renderer) override;

--- a/examples/bomberman/src/PlayerActor.h
+++ b/examples/bomberman/src/PlayerActor.h
@@ -31,12 +31,18 @@ class PlayerActor : public pixelroot32::core::Actor {
 public:
     PlayerActor(int startCellX, int startCellY);
 
-    /// Reads bomb-placement input, then advances interpolation and, when
+    /// Places a bomb if `bombPressed`, then advances interpolation and, when
     /// at rest, starts a new step toward a held direction if the target
     /// cell is enterable (board tiles and bombs, minus the own-bomb
     /// pass-through exemption).
+    ///
+    /// `bombPressed` is passed in rather than read from `input` because a
+    /// press edge belongs to the frame that produced it, while this function
+    /// runs on the fixed logic step -- the caller latches the edge across
+    /// that gap. Held direction is a level state and is read from `input`
+    /// directly, which is correct to sample per step.
     void logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
-                   const pixelroot32::input::InputManager& input);
+                   const pixelroot32::input::InputManager& input, bool bombPressed);
 
     void draw(pixelroot32::graphics::Renderer& renderer) override;
     pixelroot32::core::Rect getHitBox() override;

--- a/examples/bomberman/src/PlayerActor.h
+++ b/examples/bomberman/src/PlayerActor.h
@@ -53,6 +53,15 @@ public:
     int firePower() const { return firePower_; }
     int maxBombs() const { return maxBombs_; }
 
+    /// Applies a Fire power-up: increases the blast arm length by the fixed
+    /// increment. Takes effect on the NEXT bomb placed -- an already-placed
+    /// bomb keeps the range it snapshotted at placement (see BombermanBombs.h).
+    void applyFirePowerUp() { firePower_ += kFirePowerIncrement; }
+
+    /// Applies a Bomb power-up: increases the simultaneous-bomb limit by
+    /// one.
+    void applyBombPowerUp() { ++maxBombs_; }
+
     /// Puts the player at rest in a fresh cell (level restart). Also
     /// clears the own-bomb exemption, since a fresh level has no bombs.
     void resetTo(int startCellX, int startCellY);


### PR DESCRIPTION
Second of four slices. Ends **playable**: place bombs, watch chains propagate, destroy soft walls, and die to your own blast.

## Review this first

`examples/bomberman/src/BombermanBombs.cpp` — the chain-reaction drain. Its termination argument is the one claim in this PR worth checking rather than trusting.

## Chain context

```
feature/top-down-games
  └── 01-board-movement            — board + movement
        └── 📍 02-bombs-chains     (this PR) — bombs, fuses, chain reactions
              └── 03-enemies-winlose   — enemies, exit gating, win/lose
                    └── 04-hud-audio-docs — HUD, countdown, audio, README
```

Targets `bomberman/01-board-movement`. The diff shown here is this slice only.

## The chain loop terminates, and here is why

A pool slot enters the detonation queue in exactly two places — the fuse-expiry check in `tickFuses()` and the chain-trigger branch in `paintArm()`. Both require `active == true` and set `active = false` **in the same statement that enqueues**. Nothing reactivates a slot during a drain, so each of the 8 slots enters the queue at most once per call.

`tail` therefore never exceeds `kMaxBombs`, and the loop runs at most 8 iterations for any bomb topology, including a ring of 8 all triggering each other.

Both write sites also bound `tail < kMaxBombs` **at the write site**, not by trusting the caller.

## The own-bomb rule

You can walk off the cell you just bombed; you can never walk back onto it. This is the classic bug in the genre in both directions — trapped on your own bomb, or phasing through every bomb on the board.

The exemption names a single cell, is set in the same function that writes the bomb, and clears the instant the player's *logical* cell changes. A stale exemption is harmless by construction: it only ever gates the "there is a bomb here" branch, so once the bomb is gone it decides nothing.

## Fix included: a lost bomb press

`Engine::update()` calls `inputManager.update()` — which resets `stateChanged[]` — once per frame, then runs the scene. This scene drives a 20 ms fixed-step accumulator that executes **zero, one, or two** logic steps in that frame.

Reading `isButtonPressed()` from inside a logic step therefore consumed a frame-scoped edge on a different clock: a press landing on a zero-step frame was destroyed by the next `inputManager.update()` with no step ever having seen it. At 60 fps that is roughly **one press in six** — a "sometimes the bomb doesn't come out" bug that is very hard to reproduce deliberately.

The edge is now latched in `update()`, where it is live, and consumed by the first logic step. `PlayerActor::logicStep` takes the latched flag instead of reading the press itself; held direction still comes straight from the `InputManager`, since a level state is correct to sample per step.

Worth noting for reviewers of the other slices: **a headless test cannot reach this.** It has no frames and no `InputManager`.

## Verification

- `pio run -e native` — SUCCESS, zero warnings from any bomberman file.
- `pio run -e esp32dev` — SUCCESS. RAM 24056 B (7.3%), Flash 338589 B (25.8%).
- Chain logic checked against the real code: pool-full and same-cell rejection, arms stopping at hard and soft walls, two- and three-bomb same-cycle chains, and a ring of 8 confirming every slot detonates exactly once.
- Placing bombs, chaining them and dying to a blast confirmed by hand.

## Deliberately not in this slice

Enemies, player-enemy contact, exit, power-up pickup, the full level state enum, HUD, audio.

## Review budget

```
9 files, +531 / -52  ->  583 changed lines
```

Over the 400-line guideline, declared rather than split further: the slice boundary is "ends playable", and bombs without chain reactions is not a state worth asking anyone to review.
