### PR TITLE
feat(bomberman): HUD, countdown, audio and README (4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ PlatformIO will automatically download and install the library and its dependenc
    cd PixelRoot32-Game-Engine/examples/hello_world
    ```
 
-   Each folder (`hello_world`, `animated_tilemap`, `snake`, `flappy_bird`, `metroidvania`, `tic_tac_toe`, `space_invaders`, `brick_breaker`, `physics`, `camera`, `dual_palette`, `sprites`, `music_demo`, `2048`) is a **standalone PlatformIO project** with its own `platformio.ini`.
+   Each folder (`hello_world`, `animated_tilemap`, `snake`, `flappy_bird`, `metroidvania`, `tic_tac_toe`, `space_invaders`, `brick_breaker`, `physics`, `camera`, `dual_palette`, `sprites`, `music_demo`, `2048`, `bomberman`) is a **standalone PlatformIO project** with its own `platformio.ini`.
 
 2. **Open that example folder in VS Code** (File → Open Folder) and select your environment (`env:esp32dev`, `env:esp32cyd`, `env:esp32c3`, or `env:native`).
 3. **Build and Upload** using PlatformIO.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ The engine revision for each example is defined in **`lib_deps`** inside that ex
 | [tic_tac_toe](tic_tac_toe/) | UI, GPIO vs touch, minimax AI, vector-drawn board, **`MusicPlayer`** / melody data | `native`, `esp32dev`, `esp32cyd` |
 | [2048](2048/) | 2048 puzzle game: grid rendering, touch swipes, D-pad controls, score tracking, **AI auto-play** (expectimax algorithm), audio SFX | `native`, `esp32cyd` |
 | [flappy_bird](flappy_bird/) | Physics flappy clone, U8g2 OLED, ESP32-C3 (**no audio** in this sample) | `native`, `esp32c3` |
+| [bomberman](bomberman/) | Bomberman clone: interpolated grid movement, deterministic seeded board generation, bounded chain-reaction explosions, PRNG enemy AI, HUD + text overlays, `AudioEngine` | `native`, `esp32dev` |
 
 
 ## Suggested learning order
@@ -40,7 +41,7 @@ The engine revision for each example is defined in **`lib_deps`** inside that ex
 2. **sprites** or **dual_palette** — graphics and color models.  
 3. **camera** or **metroidvania** / **animated_tilemap** — scrolling, tilemaps, caching (read **animated_tilemap** for the fullest tilemap write-up).  
 4. **physics** — bodies, sensors, touch.  
-5. **snake** / **tic_tac_toe** / **2048** / **brick_breaker** / **music_demo** / **space_invaders** — **audio** (events, single-track music, or **multi-track** reference). **flappy_bird** — physics + OLED, no audio subsystem.
+5. **snake** / **tic_tac_toe** / **2048** / **brick_breaker** / **music_demo** / **space_invaders** / **bomberman** — **audio** (events, single-track music, or **multi-track** reference). **flappy_bird** — physics + OLED, no audio subsystem.
 
 ## Engine documentation
 

--- a/examples/bomberman/README.md
+++ b/examples/bomberman/README.md
@@ -1,0 +1,146 @@
+# Bomberman Example
+
+A classic **Bomberman**-style game on a **13×11** grid: place bombs, chain
+explosions, destroy soft walls, dodge four PRNG-driven enemies, collect
+power-ups, and reach the exit once every enemy is dead. Movement is
+**interpolated** between cells (not a teleport-per-cell like some of the
+other grid examples), and every timed rule — movement, bomb fuses,
+explosions, the level clock — runs on a **fixed 20 ms logic step**, decoupled
+from the rendered frame rate.
+
+## Requirements (build flags)
+
+Set in [`lib/platformio.ini`](lib/platformio.ini)'s `[base]` template, so
+every environment inherits them:
+
+- **`PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1`** — required, not optional.
+  `BombermanConstants.h` declares `kBoardGrid` as a `gameplay::GridSpec`, and
+  the whole `GridSpace.h` header lives behind this flag (default `0`), so the
+  example does not compile without it.
+- **`PIXELROOT32_ENABLE_AUDIO=1`** — needed for the four sound events below.
+- **`PIXELROOT32_ENABLE_PHYSICS=0`** — the physics system is never used;
+  every blocking/collision check here is a board lookup, not a physics query.
+- **`PIXELROOT32_ENABLE_PARTICLES=0`** — not used.
+- **`PIXELROOT32_ENABLE_UI_SYSTEM=0`** — HUD and overlays are drawn directly
+  with `Renderer::drawText`/`drawTextCentered`, not the UI widget system.
+
+Display size is **240×240** in the project `platformio.ini` (see
+`PHYSICAL_DISPLAY_*`).
+
+## Platforms
+
+| Environment | Display | Audio backend |
+|-------------|---------|----------------|
+| **`native`** | SDL2, 240×240 | `SDL2_AudioBackend` in [`src/platforms/native.h`](src/platforms/native.h) |
+| **`esp32dev`** | **ST7789** 240×240 | `ESP32_I2S_AudioBackend` in [`src/platforms/esp32_dev.h`](src/platforms/esp32_dev.h) |
+
+Pin choices (ST7789 SPI, I2S audio, D-pad + two buttons) are in
+`src/platforms/esp32_dev.h` — edit there if your wiring differs.
+
+## Controls
+
+| Action | `native` (keyboard) | `esp32dev` (GPIO) |
+|--------|----------------------|--------------------|
+| Move | Arrow keys | D-pad |
+| Place bomb | Space | Button A |
+| Restart (from Game Over / Stage Clear) | Enter | Button B |
+
+Movement has a fixed priority — **Up > Down > Left > Right** — when more than
+one direction is held at once, so input is never ambiguous and never
+diagonal. Holding a direction into a wall, a bomb, or the board edge simply
+leaves the player in place; it is never a death.
+
+## How audio is triggered
+
+`BombermanScene::logicStep()` builds `pixelroot32::audio::AudioEvent` values
+and calls `engine.getAudioEngine().playEvent(...)`, the same pattern the
+`snake` example uses. Four events, each tied to one exact pipeline moment:
+
+- **Bomb placed** — the step a bomb placement actually succeeds (not every
+  press of the bomb button; a press rejected by the bomb limit or an
+  already-bombed cell stays silent).
+- **Explosion** — the step any bomb(s) actually detonate, whether from a
+  timer or a chain reaction (one event per step, even if several bombs chain
+  together on that step).
+- **Player death** — one shared event for every death cause: explosion
+  contact, enemy contact, or the countdown reaching zero.
+- **Stage clear** — the step victory is reached (last enemy already dead,
+  player steps onto the revealed exit).
+
+## Features
+
+- **Deterministic board generation.** `BombermanBoard.cpp` builds the board
+  from a seed using the engine's seeded PRNG (`math::set_seed` /
+  `math::rand_int`) — never `std::rand`. Hard walls sit on the border and at
+  every even-x/even-y interior cell; every other cell is on a connected
+  corridor lattice by construction (no reachability check needed, since soft
+  walls are all destructible and never permanently block a corridor cell).
+  The player's start cell and its two adjacent cells are guaranteed free of
+  soft walls.
+- **Interpolated grid movement.** The player moves at 12 logic steps per
+  cell, enemies at 20. Both use the same small `GridMove` struct
+  (`src/GridMove.h`) but each actor writes its own advance loop — the
+  player stays put when blocked and reads held input; an enemy re-picks a
+  direction and reads the seeded PRNG. The two loops are deliberately not
+  merged into a shared controller; they disagree on enough policy (blocking
+  behavior, direction source, and the pass-through rule below) that sharing
+  more than the struct would need extra flags for every difference.
+- **Own-bomb pass-through.** A player can always leave the cell they just
+  bombed; that bomb becomes solid again the instant they arrive in a new
+  cell. Enemies have no such exemption — every bomb is solid to them.
+- **Chain reactions.** An explosion reaching another bomb detonates it
+  immediately, in the same logic step, via a small bounded queue (at most
+  8 entries — the size of the bomb pool) instead of recursion, so a ring of
+  mutually-adjacent bombs still resolves in a fixed number of iterations.
+- **Hidden content lives in the tile type, not a side table.** The three
+  soft-wall variants (plain, hiding the exit, hiding a power-up) render and
+  block identically until destroyed — there is only one array that could
+  disagree with what is drawn.
+- **Cell/world conversion via `gameplay::GridSpace`.** The board's
+  `constexpr GridSpec` places the playfield below a reserved status band
+  (`containsCell` rejects that band automatically, so no gameplay rule needs
+  to know the HUD exists) — no hand-rolled `* 16` / `/ 16` arithmetic
+  anywhere in the game logic.
+- **Plain-enum state, not the engine's generic state-machine primitive.**
+  The level's five states (Loading, Playing, ExitUnlocked, StageClear,
+  GameOver) are one plain `enum class`, driven by a fixed nine-stage update
+  pipeline that runs the same conditions in the same order every logic step.
+  Player, bomb, and tile "state" are likewise derived from a couple of
+  existing fields rather than stored as separate enums.
+- **Entity budget guardrail.** A `static_assert` (compile-time) plus a
+  post-init `assert` (development builds only — it compiles out under
+  `NDEBUG` on `esp32dev` release builds) both guard against the entity pool
+  silently dropping an actor once its fixed array is full.
+- **HUD and overlays.** Lives, enemies remaining, current fire power / max
+  bombs (`F n B n`), and the countdown are drawn every frame straight from
+  the live game state — there is no cached copy that could go stale. Game
+  Over and Stage Clear are a **text overlay drawn on top of the board**, not
+  a separate screen or `Scene`.
+- **Level countdown.** A `TIME` value counts down once per logic step
+  (never per rendered frame); reaching zero costs one life through the exact
+  same path as an explosion or an enemy contact. The 180-second starting
+  value is a first estimate, not a value tuned against a timed play session.
+
+## Documentation links
+
+- [Audio API](../../docs/api/audio.md)
+- [Core API](../../docs/api/core.md)
+- [Input API](../../docs/api/input.md)
+- [Memory system — gameplay flags and byte budgets](../../docs/architecture/memory-system.md)
+- [Grid cell occupancy pattern](../../docs/patterns/grid-cell-occupancy.md) — the status-band-above-the-grid layout this example uses
+- [`gameplay/GridSpace.h`](../../include/gameplay/GridSpace.h) — the full grid conversion API
+
+## Build
+
+From **`examples/bomberman`**:
+
+```bash
+pio run -e native
+pio run -e esp32dev
+```
+
+## Upload (ESP32)
+
+```bash
+pio run -e esp32dev --target upload
+```

--- a/examples/bomberman/src/BombermanConstants.h
+++ b/examples/bomberman/src/BombermanConstants.h
@@ -100,4 +100,14 @@ constexpr int kStartingLives = 3;
  * has no separate constant -- it is always exactly +1). */
 constexpr int kFirePowerIncrement = 1;
 
+/* Level countdown. Ticks once per logic step, inside the same pipeline
+ * stage as the bomb fuses (BombermanScene::logicStep()); reaching zero
+ * costs the player one life through the exact same path as an explosion or
+ * an enemy contact -- there is no separate "time's up" state. 180 seconds
+ * is a first estimate sized to comfortably cover destroying both
+ * power-up-bearing walls, collecting both power-ups, clearing four enemies,
+ * and reaching the exit at 240ms/cell; it is a playability guess, not a
+ * measured value, since no live play session tuned it. */
+constexpr std::uint16_t kInitialCountdownSeconds = 180;
+
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -1,6 +1,8 @@
 #include "BombermanScene.h"
 #include "core/Engine.h"
+#include "audio/AudioTypes.h"
 #include <cassert>
+#include <cstdio>
 #include <ctime>
 
 namespace pr32 = pixelroot32;
@@ -11,6 +13,7 @@ namespace bomberman {
 
 namespace gfx = pr32::graphics;
 namespace core = pr32::core;
+namespace audio = pr32::audio;
 
 BombermanScene::BombermanScene()
     : board_{},
@@ -25,7 +28,10 @@ BombermanScene::BombermanScene()
       accumulatorMs_(0),
       seed_(0),
       lives_(kStartingLives),
-      bombPressLatched_(false) {
+      countdownSeconds_(kInitialCountdownSeconds),
+      countdownSubSteps_(0),
+      bombPressLatched_(false),
+      restartPressLatched_(false) {
     // enemies_ is default-initialized above (omitted here): every slot
     // starts dead at (0,0) via EnemyActor's default constructor and is not
     // registered with the scene until startLevel() decides how many of
@@ -74,6 +80,9 @@ void BombermanScene::startLevel() {
         addEntity(&enemies_[i]);
     }
 
+    countdownSeconds_ = kInitialCountdownSeconds;
+    countdownSubSteps_ = 0;
+
     accumulatorMs_ = 0;
     // A press held across the death that triggered this restart must not
     // drop a bomb on the fresh board's first step.
@@ -89,9 +98,16 @@ void BombermanScene::startLevel() {
 
 void BombermanScene::update(unsigned long deltaTime) {
     // Latch here, at frame scope, while the press edge is still live. The
-    // loop below may run no logic step at all this frame.
-    if (engine.getInputManager().isButtonPressed(BTN_BOMB)) {
+    // loop below may run no logic step at all this frame. Both button
+    // presses this example ever reads (bomb, restart) are latched exactly
+    // this way -- isButtonPressed() is never called from inside logicStep(),
+    // which runs on the fixed 20 ms clock instead of the frame clock.
+    auto& input = engine.getInputManager();
+    if (input.isButtonPressed(BTN_BOMB)) {
         bombPressLatched_ = true;
+    }
+    if (input.isButtonPressed(BTN_RESTART)) {
+        restartPressLatched_ = true;
     }
 
     accumulatorMs_ += deltaTime;
@@ -111,8 +127,16 @@ void BombermanScene::update(unsigned long deltaTime) {
 
 void BombermanScene::logicStep() {
     if (state_ == LevelState::StageClear || state_ == LevelState::GameOver) {
-        // Terminal state: freeze the simulation. Both end states stop the
-        // pipeline the same way; only how they were reached differs.
+        // Terminal state: freeze the simulation, except for a restart
+        // request. restartPressLatched_ was set in update(), at frame
+        // scope, while the press edge was live -- reading it here (instead
+        // of calling isButtonPressed() directly) keeps every press read in
+        // this codebase on the frame clock, never the logic-step clock.
+        if (restartPressLatched_) {
+            restartPressLatched_ = false;
+            lives_ = kStartingLives;
+            startLevel();
+        }
         return;
     }
 
@@ -125,7 +149,15 @@ void BombermanScene::logicStep() {
     // frame edge instead, consumed exactly once here.
     const bool bombPressed = bombPressLatched_;
     bombPressLatched_ = false;
-    player_.logicStep(board_, bombs_, input, bombPressed);
+    if (player_.logicStep(board_, bombs_, input, bombPressed)) {
+        audio::AudioEvent bombPlacedSound;
+        bombPlacedSound.type = audio::WaveType::PULSE;
+        bombPlacedSound.frequency = 220.0f;
+        bombPlacedSound.duration = 0.08f;
+        bombPlacedSound.volume = 0.5f;
+        bombPlacedSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(bombPlacedSound);
+    }
 
     // Stage 3: enemy movement. Each alive enemy re-decides its own
     // direction independently, straight-else-PRNG; see EnemyActor.cpp.
@@ -136,16 +168,48 @@ void BombermanScene::logicStep() {
     }
 
     // Stage 4: bomb fuses tick down, seeding this step's detonation queue
-    // with any bomb whose fuse just reached zero.
+    // with any bomb whose fuse just reached zero. The level countdown ticks
+    // in this same stage, on the identical fixed 20 ms clock -- never from
+    // update()'s deltaTime -- so it is exactly as reproducible as the fuses
+    // it shares a pipeline stage with.
     uint8_t detonationQueue[kMaxBombs] = {};
     int queueTail = 0;
     tickFuses(bombs_, detonationQueue, queueTail);
+
+    if (countdownSeconds_ > 0) {
+        ++countdownSubSteps_;
+        if (countdownSubSteps_ >= kStepsPerSecond) {
+            countdownSubSteps_ = 0;
+            --countdownSeconds_;
+            if (countdownSeconds_ == 0) {
+                // Expiry costs a life via the exact same funnel as an
+                // explosion or an enemy contact. handlePlayerDeath() may
+                // call startLevel(), which resets board_/bombs_/blastSteps_
+                // -- so this returns immediately rather than letting stages
+                // 5+ below run resolveDetonations()/tickExplosions() against
+                // a detonation queue seeded for a board that no longer
+                // exists.
+                handlePlayerDeath();
+                return;
+            }
+        }
+    }
 
     // Stage 5: the queue -- including any bomb a blast arm chain-triggers
     // along the way -- drains to a fixed point within this same call. See
     // resolveDetonations()'s termination comment for why that is
     // guaranteed to happen in at most kMaxBombs iterations.
-    resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
+    const int detonatedCount =
+        resolveDetonations(detonationQueue, queueTail, bombs_, board_, blastSteps_, hiddenPowerUp_);
+    if (detonatedCount > 0) {
+        audio::AudioEvent explosionSound;
+        explosionSound.type = audio::WaveType::NOISE;
+        explosionSound.frequency = 90.0f;
+        explosionSound.duration = 0.3f;
+        explosionSound.volume = 0.7f;
+        explosionSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(explosionSound);
+    }
 
     // Stage 6: explosion cells count down toward reverting to their
     // post-destruction tile.
@@ -211,6 +275,13 @@ void BombermanScene::logicStep() {
     }
     if (state_ == LevelState::ExitUnlocked && board_[playerCell] == TileType::Exit) {
         state_ = LevelState::StageClear;
+        audio::AudioEvent stageClearSound;
+        stageClearSound.type = audio::WaveType::TRIANGLE;
+        stageClearSound.frequency = 660.0f;
+        stageClearSound.duration = 0.6f;
+        stageClearSound.volume = 0.7f;
+        stageClearSound.duty = 0.5f;
+        engine.getAudioEngine().playEvent(stageClearSound);
     }
 }
 
@@ -221,6 +292,17 @@ void BombermanScene::killEnemy(int index) {
 }
 
 void BombermanScene::handlePlayerDeath() {
+    // The single funnel for every death cause (explosion contact, enemy
+    // contact, countdown expiry) -- one audio event fires here regardless
+    // of which one triggered it.
+    audio::AudioEvent deathSound;
+    deathSound.type = audio::WaveType::SAW;
+    deathSound.frequency = 300.0f;
+    deathSound.duration = 0.4f;
+    deathSound.volume = 0.7f;
+    deathSound.duty = 0.5f;
+    engine.getAudioEngine().playEvent(deathSound);
+
     --lives_;
     if (lives_ > 0) {
         // lives_ lives outside startLevel() entirely, so it carries the
@@ -233,9 +315,33 @@ void BombermanScene::handlePlayerDeath() {
 
 void BombermanScene::draw(gfx::Renderer& renderer) {
     // BoardRenderer (layer 0), then PlayerActor + live EnemyActors
-    // (layer 1) -- Scene::draw() sorts by render layer. HUD text and
-    // overlays are later work.
+    // (layer 1) -- Scene::draw() sorts by render layer. HUD text and the
+    // game-over/stage-clear overlay are drawn on top, here, same idiom as
+    // the board's status band (BoardRenderer draws the band's background;
+    // this draws the text that sits on it).
     Scene::draw(renderer);
+
+    char buffer[24];
+
+    std::snprintf(buffer, sizeof(buffer), "LIVES %d  ENEMIES %d", lives_, enemiesAlive_);
+    renderer.drawText(buffer, 4, 6, gfx::Color::White, 1);
+
+    std::snprintf(buffer, sizeof(buffer), "F%d B%d  TIME %03u", player_.firePower(), player_.maxBombs(),
+                  static_cast<unsigned>(countdownSeconds_));
+    renderer.drawText(buffer, 4, 22, gfx::Color::White, 1);
+
+    // Text overlay, not a separate screen or Scene: both terminal states
+    // draw a dark band across the middle of the board with centered text
+    // over whatever the board looks like at the moment of the transition.
+    if (state_ == LevelState::GameOver) {
+        renderer.drawFilledRectangle(0, 104, DISPLAY_WIDTH, 32, gfx::Color::Black);
+        renderer.drawTextCentered("GAME OVER", 112, gfx::Color::Red, 1);
+        renderer.drawTextCentered("PRESS RESTART", 124, gfx::Color::Red, 1);
+    } else if (state_ == LevelState::StageClear) {
+        renderer.drawFilledRectangle(0, 104, DISPLAY_WIDTH, 32, gfx::Color::Black);
+        renderer.drawTextCentered("STAGE CLEAR", 112, gfx::Color::Cyan, 1);
+        renderer.drawTextCentered("PRESS RESTART", 124, gfx::Color::Cyan, 1);
+    }
 }
 
 }  // namespace bomberman

--- a/examples/bomberman/src/BombermanScene.cpp
+++ b/examples/bomberman/src/BombermanScene.cpp
@@ -126,14 +126,23 @@ void BombermanScene::update(unsigned long deltaTime) {
 }
 
 void BombermanScene::logicStep() {
+    // The restart press is consumed here, once per logic step, in EVERY
+    // state -- not only in the terminal branch below. Latching in update()
+    // is what keeps the read on the frame clock; clearing it unconditionally
+    // is what keeps it from going stale. A press made during normal play is
+    // meaningless, so it is discarded rather than left armed: leaving it set
+    // would mean one stray press at any point in a session sits pending and
+    // then fires on the very first step after the game ends, skipping the
+    // game-over and stage-clear states entirely. The bomb latch below is
+    // safe for the same reason -- it is consumed every step, never only in
+    // the state that happens to act on it.
+    const bool restartPressed = restartPressLatched_;
+    restartPressLatched_ = false;
+
     if (state_ == LevelState::StageClear || state_ == LevelState::GameOver) {
         // Terminal state: freeze the simulation, except for a restart
-        // request. restartPressLatched_ was set in update(), at frame
-        // scope, while the press edge was live -- reading it here (instead
-        // of calling isButtonPressed() directly) keeps every press read in
-        // this codebase on the frame clock, never the logic-step clock.
-        if (restartPressLatched_) {
-            restartPressLatched_ = false;
+        // request.
+        if (restartPressed) {
             lives_ = kStartingLives;
             startLevel();
         }

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -61,6 +61,16 @@ private:
     uint32_t seed_;
     int lives_;
 
+    /// Level countdown: seconds remaining plus how many logic steps have
+    /// elapsed into the current second. Both tick inside logicStep()'s
+    /// bomb/timer stage, on the fixed 20 ms clock -- never from
+    /// update()'s deltaTime -- so the countdown is exactly as reproducible
+    /// as every other timer in this game (fuses, explosion decay). Reaching
+    /// zero costs the player one life through handlePlayerDeath(), the same
+    /// funnel explosion and enemy contact already use.
+    uint16_t countdownSeconds_;
+    uint8_t countdownSubSteps_;
+
     /// Frame-scoped bomb press, latched for the fixed-step loop to consume.
     /// InputManager recomputes its press edge once per engine frame, but the
     /// accumulator below runs zero, one, or two logic steps in that same
@@ -72,6 +82,13 @@ private:
     /// neither lost on a zero-step frame nor acted on twice on a two-step
     /// one.
     bool bombPressLatched_;
+
+    /// Same latch pattern as bombPressLatched_ above, for the restart
+    /// button read during GameOver/StageClear. Both isButtonPressed() reads
+    /// in this codebase live in update(), at frame scope -- logicStep()
+    /// only ever consumes an already-latched bool, never the raw edge, so
+    /// the fixed-step clock never observes a press directly.
+    bool restartPressLatched_;
 
     /// (Re)generates the board, resets the bomb pool/explosion mask, resets
     /// the player, and redeploys enemies to match the freshly generated
@@ -87,12 +104,16 @@ private:
 
     /// The fixed nine-stage logic pipeline, driven by update()'s
     /// accumulator: (1) input, (2) player movement, (3) enemy movement,
-    /// (4) bomb fuse tick, (5) chain-reaction drain, (6) explosion decay,
-    /// (7) power-up pickup, (8) collision detection (explosion contact for
-    /// both enemies and the player, then player-enemy contact), (9) victory
-    /// check. A "cycle" in this codebase always means one fixed 20 ms logic
-    /// step (BombermanConstants.h's kLogicStepMs) -- never a rendered frame,
-    /// which runs at a different, variable rate.
+    /// (4) bomb fuse tick (the level countdown ticks in this same stage),
+    /// (5) chain-reaction drain, (6) explosion decay, (7) power-up pickup,
+    /// (8) collision detection (explosion contact for both enemies and the
+    /// player, then player-enemy contact), (9) victory check. A "cycle" in
+    /// this codebase always means one fixed 20 ms logic step
+    /// (BombermanConstants.h's kLogicStepMs) -- never a rendered frame,
+    /// which runs at a different, variable rate. While the level is in a
+    /// terminal state (StageClear/GameOver) this function only checks for a
+    /// latched restart press and otherwise returns immediately -- the nine
+    /// stages above never run against a frozen level.
     void logicStep();
 
     /// Removes an enemy from play: marks it dead, unregisters it from the

--- a/examples/bomberman/src/BombermanScene.h
+++ b/examples/bomberman/src/BombermanScene.h
@@ -83,11 +83,17 @@ private:
     /// one.
     bool bombPressLatched_;
 
-    /// Same latch pattern as bombPressLatched_ above, for the restart
-    /// button read during GameOver/StageClear. Both isButtonPressed() reads
-    /// in this codebase live in update(), at frame scope -- logicStep()
-    /// only ever consumes an already-latched bool, never the raw edge, so
-    /// the fixed-step clock never observes a press directly.
+    /// Same latch pattern as bombPressLatched_ above, for the restart button
+    /// acted on during GameOver/StageClear. Both isButtonPressed() reads in
+    /// this codebase live in update(), at frame scope -- logicStep() only
+    /// ever consumes an already-latched bool, never the raw edge, so the
+    /// fixed-step clock never observes a press directly.
+    ///
+    /// Consumed on EVERY logic step, not only in the states that act on it.
+    /// A latch cleared only by the state that uses it is a latch that goes
+    /// stale: a press during normal play would stay armed for the rest of
+    /// the session and then fire on the first step after the game ended,
+    /// skipping the very state it was meant to be read in.
     bool restartPressLatched_;
 
     /// (Re)generates the board, resets the bomb pool/explosion mask, resets

--- a/examples/bomberman/src/PlayerActor.cpp
+++ b/examples/bomberman/src/PlayerActor.cpp
@@ -15,7 +15,7 @@ PlayerActor::PlayerActor(int startCellX, int startCellY)
     resetTo(startCellX, startCellY);
 }
 
-void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+bool PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
                              const input::InputManager& inputManager, bool bombPressed) {
     // This advance loop is a deliberate, near-duplicate of
     // EnemyActor::logicStep()'s. They are not merged into one shared
@@ -39,8 +39,9 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
     // this function runs on the fixed logic step, which is a different
     // clock. Held movement below is a level state, so sampling it per step
     // is correct as-is.
+    bool bombPlaced = false;
     if (bombPressed) {
-        tryPlaceBomb(bombs);
+        bombPlaced = tryPlaceBomb(bombs);
     }
 
     if (mv.progress > 0) {
@@ -63,7 +64,7 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
             }
         }
         updateInterpolatedPosition();
-        return;
+        return bombPlaced;
     }
 
     // At rest: held input may start a new step. Fixed priority
@@ -95,6 +96,7 @@ void PlayerActor::logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxB
     }
 
     updateInterpolatedPosition();
+    return bombPlaced;
 }
 
 bool PlayerActor::canEnter(int nx, int ny, const TileType (&board)[kCells],

--- a/examples/bomberman/src/PlayerActor.h
+++ b/examples/bomberman/src/PlayerActor.h
@@ -41,7 +41,12 @@ public:
     /// runs on the fixed logic step -- the caller latches the edge across
     /// that gap. Held direction is a level state and is read from `input`
     /// directly, which is correct to sample per step.
-    void logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
+    ///
+    /// Returns true iff a bomb was actually placed this call (the press was
+    /// latched AND the pool/limit checks in tryPlaceBomb() both passed) --
+    /// the caller uses this to fire the bomb-placed audio event exactly once
+    /// per successful placement, never on a press that was rejected.
+    bool logicStep(const TileType (&board)[kCells], Bomb (&bombs)[kMaxBombs],
                    const pixelroot32::input::InputManager& input, bool bombPressed);
 
     void draw(pixelroot32::graphics::Renderer& renderer) override;


### PR DESCRIPTION
Last of four slices. Completes the example: HUD, TIME countdown, minimal audio, and a self-contained README.

## Review this first

`examples/bomberman/README.md` — it is the artifact readers actually open, and the only one whose audience is not this PR.

## Chain context

```
feature/top-down-games
  └── 01-board-movement                     — board + movement
        └── 02-bombs-chains                 — bombs, fuses, chain reactions
              └── 03-enemies-winlose        — enemies, exit gating, win/lose
                    └── 📍 04-hud-audio-docs (this PR) — HUD, countdown, audio, README
```

Targets `bomberman/03-enemies-winlose`.

## The countdown runs on the logic clock

TIME counts fixed 20 ms logic steps, exactly like bomb fuses and explosion decay. It never accumulates `deltaTime`.

That is not a style preference. Frame rate varies and the logic step does not, so a countdown driven by frame time drifts — and drifts *differently* on hardware that renders slower than a desktop. `deltaTime` does not appear anywhere outside `update()` in this example.

Expiry costs a life through the same path as any other death, rather than a second death path that could disagree with the first.

## Fix included: a restart press that armed itself and waited

The restart latch was set in `update()` at frame scope — correct — but consumed **only inside the terminal-state branch**. During normal play nothing read it and nothing cleared it.

So pressing restart at any point in a session left the flag armed for the rest of the run, and the first logic step after reaching game-over or stage-clear consumed it immediately: the game restarted instantly and **both end states became unreachable**. One stray press was enough.

It is now consumed and cleared once per logic step in every state, and acted on only where it means something.

This is the second bug in this example at the same seam — the boundary between the engine's frame clock and the scene's fixed-step clock — and it failed in the opposite direction from the first (slice 2 *lost* a press; this one *kept* one forever). The bomb latch was safe from this variant only because it happens to be consumed every step. Both latches now state the rule where they are declared.

Worth repeating: neither bug is reachable by a headless test. There are no frames and no `InputManager`.

## Verification

- `pio run -e native` (clean) — SUCCESS, exactly one warning in the whole build, the pre-existing `-Wtype-limits` in `src/graphics/TileAnimation.cpp:179`. Zero from bomberman.
- `pio run -e esp32dev` — SUCCESS. RAM 24672 B (7.5%), Flash 342169 B (26.1%).
- **All 16 examples** build for `native`. Bomberman is the 16th.
- `pio test -e native_test` — **1595 cases: 4 skipped, 1591 succeeded, 0 failed** (4 + 1591 = 1595).
- `pio test -e native_test_gameplay` — **1664 cases: 4 skipped, 1660 succeeded, 0 failed** (4 + 1660 = 1664).
- Countdown expiry checked against the real tick block: fires at exactly step 9000 (180 s × 50 steps/s), exactly once, never early, and clamps at zero without re-firing.
- The full loop — win, lose, restart — confirmed by hand at 240×240.

## Still genuinely open

**Nobody has run this on ESP32 hardware.** It builds and fits at 7.5% RAM / 26.1% Flash — that is all that is known. HUD legibility and audio on a real 240×240 panel are unverified.

## The example, finished

```
2088 lines total across all four slices
```

Against 2048's 1087, the largest example that existed — roughly 1.9×, which the game's scope justifies.

**Zero new engine code.** The whole example is built on what already shipped: `gameplay::GridSpace`, the seeded PRNG, `Actor`/`Scene`, shape primitives, and the grid-cell-occupancy recipe. It found no gaps in the engine — the four defects fixed along the way were all its own.

## Review budget

```
8 files, +328 / -22  ->  350 changed lines
```

Within the 400-line guideline.
