### PR TITLE
docs(physics): document TileConsumptionHelper multi-hit pattern + budget

### DIFF
--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -129,6 +129,8 @@ Total instance size is `N * sizeof(T) + bookkeeping`, plus up to `alignof(T) - 1
 
 **Non-atomic bus contract:** `gameplay::GameplayEventBus` is produced and consumed entirely inside the single-threaded `Scene::update()`/`Scene::draw()` loop driven from `SceneManager::update()`. Its head/tail/count indices are plain `uint16_t`, not `std::atomic` — unlike `AudioCommandQueue`, which bridges the game thread and the audio task. Publishing from an ISR or the audio task is **explicitly unsupported** and will corrupt the ring buffer's indices; it is not a replacement for `AudioCommandQueue`. Overflow policy is drop-newest with a monotonic `getDroppedCount()` diagnostic (preserves enter/exit pairing rather than risking a dangling `TriggerExit` for an evicted `TriggerEnter`). The bus is drained (`clear()`) on every `SceneManager::setCurrentScene()` call (including `SceneSwap` transitions), but **not** on `pushScene()`/`popScene()`, since a paused scene under an overlay never runs and should not lose events it expects to consume on resume.
 
+**`TileConsumptionConfig` byte budget:** the `requiredHits` field (added in `tile-consume-generalization`) adds **+1 byte** per config instance (`uint8_t`, default `1`). Typical call sites construct a stack-local `TileConsumptionConfig` per collision event, so the cost is one `uint8_t` on the stack, amortized per collision — no persistent SRAM cost.
+
 #### Subsystem Compilation Patterns
 
 **File-level guards:**

--- a/include/physics/TileConsumptionHelper.h
+++ b/include/physics/TileConsumptionHelper.h
@@ -157,8 +157,11 @@ private:
 /**
  * @brief Convenience function for consuming tiles from collision callbacks.
  * 
- * This is the typical usage pattern from Phase 6 onCollision callbacks:
- * ```cpp
+ * This is the typical usage pattern from Phase 6 onCollision callbacks.
+ * Accepts any TileFlags combination — the caller decides which tiles are consumable.
+ * 
+ * @code
+ * // Single-hit (instant consumption): default requiredHits=1
  * void onCollision(Actor* other) override {
  *     if (other->getUserData()) {
  *         uintptr_t packed = reinterpret_cast<uintptr_t>(other->getUserData());
@@ -166,12 +169,26 @@ private:
  *         TileFlags flags;
  *         unpackTileData(packed, x, y, flags);
  *         
- *         if (flags & TILE_COLLECTIBLE) {
- *             consumeTileFromCollision(other, packed, scene, tilemap);
+ *         // Caller decides which flags are consumable (e.g. any non-SOLID tile)
+ *         consumeTileFromCollision(other, packed, scene, tilemap);
+ *     }
+ * }
+ * 
+ * // Multi-hit breakable: use applyHit + consumeTile when remainingHits == 0
+ * void onCollision(Actor* other) override {
+ *     if (other->getUserData()) {
+ *         uintptr_t packed = reinterpret_cast<uintptr_t>(other->getUserData());
+ *         if (!breakableHitMap.contains(packed)) breakableHitMap[packed] = config.requiredHits;
+ *         uint8_t& remaining = breakableHitMap[packed];
+ *         if (applyHitFromCollision(other, packed, scene, tilemap, remaining, config)) {
+ *             if (remaining == 0) {
+ *                 consumeTileFromCollision(other, packed, scene, tilemap);
+ *                 breakableHitMap.erase(packed);
+ *             }
  *         }
  *     }
  * }
- * ```
+ * @endcode
  * 
  * @param tileActor Pointer to the tile physics actor
  * @param packedUserData Packed userData from tileActor


### PR DESCRIPTION
## Summary
- Updates `consumeTileFromCollision` Doxygen example to remove the COLLECTIBLE-only guard
- Documents the multi-hit `applyHit` → `consumeTile` workflow in the header example
- Adds `TileConsumptionConfig::requiredHits` byte-budget row (+1 B per stack-local config) to `docs/architecture/memory-system.md`

## Chain Context
```
feature/top-down-games (tracker)
 └── PR #1: relax COLLECTIBLE gate ✅
      └── PR #2: add requiredHits + applyHit ✅
           └── 📍 PR #3: docs + memory budget (this PR — last in chain)
```
Audit: `docs/audits/topdown-genre-capability-audit.md` §5.7

## Files
| File | Δ |
|------|----|
| `include/physics/TileConsumptionHelper.h` | +24/−5 lines (Doxygen refresh) |
| `docs/architecture/memory-system.md` | +2 lines (byte-budget row) |

## Verification
```
pio test -e native_test -f "unit/test_tile_consumption_helper"
→ 37/37 PASSED (no code change, docs only)
```
