### PR TITLE
fix(physics): relax TileConsumptionHelper flag check + tests for non-collectible

### DIFF
--- a/include/physics/TileConsumptionHelper.h
+++ b/include/physics/TileConsumptionHelper.h
@@ -78,6 +78,8 @@ public:
      * 
      * Convenience method that unpacks userData and calls consumeTile().
      * This is the typical usage pattern from Phase 6 collision callbacks.
+     * Accepts any TileFlags combination — the caller is responsible
+     * for deciding which flags are consumable.
      * 
      * @param tileActor Pointer to the tile physics actor
      * @param packedUserData Packed userData from tileActor->getUserData()

--- a/src/physics/TileConsumptionHelper.cpp
+++ b/src/physics/TileConsumptionHelper.cpp
@@ -78,15 +78,7 @@ bool TileConsumptionHelper::consumeTileFromUserData(pixelroot32::core::Actor* ti
     TileFlags flags;
     unpackTileData(packedUserData, tileX, tileY, flags);
     
-    // Only consume collectible tiles (not solid, damage, or trigger tiles)
-    if (!(flags & TILE_COLLECTIBLE)) {
-        if (config.logConsumption) {
-            log("TileConsumptionHelper: Tile at (%d, %d) not collectible (flags: 0x%02X)", 
-                                         tileX, tileY, static_cast<uint8_t>(flags));
-        }
-        return false;
-    }
-    
+    // Any TileFlags combination is accepted — the caller decides which flags are consumable.
     return consumeTile(tileActor, tileX, tileY);
 }
 

--- a/test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp
+++ b/test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp
@@ -157,24 +157,79 @@ void test_consume_tile_from_userdata_zero(void) {
     TEST_ASSERT_FALSE(result);
 }
 
-void test_consume_tile_from_userdata_non_collectible(void) {
+// =============================================================================
+// consumeTileFromUserData — generalized flag acceptance tests (CU1)
+// =============================================================================
+
+void test_consume_tile_from_userdata_solid_flag(void) {
     MockScene scene;
-    TileConsumptionHelper helper(scene, nullptr, createDefaultConfig());
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
     
-    // Pack tile data with NO TILE_COLLECTIBLE flag
-    // Format: x (9 bits) | y (9 bits) | flags (upper bits)
-    uint16_t x = 5;
-    uint16_t y = 10;
-    uint16_t flags = 0;  // No collectible flag
-    
-    uintptr_t packed = (static_cast<uintptr_t>(flags) << 18) | 
-                       (static_cast<uintptr_t>(y) << 9) | 
-                       static_cast<uintptr_t>(x);
-    
+    uintptr_t packed = packTileData(5, 10, TILE_SOLID);
     bool result = helper.consumeTileFromUserData(nullptr, packed);
     
-    // Should fail because tile is not collectible
-    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_damage_flag(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    uintptr_t packed = packTileData(5, 10, TILE_DAMAGE);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_trigger_flag(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    uintptr_t packed = packTileData(5, 10, TILE_TRIGGER);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_oneway_flag(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    uintptr_t packed = packTileData(5, 10, TILE_ONEWAY);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_sensor_flag(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    uintptr_t packed = packTileData(5, 10, TILE_SENSOR);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_combined_flags(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    TileFlags flags = static_cast<TileFlags>(TILE_SOLID | TILE_COLLECTIBLE);
+    uintptr_t packed = packTileData(5, 10, flags);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
+}
+
+void test_consume_tile_from_userdata_no_flags(void) {
+    MockScene scene;
+    TileConsumptionHelper helper(scene, nullptr, createNoOpConfig());
+    
+    uintptr_t packed = packTileData(5, 10, TILE_NONE);
+    bool result = helper.consumeTileFromUserData(nullptr, packed);
+    
+    TEST_ASSERT_TRUE(result);
 }
 
 // =============================================================================
@@ -389,7 +444,15 @@ int main(void) {
     
     // consumeTileFromUserData tests
     RUN_TEST(test_consume_tile_from_userdata_zero);
-    RUN_TEST(test_consume_tile_from_userdata_non_collectible);
+    
+    // Generalized flag acceptance (CU1)
+    RUN_TEST(test_consume_tile_from_userdata_solid_flag);
+    RUN_TEST(test_consume_tile_from_userdata_damage_flag);
+    RUN_TEST(test_consume_tile_from_userdata_trigger_flag);
+    RUN_TEST(test_consume_tile_from_userdata_oneway_flag);
+    RUN_TEST(test_consume_tile_from_userdata_sensor_flag);
+    RUN_TEST(test_consume_tile_from_userdata_combined_flags);
+    RUN_TEST(test_consume_tile_from_userdata_no_flags);
     
     // isTileConsumed tests
     RUN_TEST(test_is_tile_consumed_with_nullptr_tilemap);


### PR DESCRIPTION
## Summary
- Removes the hard `TILE_COLLECTIBLE` gate from `consumeTileFromUserData` — any `TileFlags` combination is now accepted
- Adds 7 new unit tests for non-collectible flag consumption (SOLID, DAMAGE, TRIGGER, ONEWAY, SENSOR, combined, TILE_NONE)
- Removes obsolete `test_consume_tile_from_userdata_non_collectible` (replaced by `test_consume_tile_from_userdata_no_flags`)
- Updates Doxygen on `consumeTileFromUserData` to document the generalized behavior

## Chain Context
```
feature/top-down-games (tracker)
 └── 📍 PR #1: relax COLLECTIBLE gate (this PR)
      └── PR #2: add requiredHits + applyHit (next)
           └── PR #3: docs + memory budget (last)
```
Audit: `docs/audits/topdown-genre-capability-audit.md` §5.7

## Files
| File | Δ |
|------|-----|
| `src/physics/TileConsumptionHelper.cpp` | −8 lines (remove gate) |
| `include/physics/TileConsumptionHelper.h` | +2 lines (Doxygen) |
| `test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp` | +79/−22 lines (7 new tests) |

## Verification
```
pio test -e native_test -f "unit/test_tile_consumption_helper"
→ 27/27 PASSED (7 new + 20 existing)
```
