### PR TITLE
feat(example): add room_screen example and Phase 3 part 2 byte budget

### DIFF
--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -115,7 +115,8 @@ Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field
 |------|-------------------|---------------------|-------|
 | `RoomGraphBase*` ptr on `Scene` | 4 B per Scene | 8 B per Scene | Type-erased pointer; nullptr when flag=0 or no graph is registered |
 | `RoomGraphBase` vtable | 12–16 B in flash | 12–16 B in flash | One shared vtable per program (not per instance) |
-| `RoomGraph<32>` (max rooms) | ~1292 B (32 × 40 B/room + 12 B bookkeeping) | ~1560 B (32 × 48 B/room + 16 B bookkeeping) | Bookkeeping: `roomCount_` (2 B), `currentRoomIndex_` (2 B), `onEnter_` fn ptr + `userData_` ptr (8 B on 32-bit, 16 B on 64-bit). No per-room allocated by a game that never instantiates `RoomGraph<N>`. |
+| `RoomGraph<N>` vptr (from `RoomGraphBase`) | 4 B per instance | 8 B per instance | Per-instance vtable pointer; one per `RoomGraph<N>` regardless of N |
+| `RoomGraph<32>` (max rooms) | ~1296 B (32 × 40 B/room + 12 B bookkeeping + 4 B vptr) | ~1564 B (32 × 48 B/room + 16 B bookkeeping + 8 B vptr) | Bookkeeping: `roomCount_` (2 B), `currentRoomIndex_` (2 B), `onEnter_` fn ptr + `userData_` ptr (8 B on 32-bit, 16 B on 64-bit). No per-room allocated by a game that never instantiates `RoomGraph<N>`. |
 | `RoomGraph<2>` (typical example) | ~100 B (2 × 40 B + 12 B) | ~120 B (2 × 48 B + 16 B) | The `examples/room_screen/` example ships with N=2 |
 | Per-`Room` size (`sizeof(Room)`) | 40 B | 48 B | Four `Scalar` fields (camera rect, 4×4 B), tile window (8 B + 1 B flag + 1 B pad), `connections_[4]` (16 B), `connectionCount_` (1 B + 3 B pad) |
 | Flag = 0 | **0 B** | **0 B** | Whole header is an empty `#if` block; no code, no data |

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -109,6 +109,19 @@ Confirmed against the shipped `include/gameplay/StateMachine.h` layout — field
 
 **`GridSpec` byte budget:** every shipped consumer (`examples/snake`, `examples/tic_tac_toe`) declares its grid as `inline constexpr GridSpec`. `constexpr` implies `const`, so the six-`int` aggregate lands in `.rodata`/flash, never `.data`/`.bss` — **0 B SRAM**, at every optimization level, independent of whether the optimizer also folds the constant away entirely. `sizeof(GridSpec) == 24 B` (six `int`s — `int` is 4 B under both the ESP32-C3's ILP32 and native's LP64), identical on both targets. A non-`constexpr` (runtime) `GridSpec` would cost 24 B SRAM instead; no shipped consumer uses one.
 
+**Gameplay Framework Phase 3 part 2 — Room/Screen (opt-in, default `0`):** `RoomGraph<N>` is a header-only template class under `PIXELROOT32_ENABLE_GAMEPLAY_ROOM`. A `Scene` owns it via a type-erased `RoomGraphBase*` pointer (composition, no inheritance). Entering a room updates camera bounds and fires an optional `onEnter` callback. The flag defaults to `0` — when disabled the entire `#if` block is excluded and the engine contributes zero bytes.
+
+| Item | ESP32-C3 (32-bit) | native/PC (64-bit) | Notes |
+|------|-------------------|---------------------|-------|
+| `RoomGraphBase*` ptr on `Scene` | 4 B per Scene | 8 B per Scene | Type-erased pointer; nullptr when flag=0 or no graph is registered |
+| `RoomGraphBase` vtable | 12–16 B in flash | 12–16 B in flash | One shared vtable per program (not per instance) |
+| `RoomGraph<32>` (max rooms) | ~1292 B (32 × 40 B/room + 12 B bookkeeping) | ~1560 B (32 × 48 B/room + 16 B bookkeeping) | Bookkeeping: `roomCount_` (2 B), `currentRoomIndex_` (2 B), `onEnter_` fn ptr + `userData_` ptr (8 B on 32-bit, 16 B on 64-bit). No per-room allocated by a game that never instantiates `RoomGraph<N>`. |
+| `RoomGraph<2>` (typical example) | ~100 B (2 × 40 B + 12 B) | ~120 B (2 × 48 B + 16 B) | The `examples/room_screen/` example ships with N=2 |
+| Per-`Room` size (`sizeof(Room)`) | 40 B | 48 B | Four `Scalar` fields (camera rect, 4×4 B), tile window (8 B + 1 B flag + 1 B pad), `connections_[4]` (16 B), `connectionCount_` (1 B + 3 B pad) |
+| Flag = 0 | **0 B** | **0 B** | Whole header is an empty `#if` block; no code, no data |
+
+Design: #3081 (`sdd/room-screen-abstraction/design`).
+
 **`ObjectPool<T, N>` byte budget:** `N * sizeof(T)` for the aligned slot storage, plus target-independent bookkeeping (a `uint32_t liveWords_[(N+31)/32]` bitmask plus two `uint16_t` counters, `liveCount_` and `scanHint_`) — identical on ESP32-C3 and native because every bookkeeping field is a fixed-width type:
 
 | `N` (pool capacity) | `liveWords_` | counters (`liveCount_` + `scanHint_`) | **bookkeeping total** | per-slot equivalent |

--- a/examples/room_screen/.gitignore
+++ b/examples/room_screen/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/room_screen/.vscode/extensions.json
+++ b/examples/room_screen/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/examples/room_screen/README.md
+++ b/examples/room_screen/README.md
@@ -1,0 +1,32 @@
+# Room/Screen Example
+
+> **Demonstration example** — showcases the `RoomGraph` API. May not be 100% finished; provided as an example of what you can build.
+
+Minimal 2-room layout: two adjacent rooms (240×240 each), connected left-to-right. Arrow keys trigger `enterRoom`, which clamps the camera to the target room and fires an `onEnter` callback.
+
+## Requirements (build flags)
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `PIXELROOT32_ENABLE_GAMEPLAY_ROOM=1` | Yes | Enables `RoomGraph<N>` |
+| `PIXELROOT32_ENABLE_AUDIO=1` | No | Audio backend for SDL2/ESP32 |
+
+## Controls
+
+- **Left/Right arrow keys**: transition between Room 0 ↔ Room 1.
+- Room label and background color change on transition.
+
+## Build
+
+From `examples/room_screen`:
+
+```bash
+pio run -e native
+pio run -e esp32dev
+```
+
+## Upload (ESP32)
+
+```bash
+pio run -e esp32dev --target upload
+```

--- a/examples/room_screen/lib/platformio.ini
+++ b/examples/room_screen/lib/platformio.ini
@@ -1,0 +1,54 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+; TEMPLATES
+
+[base]
+build_unflags = 
+	-std=gnu++11        ; Remove C++11 standard flag (we use C++17 instead)
+build_flags =
+    -Wl,--gc-sections
+	-std=gnu++17        ; Use GNU C++17 standard
+    -fno-exceptions     ; Saves ~15KB Flash (Removes try/catch overhead)
+    -D PIXELROOT32_ENABLE_AUDIO=1
+    -D PIXELROOT32_ENABLE_PARTICLES=0
+    -D PIXELROOT32_ENABLE_PHYSICS=0
+    -D PIXELROOT32_ENABLE_UI_SYSTEM=0
+    -D PIXELROOT32_ENABLE_GAMEPLAY_GRID_SPACE=1
+    -D PIXELROOT32_ENABLE_GAMEPLAY_ROOM=1
+
+[base_esp32]
+platform = espressif32
+monitor_speed = 115200
+build_unflags = 
+	${base.build_unflags}
+build_flags =
+    ${base.build_flags}
+    -Os                  ; Optimize for binary size (useful on ESP32 with limited RAM/Flash)
+    -flto                ; Link-Time Optimization (reduces binary size by combining code)
+    -fuse-linker-plugin  ; Allows ld to use the LTO plugin; required for RISC-V toolchain
+    -ffunction-sections  ; Put each function in its own section; helps remove unused functions (-Wl,--gc-sections)
+    -fdata-sections      ; Same as above but for data; helps reduce flash usage
+    -fno-lto             ; Disable LTO for problematic objects; prevents "plugin needed to handle lto object" in mixed C/C++ code
+    -fno-rtti            ; Remove RTTI support; saves ~20 KB of Flash and RAM
+
+[base_native]
+platform = native
+build_unflags = 
+	${base.build_unflags}
+	; Apple ld does not support GNU --gc-sections (use -dead_strip instead)
+	; -Wl,--gc-sections
+build_flags =
+    ${base.build_flags}
+    -DPLATFORM_NATIVE
+    -DSDL_MAIN_HANDLED
+    -lSDL2
+    ; Apple
+    ; -Wl,-dead_strip

--- a/examples/room_screen/platformio.ini
+++ b/examples/room_screen/platformio.ini
@@ -1,0 +1,62 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = native
+extra_configs = lib/platformio.ini
+
+[env:native]
+extends = base_native
+lib_deps =
+	symlink://../../
+build_flags = 
+    ${base_native.build_flags}
+    -D PHYSICAL_DISPLAY_WIDTH=240
+    -D PHYSICAL_DISPLAY_HEIGHT=240
+    -Isrc
+    -Iinclude
+    -I.pio/libdeps/native/PixelRoot32-Game-Engine/include
+    -I.pio/libdeps/native/PixelRoot32-Game-Engine/src
+    ; macOS (Homebrew): #include <SDL2/SDL.h> needs the parent include dir
+    ; -I/opt/homebrew/include
+    ; -L/opt/homebrew/lib
+    ; Windows (MSYS2/MinGW) — uncomment on Windows, comment macOS flags above:
+    -IC:/msys64/mingw64/include
+    -LC:/msys64/mingw64/lib
+    -O2
+    -Wall
+    -Wextra
+    -mconsole
+
+[env:esp32dev]
+extends = base_esp32
+board = esp32dev
+framework = arduino
+lib_deps =
+	symlink://../../
+build_flags = 
+    ${base_esp32.build_flags}
+    -D PHYSICAL_DISPLAY_WIDTH=240
+    -D PHYSICAL_DISPLAY_HEIGHT=240
+    -D PLATFORM_ESP32DEV
+    ; TFT config (ST7789 240x240)
+    -D USER_SETUP_LOADED=1
+    -D ST7789_DRIVER
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=240
+    -D TFT_MOSI=23
+    -D TFT_SCLK=18
+    -D TFT_DC=2
+    -D TFT_RST=4
+    -D TFT_CS=-1
+    -D TOUCH_CS=-1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=20000000
+    -Isrc
+    -O2

--- a/examples/room_screen/src/GameConstants.h
+++ b/examples/room_screen/src/GameConstants.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <cstdint>
+
+namespace room_screen {
+
+/// Display size in pixels (square 240x240).
+inline constexpr int kDisplaySize = 240;
+
+/// Room dimensions in world units (one screen per room).
+inline constexpr int kRoomWidth  = kDisplaySize;
+inline constexpr int kRoomHeight = kDisplaySize;
+
+/// Button indices matching the InputConfig order (Up, Down, Left, Right, A, B).
+inline constexpr std::uint8_t BTN_UP    = 0;
+inline constexpr std::uint8_t BTN_DOWN  = 1;
+inline constexpr std::uint8_t BTN_LEFT  = 2;
+inline constexpr std::uint8_t BTN_RIGHT = 3;
+
+} // namespace room_screen

--- a/examples/room_screen/src/RoomScreenScene.cpp
+++ b/examples/room_screen/src/RoomScreenScene.cpp
@@ -1,0 +1,67 @@
+#include "RoomScreenScene.h"
+#include "core/Engine.h"
+#include "graphics/Color.h"
+#include "math/Scalar.h"
+#include "GameConstants.h"
+
+namespace pr32 = pixelroot32;
+extern pr32::core::Engine engine;
+
+namespace room_screen {
+
+namespace gfx = pr32::graphics;
+namespace math = pr32::math;
+namespace gameplay = pr32::gameplay;
+
+RoomScreenScene::RoomScreenScene()
+    : camera(kDisplaySize, kDisplaySize) {
+}
+
+void RoomScreenScene::init() {
+    Scene::init();
+
+    // Build a 2-room horizontal graph. Room 0 = left, Room 1 = right.
+    rooms_.addRoom(math::toScalar(0), math::toScalar(0),
+                   math::toScalar(kRoomWidth), math::toScalar(kRoomHeight));
+    rooms_.addRoom(math::toScalar(kRoomWidth), math::toScalar(0),
+                   math::toScalar(kRoomWidth * 2), math::toScalar(kRoomHeight));
+
+    rooms_.connect(0, 1, gameplay::RoomDir::Right);
+    rooms_.connect(1, 0, gameplay::RoomDir::Left);
+
+    rooms_.setOnEnter(onRoomEnterCallback, this);
+    setRoomGraph(&rooms_);
+
+    // Start in room 0 (sets initial camera bounds).
+    rooms_.enterRoom(0, &camera);
+}
+
+void RoomScreenScene::onRoomEnterCallback(int /*fromIdx*/, int /*toIdx*/, void* /*userData*/) {
+    // Camera bounds already clamped by RoomGraph::enterRoom.
+}
+
+void RoomScreenScene::update(unsigned long deltaTime) {
+    (void)deltaTime;
+    auto& input = engine.getInputManager();
+    uint16_t currentRoom = rooms_.currentRoomIndex();
+
+    if (currentRoom == 0 && input.isButtonPressed(BTN_RIGHT)) {
+        rooms_.enterRoom(1, &camera);
+    } else if (currentRoom == 1 && input.isButtonPressed(BTN_LEFT)) {
+        rooms_.enterRoom(0, &camera);
+    }
+}
+
+void RoomScreenScene::draw(pixelroot32::graphics::Renderer& renderer) {
+    uint16_t currentRoom = rooms_.currentRoomIndex();
+
+    // Per-room background color.
+    gfx::Color bg = (currentRoom == 0) ? gfx::Color::DarkGreen : gfx::Color::Navy;
+    renderer.drawFilledRectangle(0, 0, kDisplaySize, kDisplaySize, bg);
+
+    // Centered room label.
+    const char* label = (currentRoom == 0) ? "Room 0" : "Room 1";
+    renderer.drawTextCentered(label, kDisplaySize / 2 - 10, gfx::Color::White, 2);
+}
+
+} // namespace room_screen

--- a/examples/room_screen/src/RoomScreenScene.h
+++ b/examples/room_screen/src/RoomScreenScene.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "core/Scene.h"
+#include "graphics/Camera2D.h"
+#include "graphics/Renderer.h"
+#include "gameplay/RoomGraph.h"
+
+namespace room_screen {
+
+/**
+ * @brief Minimal 2-room example demonstrating RoomGraph.
+ *
+ * Two rooms laid out horizontally (Room 0 → Room 1). Arrow-key
+ * input triggers an enterRoom transition, which clamps the camera
+ * to the target room's bounds and fires an onEnter callback.
+ */
+class RoomScreenScene : public pixelroot32::core::Scene {
+public:
+    RoomScreenScene();
+    void init() override;
+    void update(unsigned long deltaTime) override;
+    void draw(pixelroot32::graphics::Renderer& renderer) override;
+
+private:
+    /// Camera viewport (one screen).
+    pixelroot32::graphics::Camera2D camera;
+    /// Fixed-capacity 2-room graph.
+    pixelroot32::gameplay::RoomGraph<2> rooms_;
+
+    /// RoomGraph onEnter callback. Camera bounds are already updated when this fires.
+    static void onRoomEnterCallback(int fromIdx, int toIdx, void* userData);
+};
+
+} // namespace room_screen

--- a/examples/room_screen/src/main.cpp
+++ b/examples/room_screen/src/main.cpp
@@ -1,0 +1,5 @@
+#ifdef PLATFORM_NATIVE
+#include "platforms/native.h"
+#else
+#include "platforms/esp32_dev.h"
+#endif

--- a/examples/room_screen/src/platforms/esp32_dev.h
+++ b/examples/room_screen/src/platforms/esp32_dev.h
@@ -1,0 +1,56 @@
+#ifdef PLATFORM_ESP32DEV
+
+#include <Arduino.h>
+#include <drivers/esp32/TFT_eSPI_Drawer.h>
+#include <drivers/esp32/ESP32_I2S_AudioBackend.h>
+#include <core/Engine.h>
+#include <platforms/EngineConfig.h>
+
+#include "RoomScreenScene.h"
+
+namespace pr32 = pixelroot32;
+
+// Audio Pin Configuration (I2S)
+const int I2S_BCLK = 26;
+const int I2S_LRCK = 25;
+const int I2S_DOUT = 22;
+
+// Button Mapping (Arduino ESP32)
+const int BTN_UP = 32;
+const int BTN_DOWN = 27;
+const int BTN_LEFT = 33;
+const int BTN_RIGHT = 14;
+const int BTN_A = 13;
+const int BTN_B = 12;
+
+pr32::drivers::esp32::ESP32_I2S_AudioBackend audioBackend(I2S_BCLK, I2S_LRCK, I2S_DOUT, 22050);
+
+pr32::graphics::DisplayConfig config(
+    pr32::graphics::DisplayType::ST7789, 
+    DISPLAY_ROTATION, 
+    PHYSICAL_DISPLAY_WIDTH, 
+    PHYSICAL_DISPLAY_HEIGHT,
+    LOGICAL_WIDTH,
+    LOGICAL_HEIGHT,
+    X_OFF_SET,
+    Y_OFF_SET
+);
+
+pr32::input::InputConfig inputConfig(BTN_UP, BTN_DOWN, BTN_LEFT, BTN_RIGHT, BTN_A, BTN_B);
+
+pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
+
+pr32::core::Engine engine(config, inputConfig, audioConfig);
+
+room_screen::RoomScreenScene roomScreenScene;
+
+void setup() {
+    engine.init();
+    engine.setScene(&roomScreenScene);
+}
+
+void loop() {
+    engine.run();
+}
+
+#endif

--- a/examples/room_screen/src/platforms/native.h
+++ b/examples/room_screen/src/platforms/native.h
@@ -1,0 +1,47 @@
+#ifdef PLATFORM_NATIVE
+
+#include <SDL2/SDL.h>
+
+#include <drivers/native/SDL2_Drawer.h> 
+#include <drivers/native/SDL2_AudioBackend.h>
+#include <core/Engine.h>
+#include <platforms/EngineConfig.h>
+
+#include "RoomScreenScene.h"
+
+namespace pr32 = pixelroot32;
+
+pr32::drivers::native::SDL2_AudioBackend audioBackend(22050, 1024);
+
+pr32::graphics::DisplayConfig config(
+    pr32::graphics::DisplayType::NONE, 
+    DISPLAY_ROTATION, 
+    PHYSICAL_DISPLAY_WIDTH, 
+    PHYSICAL_DISPLAY_HEIGHT,
+    LOGICAL_WIDTH,
+    LOGICAL_HEIGHT,
+    X_OFF_SET,
+    Y_OFF_SET
+);
+
+pr32::input::InputConfig inputConfig(SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_SPACE, SDL_SCANCODE_RETURN);
+
+pr32::audio::AudioConfig audioConfig(&audioBackend, audioBackend.getSampleRate());
+
+pr32::core::Engine engine(config, inputConfig, audioConfig);
+
+room_screen::RoomScreenScene roomScreenScene;
+
+int main(int argc, char* argv[]) {
+    (void)argc;
+    (void)argv;
+
+    engine.init();
+    engine.setScene(&roomScreenScene);
+
+    engine.run();
+
+    return 0;
+}
+
+#endif // PLATFORM_NATIVE

--- a/test/unit/test_gameplay_room_graph/test_gameplay_room_graph.cpp
+++ b/test/unit/test_gameplay_room_graph/test_gameplay_room_graph.cpp
@@ -137,12 +137,36 @@ void test_enter_room_updates_camera_bounds(void) {
     graph.addRoom(toScalar(50), toScalar(100), toScalar(200), toScalar(300));
 
     Camera2D camera(240, 240);
-    // enterRoom with a valid camera must NOT crash and must update
-    // currentRoomIndex.  The internal camera bounds update (setBounds /
-    // setVerticalBounds) is verified by the example migration (CU4);
-    // this unit test verifies the no-crash contract and room-index update.
+    // enterRoom must update the camera bounds to match the room's rect.
+    // Camera2D exposes the bounds only indirectly (via setPosition
+    // clamping), so we verify by setting a position outside the room and
+    // asserting the clamp matches the room's min/max values.
     graph.enterRoom(0, &camera);
     TEST_ASSERT_EQUAL_UINT16(0, graph.currentRoomIndex());
+
+    // Position far right/bottom of room 0 — must clamp to maxX/maxY.
+    camera.setPosition(Vector2(toScalar(1000), toScalar(1000)));
+    TEST_ASSERT_EQUAL_INT(200, static_cast<int>(camera.getX()));
+    TEST_ASSERT_EQUAL_INT(300, static_cast<int>(camera.getY()));
+
+    // Position far left/top of room 0 — must clamp to minX/minY.
+    camera.setPosition(Vector2(toScalar(0), toScalar(0)));
+    TEST_ASSERT_EQUAL_INT(50, static_cast<int>(camera.getX()));
+    TEST_ASSERT_EQUAL_INT(100, static_cast<int>(camera.getY()));
+
+    // Add a second room with different bounds and verify the bounds ARE
+    // updated per-room (not stuck at room 0's rect).
+    graph.addRoom(toScalar(400), toScalar(500), toScalar(600), toScalar(700));
+    graph.enterRoom(1, &camera);
+    TEST_ASSERT_EQUAL_UINT16(1, graph.currentRoomIndex());
+
+    camera.setPosition(Vector2(toScalar(0), toScalar(0)));
+    TEST_ASSERT_EQUAL_INT(400, static_cast<int>(camera.getX()));
+    TEST_ASSERT_EQUAL_INT(500, static_cast<int>(camera.getY()));
+
+    camera.setPosition(Vector2(toScalar(1000), toScalar(1000)));
+    TEST_ASSERT_EQUAL_INT(600, static_cast<int>(camera.getX()));
+    TEST_ASSERT_EQUAL_INT(700, static_cast<int>(camera.getY()));
 }
 
 void test_enter_room_invalid_is_noop(void) {


### PR DESCRIPTION
## Summary
- Adds `examples/room_screen/` - a minimal 2-room example demonstrating `RoomGraph<N>` with arrow-key input, camera-bounds clamping, and `onEnter` callback.
- Updates `docs/architecture/memory-system.md` with the Phase 3 part 2 byte budget row for `RoomGraph<N>` (~1296 B on ESP32, ~1564 B on native at N=32, including the `RoomGraphBase` vptr).
- Followup fixup commit `1bed032`: strengthens `test_enter_room_updates_camera_bounds` with 8 explicit assertions (using Camera2D's position-clamping behavior to prove `setBounds` and `setVerticalBounds` were both called for both rooms).

## Why
Phase 3 of the [top-down genre capability audit](../docs/audits/topdown-genre-capability-audit.md), item 5.6 (continuation of #183). The example is the minimal API demonstration a developer can copy-paste; bomberbot was evaluated and rejected for migration because it is a single-stage game (no room transitions exist) and uses `GridSpace` for cell-to-world math, which is the right primitive for its scope.

## Files (PR #3 base)
- `examples/room_screen/.gitignore`
- `examples/room_screen/.vscode/extensions.json`
- `examples/room_screen/README.md`
- `examples/room_screen/platformio.ini`
- `examples/room_screen/lib/platformio.ini`
- `examples/room_screen/src/main.cpp`
- `examples/room_screen/src/platforms/native.h`
- `examples/room_screen/src/platforms/esp32_dev.h`
- `examples/room_screen/src/GameConstants.h`
- `examples/room_screen/src/RoomScreenScene.h`
- `examples/room_screen/src/RoomScreenScene.cpp`
- `docs/architecture/memory-system.md` (+13)

## Followup fixup (`1bed032`)
- `test/unit/test_gameplay_room_graph/test_gameplay_room_graph.cpp` (+30 / -5)
- `docs/architecture/memory-system.md` (vptr row added to byte budget table)

## Migration line delta
Net +11 lines vs a naive 2-room Scene. Hard gate from the design was <= +20.

## Test plan
- `pio test -e native_test` - flag=0, passes (zero-cost property).
- `pio test -e native_test_gameplay` - flag=1, 1721/1722 pass (1 pre-existing bomberbot failure unrelated).
- Example builds clean on `pio run -e native`.

## Chain
This is PR #3 of 3 in a `feature-branch-chain`:
- PR #1 #182 -> `feature/top-down-games`
- PR #2 #183 -> `feat/room-screen-01-flag-and-tests`
- PR #3 (this) -> `feat/room-screen-02-scene-integration`

After this chain lands, the change is ready for `sdd-archive`.
