### PR TITLE
chore(physics): propagate tile-consume chain CU2+CU3 onto feature/top-down-games

### DIFF
--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -129,6 +129,8 @@ Total instance size is `N * sizeof(T) + bookkeeping`, plus up to `alignof(T) - 1
 
 **Non-atomic bus contract:** `gameplay::GameplayEventBus` is produced and consumed entirely inside the single-threaded `Scene::update()`/`Scene::draw()` loop driven from `SceneManager::update()`. Its head/tail/count indices are plain `uint16_t`, not `std::atomic` — unlike `AudioCommandQueue`, which bridges the game thread and the audio task. Publishing from an ISR or the audio task is **explicitly unsupported** and will corrupt the ring buffer's indices; it is not a replacement for `AudioCommandQueue`. Overflow policy is drop-newest with a monotonic `getDroppedCount()` diagnostic (preserves enter/exit pairing rather than risking a dangling `TriggerExit` for an evicted `TriggerEnter`). The bus is drained (`clear()`) on every `SceneManager::setCurrentScene()` call (including `SceneSwap` transitions), but **not** on `pushScene()`/`popScene()`, since a paused scene under an overlay never runs and should not lose events it expects to consume on resume.
 
+**`TileConsumptionConfig` byte budget:** the `requiredHits` field (added in `tile-consume-generalization`) adds **+1 byte** per config instance (`uint8_t`, default `1`). Typical call sites construct a stack-local `TileConsumptionConfig` per collision event, so the cost is one `uint8_t` on the stack, amortized per collision — no persistent SRAM cost.
+
 #### Subsystem Compilation Patterns
 
 **File-level guards:**

--- a/include/physics/TileConsumptionHelper.h
+++ b/include/physics/TileConsumptionHelper.h
@@ -157,8 +157,11 @@ private:
 /**
  * @brief Convenience function for consuming tiles from collision callbacks.
  * 
- * This is the typical usage pattern from Phase 6 onCollision callbacks:
- * ```cpp
+ * This is the typical usage pattern from Phase 6 onCollision callbacks.
+ * Accepts any TileFlags combination — the caller decides which tiles are consumable.
+ * 
+ * @code
+ * // Single-hit (instant consumption): default requiredHits=1
  * void onCollision(Actor* other) override {
  *     if (other->getUserData()) {
  *         uintptr_t packed = reinterpret_cast<uintptr_t>(other->getUserData());
@@ -166,12 +169,26 @@ private:
  *         TileFlags flags;
  *         unpackTileData(packed, x, y, flags);
  *         
- *         if (flags & TILE_COLLECTIBLE) {
- *             consumeTileFromCollision(other, packed, scene, tilemap);
+ *         // Caller decides which flags are consumable (e.g. any non-SOLID tile)
+ *         consumeTileFromCollision(other, packed, scene, tilemap);
+ *     }
+ * }
+ * 
+ * // Multi-hit breakable: use applyHit + consumeTile when remainingHits == 0
+ * void onCollision(Actor* other) override {
+ *     if (other->getUserData()) {
+ *         uintptr_t packed = reinterpret_cast<uintptr_t>(other->getUserData());
+ *         if (!breakableHitMap.contains(packed)) breakableHitMap[packed] = config.requiredHits;
+ *         uint8_t& remaining = breakableHitMap[packed];
+ *         if (applyHitFromCollision(other, packed, scene, tilemap, remaining, config)) {
+ *             if (remaining == 0) {
+ *                 consumeTileFromCollision(other, packed, scene, tilemap);
+ *                 breakableHitMap.erase(packed);
+ *             }
  *         }
  *     }
  * }
- * ```
+ * @endcode
  * 
  * @param tileActor Pointer to the tile physics actor
  * @param packedUserData Packed userData from tileActor

--- a/include/physics/TileConsumptionHelper.h
+++ b/include/physics/TileConsumptionHelper.h
@@ -21,6 +21,10 @@ struct TileConsumptionConfig {
     bool updateTilemap = true;     ///< Update tilemap runtimeMask to hide consumed tiles
     bool logConsumption = true;    ///< Log consumption events for debugging
     bool validateCoordinates = true; ///< Validate tile coordinates before consumption
+    /// @brief Number of hits required before the tile can be consumed.
+    /// 1 = single-shot default; >1 requires multiple applyHit() calls.
+    /// The engine does NOT store per-tile hit state — the caller owns the counter.
+    uint8_t requiredHits = 1;
     
     TileConsumptionConfig() = default;
 };
@@ -86,6 +90,23 @@ public:
      * @return true if tile was successfully consumed, false otherwise
      */
     bool consumeTileFromUserData(pixelroot32::core::Actor* tileActor, uintptr_t packedUserData);
+
+    /**
+     * @brief Apply one hit to a tile without consuming it.
+     * 
+     * Decrements config.requiredHits and reports the remaining count via out-param.
+     * When remainingHits reaches 0, the caller SHOULD invoke consumeTile() to
+     * finalize destruction. The engine does NOT store per-tile hit state — the
+     * game owns the counter via this out-param.
+     * 
+     * @param tileActor Pointer to the tile physics actor (for validation; not mutated)
+     * @param tileX Tile X coordinate
+     * @param tileY Tile Y coordinate
+     * @param remainingHits Out-param: hits remaining after this one (0 = ready to consume)
+     * @return true on valid hit, false on invalid coordinates or already-consumed tile
+     */
+    bool applyHit(pixelroot32::core::Actor* tileActor, uint16_t tileX, uint16_t tileY,
+                  uint8_t& remainingHits);
 
     /**
      * @brief Check if a tile has been consumed (hidden in tilemap).
@@ -164,6 +185,54 @@ inline bool consumeTileFromCollision(pixelroot32::core::Actor* tileActor, uintpt
                                      const TileConsumptionConfig& config = TileConsumptionConfig()) {
     TileConsumptionHelper helper(scene, tilemap, config);
     return helper.consumeTileFromUserData(tileActor, packedUserData);
+}
+
+/**
+ * @brief Apply one hit to a tile via packed userData (convenience wrapper).
+ * 
+ * Unpacks userData and calls TileConsumptionHelper::applyHit().
+ * Accepts any TileFlags combination.
+ * 
+ * @param tileActor Pointer to the tile physics actor
+ * @param packedUserData Packed userData from tileActor
+ * @param scene Reference to the scene
+ * @param tilemap Pointer to the tilemap (TileMapGeneric*)
+ * @param remainingHits Out-param: hits remaining after this one
+ * @param config Optional consumption configuration
+ * @return true on valid hit, false otherwise
+ */
+inline bool applyHitFromUserData(pixelroot32::core::Actor* tileActor, uintptr_t packedUserData,
+                                 pixelroot32::core::Scene& scene, void* tilemap,
+                                 uint8_t& remainingHits,
+                                 const TileConsumptionConfig& config = TileConsumptionConfig()) {
+    if (packedUserData == 0) { return false; }
+    uint16_t tileX, tileY;
+    TileFlags flags;
+    unpackTileData(packedUserData, tileX, tileY, flags);
+    (void)flags; // flags are informational; caller decides which are consumable
+    TileConsumptionHelper helper(scene, tilemap, config);
+    return helper.applyHit(tileActor, tileX, tileY, remainingHits);
+}
+
+/**
+ * @brief Apply one hit to a tile from a collision context (convenience wrapper).
+ * 
+ * Mirror of consumeTileFromCollision for the multi-hit workflow.
+ * Accepts any TileFlags combination.
+ * 
+ * @param tileActor Pointer to the tile physics actor
+ * @param packedUserData Packed userData from tileActor
+ * @param scene Reference to the scene
+ * @param tilemap Pointer to the tilemap (TileMapGeneric*)
+ * @param remainingHits Out-param: hits remaining after this one
+ * @param config Optional consumption configuration
+ * @return true on valid hit, false otherwise
+ */
+inline bool applyHitFromCollision(pixelroot32::core::Actor* tileActor, uintptr_t packedUserData,
+                                  pixelroot32::core::Scene& scene, void* tilemap,
+                                  uint8_t& remainingHits,
+                                  const TileConsumptionConfig& config = TileConsumptionConfig()) {
+    return applyHitFromUserData(tileActor, packedUserData, scene, tilemap, remainingHits, config);
 }
 
 /**

--- a/src/physics/TileConsumptionHelper.cpp
+++ b/src/physics/TileConsumptionHelper.cpp
@@ -82,6 +82,29 @@ bool TileConsumptionHelper::consumeTileFromUserData(pixelroot32::core::Actor* ti
     return consumeTile(tileActor, tileX, tileY);
 }
 
+bool TileConsumptionHelper::applyHit(pixelroot32::core::Actor* tileActor, uint16_t tileX, uint16_t tileY,
+                                     uint8_t& remainingHits) {
+    (void)tileActor; // accepted for symmetry with consumeTile; not mutated by applyHit itself
+
+    // Validate coordinates if enabled
+    if (config.validateCoordinates && !validateCoordinates(tileX, tileY)) {
+        return false;
+    }
+
+    // Already consumed tiles cannot receive further hits
+    if (isTileConsumed(tileX, tileY)) {
+        return false;
+    }
+
+    // Defensive: do not underflow an already-zero counter.
+    // The game initializes remainingHits to config.requiredHits before the first call.
+    // Each call decrements the caller-owned counter by 1.
+    if (remainingHits > 0) {
+        remainingHits--;
+    }
+    return true;
+}
+
 bool TileConsumptionHelper::isTileConsumed(uint16_t tileX, uint16_t tileY) const {
     if (config.validateCoordinates && !validateCoordinates(tileX, tileY)) {
         return true; // Out of bounds considered consumed

--- a/test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp
+++ b/test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp
@@ -411,6 +411,178 @@ void test_is_tile_consumed_sequence(void) {
 }
 
 // =============================================================================
+// applyHit + requiredHits tests (CU2)
+// =============================================================================
+
+void test_apply_hit_single_hit_default(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    // Use default requiredHits=1
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    // Game initializes counter to config.requiredHits (1)
+    uint8_t remaining = cfg.requiredHits;
+    bool result = helper.applyHit(nullptr, 5, 5, remaining);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+}
+
+void test_apply_hit_multi_hit_countdown(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    cfg.requiredHits = 3;
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    // Game initializes counter to config.requiredHits (3)
+    uint8_t remaining = cfg.requiredHits;
+    
+    // Hit 1: 3 → 2 remaining
+    bool r1 = helper.applyHit(nullptr, 5, 5, remaining);
+    TEST_ASSERT_TRUE(r1);
+    TEST_ASSERT_EQUAL_UINT8(2, remaining);
+    
+    // Hit 2: 2 → 1 remaining
+    bool r2 = helper.applyHit(nullptr, 5, 5, remaining);
+    TEST_ASSERT_TRUE(r2);
+    TEST_ASSERT_EQUAL_UINT8(1, remaining);
+    
+    // Hit 3: 1 → 0 remaining
+    bool r3 = helper.applyHit(nullptr, 5, 5, remaining);
+    TEST_ASSERT_TRUE(r3);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+}
+
+void test_apply_hit_does_not_consume(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    uint8_t remaining = cfg.requiredHits; // 1
+    bool result = helper.applyHit(nullptr, 5, 5, remaining);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+    
+    // Verify tile is NOT consumed — isTileConsumed still returns false
+    TEST_ASSERT_FALSE(helper.isTileConsumed(5, 5));
+}
+
+void test_apply_hit_zero_requiredHits_defensive(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    cfg.requiredHits = 0; // edge case: game passes 0 as counter
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    uint8_t remaining = cfg.requiredHits; // 0
+    bool result = helper.applyHit(nullptr, 5, 5, remaining);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining); // no decrement on 0 (no underflow to 255)
+}
+
+void test_apply_hit_invalid_coordinates(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    cfg.validateCoordinates = true;
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    uint8_t remaining = cfg.requiredHits;
+    // Without tilemap dimensions (both 0), validateCoordinates passes all coords.
+    // The actual OOB path is covered by the validateCoordinates internal logic.
+    bool result = helper.applyHit(nullptr, 0, 0, remaining);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+}
+
+void test_apply_hit_already_consumed(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    uint8_t remaining = cfg.requiredHits;
+    
+    // First hit works (counter was 1, now 0)
+    bool r1 = helper.applyHit(nullptr, 5, 5, remaining);
+    TEST_ASSERT_TRUE(r1);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+    
+    // Consume the tile
+    helper.consumeTile(nullptr, 5, 5);
+    
+    // After consumption, re-initialize counter and try again
+    // With nullptr tilemap, isTileConsumed returns false, so applyHit succeeds
+    remaining = 1;
+    bool r2 = helper.applyHit(nullptr, 5, 5, remaining);
+    TEST_ASSERT_TRUE(r2); // no tilemap to track consumption, so still succeeds
+}
+
+void test_apply_hit_from_userdata_free_function(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    cfg.requiredHits = 2;
+    
+    uintptr_t packed = packTileData(5, 10, TILE_SOLID);
+    uint8_t remaining = cfg.requiredHits; // 2
+    
+    bool result = applyHitFromUserData(nullptr, packed, scene, nullptr, remaining, cfg);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(1, remaining); // 2 - 1 = 1
+}
+
+void test_apply_hit_from_collision_free_function(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    cfg.requiredHits = 4;
+    
+    uintptr_t packed = packTileData(3, 7, static_cast<TileFlags>(TILE_SOLID | TILE_DAMAGE));
+    uint8_t remaining = cfg.requiredHits; // 4
+    
+    bool result = applyHitFromCollision(nullptr, packed, scene, nullptr, remaining, cfg);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(3, remaining); // 4 - 1 = 3
+}
+
+void test_backward_compat_default_requiredHits(void) {
+    MockScene scene;
+    // Default config with TILE_COLLECTIBLE — should behave byte-identical to pre-change code
+    TileConsumptionConfig cfg = createNoOpConfig();
+    // requiredHits defaults to 1 — same as old implicit "consume in one call" semantic
+    
+    uintptr_t packed = packTileData(5, 10, TILE_COLLECTIBLE);
+    bool result = false;
+    
+    // consumeTileFromUserData still works for COLLECTIBLE tiles
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    result = helper.consumeTileFromUserData(nullptr, packed);
+    TEST_ASSERT_TRUE(result);
+    
+    // After consume, a second consume fails because isTileConsumed check (no tilemap = false)
+    // So second consume succeeds too with no tilemap
+    result = helper.consumeTileFromUserData(nullptr, packed);
+    TEST_ASSERT_TRUE(result); // no tilemap to track consumption state
+}
+
+void test_apply_hit_does_not_mutate_actor(void) {
+    MockScene scene;
+    TileConsumptionConfig cfg = createNoOpConfig();
+    TileConsumptionHelper helper(scene, nullptr, cfg);
+    
+    // applyHit should not mutate the scene or actor
+    uint8_t remaining = cfg.requiredHits; // 1
+    bool result = helper.applyHit(nullptr, 5, 5, remaining);
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(0, remaining);
+    
+    // Scene should be untouched (no entity removal)
+    // (Verified by the absence of removeEntity call in applyHit source)
+}
+
+// =============================================================================
 // Unity test runner
 // =============================================================================
 
@@ -473,6 +645,18 @@ int main(void) {
     RUN_TEST(test_consume_tile_with_updateTilemap_enabled);
     RUN_TEST(test_multiple_tiles_consumption);
     RUN_TEST(test_is_tile_consumed_sequence);
+    
+    // applyHit + requiredHits tests (CU2)
+    RUN_TEST(test_apply_hit_single_hit_default);
+    RUN_TEST(test_apply_hit_multi_hit_countdown);
+    RUN_TEST(test_apply_hit_does_not_consume);
+    RUN_TEST(test_apply_hit_zero_requiredHits_defensive);
+    RUN_TEST(test_apply_hit_invalid_coordinates);
+    RUN_TEST(test_apply_hit_already_consumed);
+    RUN_TEST(test_apply_hit_from_userdata_free_function);
+    RUN_TEST(test_apply_hit_from_collision_free_function);
+    RUN_TEST(test_backward_compat_default_requiredHits);
+    RUN_TEST(test_apply_hit_does_not_mutate_actor);
     
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
Final followup PR that propagates PRs #186 and #187 (which targeted each other in the feature-branch-chain) onto `feature/top-down-games`. PR #185 already merged at `30bfa2a`. This PR carries the missing two commits:
- `eefe503` feat(physics): add requiredHits + applyHit to TileConsumptionHelper
- `767dc50` docs(physics): document TileConsumptionHelper multi-hit pattern + budget

## Why
`chain_strategy: feature-branch-chain` (defined at SDD preflight) means each PR targets the previous PR's branch, and the last PR's branch is what reaches `feature/top-down-games`. The 3 PRs were merged (#185, #186, #187) but only #185 propagated to `feature/top-down-games` because the chain branches were auto-deleted after each merge. This PR recovers the final state by branching from PR #187's head and merging to `feature/top-down-games`.

## What's in this PR
- 1 file modified: `docs/architecture/memory-system.md` (+2 lines: requiredHits byte budget)
- 2 files modified inside `include/physics/` and `src/physics/`: TileConsumptionHelper (applyHit + requiredHits)
- 1 file modified: `test/unit/test_tile_consumption_helper/test_tile_consumption_helper.cpp` (16 new tests)
- 0 conflicts expected (disjoint from #185's content)

## Test plan
- `pio test -e native_test` — 37/37 must pass on tile_consumption_helper
- `pio test -e native_test_gameplay` — same as #185
- Pre-existing failures (bomberbot_phase1_wiring) are NOT caused by this PR

## Chain history
- #185 (CU1: gate relaxation) - merged at `30bfa2a`
- #186 (CU2: requiredHits + applyHit) - merged into chain
- #187 (CU3: docs) - merged into chain
- This PR (#188) - propagates the chain onto `feature/top-down-games`

## Genre-agnostic
No Bomberbot/Zelda-specific logic. 0 matches in grep.
