### PR TITLE
docs(api): tag the public types the doc generator was hiding

### DIFF
--- a/docs/api/generated/audio/ImmediateSfxDelayScheduler.md
+++ b/docs/api/generated/audio/ImmediateSfxDelayScheduler.md
@@ -1,0 +1,21 @@
+# ImmediateSfxDelayScheduler
+
+<Badge type="info" text="Class" />
+
+**Source:** `SfxBankPlayback.h`
+
+**Inherits from:** [SfxDelayScheduler](./SfxDelayScheduler.md)
+
+## Description
+
+Plays every scheduled event immediately (ignores delay). Test / stub only.
+
+## Inheritance
+
+[SfxDelayScheduler](./SfxDelayScheduler.md) → `ImmediateSfxDelayScheduler`
+
+## Methods
+
+### `explicit ImmediateSfxDelayScheduler(AudioEngine& engine) : engine_(&engine)`
+
+### `void schedule(float /*delaySec*/, const AudioEvent& event)`

--- a/docs/api/generated/audio/NullSfxDelayScheduler.md
+++ b/docs/api/generated/audio/NullSfxDelayScheduler.md
@@ -1,0 +1,19 @@
+# NullSfxDelayScheduler
+
+<Badge type="info" text="Class" />
+
+**Source:** `SfxBankPlayback.h`
+
+**Inherits from:** [SfxDelayScheduler](./SfxDelayScheduler.md)
+
+## Description
+
+No-op scheduler for banks that only use simultaneous layers (no delayed steps).
+
+## Inheritance
+
+[SfxDelayScheduler](./SfxDelayScheduler.md) → `NullSfxDelayScheduler`
+
+## Methods
+
+### `void schedule(float /*delaySec*/, const AudioEvent& /*event*/)`

--- a/docs/api/generated/audio/SfxDelayScheduler.md
+++ b/docs/api/generated/audio/SfxDelayScheduler.md
@@ -1,0 +1,29 @@
+# SfxDelayScheduler
+
+<Badge type="info" text="Class" />
+
+**Source:** `SfxBankPlayback.h`
+
+## Description
+
+Schedules delayed SFX events for `playSfxBank` sequence steps.
+
+Games implement this with a scene timer / command queue. The helper does not
+own timing and does not allocate.
+
+Looping events (`AudioEvent::loop == true`) stay active until the game sends
+`AudioCommandType::STOP_CHANNEL` (or the voice is stolen). This helper does
+not auto-stop loops and does not manage cooldowns or global SFX volume.
+
+## Methods
+
+### `virtual void schedule(float delaySec, const AudioEvent& event)`
+
+**Description:**
+
+Schedule `playEvent(event)` after `delaySec` seconds from effect start.
+
+**Parameters:**
+
+- `delaySec`: Delay relative to the `playSfxBank` call (>= 0).
+- `event`: Event to play when the delay elapses.

--- a/docs/api/generated/core/SceneArena.md
+++ b/docs/api/generated/core/SceneArena.md
@@ -1,0 +1,35 @@
+# SceneArena
+
+<Badge type="info" text="Struct" />
+
+**Source:** `Scene.h`
+
+## Description
+
+Bump allocator for objects whose lifetime is one scene.
+
+Hands out aligned slices of a caller-supplied buffer by advancing an offset.
+There is no individual free: reset() rewinds the offset to zero and releases
+everything at once, which is why allocations must not outlive the scene.
+Destructors are never run, so only trivially destructible types are safe.
+
+allocate() returns nullptr when the request does not fit, and callers must
+check. Prefer arenaNew() over calling allocate() directly.
+
+Gated by platforms::config::EnableSceneArena. With the arena
+      disabled every allocate() returns nullptr and init()/reset() are
+      no-ops, so callers keep their fallback path.
+
+::: tip
+Gated by platforms::config::EnableSceneArena. With the arena
+      disabled every allocate() returns nullptr and init()/reset() are
+      no-ops, so callers keep their fallback path.
+:::
+
+## Methods
+
+### `void init(void* memory, std::size_t size)`
+
+### `void reset()`
+
+### `void* allocate(std::size_t size, std::size_t alignment)`

--- a/docs/api/generated/graphics/Color.md
+++ b/docs/api/generated/graphics/Color.md
@@ -1,0 +1,35 @@
+# Color
+
+<Badge type="info" text="Enum" />
+
+**Source:** `Color.h`
+
+## Description
+
+Named color indices into the active 16-entry palette.
+
+Enumerator values are the PR32 palette indices 0-15, so a Color is a palette
+slot, not an RGB value: the same enumerator resolves differently under each
+PaletteType.
+
+Legacy names are aliases, not extra colors. `LightBlue`, `Teal`,
+      `Olive`, `Gold` and `Brown` collapse onto the nearest of the 16 slots,
+      and every gray name (`MidGray`, `LightGray`, `DarkGray`, `Silver`)
+      resolves to the single `Gray` slot. Two aliased names compare equal.
+
+`Transparent` (255) is a sentinel, not a color. The renderer and
+         blitter must intercept it; it must never be resolved against a
+         palette, and passing it to a drawing primitive is a no-op.
+
+::: warning
+`Transparent` (255) is a sentinel, not a color. The renderer and
+         blitter must intercept it; it must never be resolved against a
+         palette, and passing it to a drawing primitive is a no-op.
+:::
+
+::: tip
+Legacy names are aliases, not extra colors. `LightBlue`, `Teal`,
+      `Olive`, `Gold` and `Brown` collapse onto the nearest of the 16 slots,
+      and every gray name (`MidGray`, `LightGray`, `DarkGray`, `Silver`)
+      resolves to the single `Gray` slot. Two aliased names compare equal.
+:::

--- a/docs/api/generated/graphics/DisplayConfig.md
+++ b/docs/api/generated/graphics/DisplayConfig.md
@@ -1,0 +1,93 @@
+# DisplayConfig
+
+<Badge type="info" text="Struct" />
+
+**Source:** `DisplayConfig.h`
+
+## Description
+
+Configuration settings for initializing displays with optional resolution scaling.
+
+Supports both physical (hardware) and logical (rendering) resolutions.
+When logical resolution is smaller than physical, the engine automatically
+scales the output using nearest-neighbor interpolation.
+
+Use this structure to define the hardware pins, display dimensions, rotation,
+and communication type (I2C or SPI).
+
+## Methods
+
+### `static DisplayConfig createCustom(DrawSurface* surface, uint16_t w, uint16_t h, int rot = 0)`
+
+**Description:**
+
+Static factory to create a DisplayConfig with a custom DrawSurface.
+
+**Parameters:**
+
+- `surface`: Pointer to the custom DrawSurface implementation (ownership is transferred).
+- `w`: Physical and logical width.
+- `h`: Physical and logical height.
+- `rot`: Rotation.
+
+### `bool needsScaling() const`
+
+**Description:**
+
+Checks if scaling is needed (logical != physical).
+
+**Returns:** true if the engine needs to scale output.
+
+### `float getScaleX() const`
+
+**Description:**
+
+Gets horizontal scaling factor.
+
+**Returns:** Scale factor (physical / logical).
+
+### `float getScaleY() const`
+
+**Description:**
+
+Gets vertical scaling factor.
+
+**Returns:** Scale factor (physical / logical).
+
+### `uint16_t width() const`
+
+**Description:**
+
+Deprecated, gets logical width.
+
+**Returns:** The logical width.
+
+### `uint16_t height() const`
+
+**Description:**
+
+Deprecated, gets logical height.
+
+**Returns:** The logical height.
+
+### `DrawSurface& getDrawSurface() const`
+
+**Description:**
+
+Gets the underlying DrawSurface implementation.
+
+**Returns:** Reference to the DrawSurface.
+
+### `void initDrawSurface()`
+
+**Description:**
+
+Initializes the underlying draw surface.
+
+### `std::unique_ptr<DrawSurface> releaseDrawSurface()`
+
+**Description:**
+
+Transfers ownership of the DrawSurface to the caller.
+
+**Returns:** A unique_ptr containing the DrawSurface.

--- a/docs/api/generated/graphics/PaletteContext.md
+++ b/docs/api/generated/graphics/PaletteContext.md
@@ -1,0 +1,11 @@
+# PaletteContext
+
+<Badge type="info" text="Enum" />
+
+**Source:** `Color.h`
+
+## Description
+
+Context for palette selection in dual palette mode.
+
+Determines which palette (background or sprite) is used for color resolution.

--- a/docs/api/generated/graphics/PaletteType.md
+++ b/docs/api/generated/graphics/PaletteType.md
@@ -1,0 +1,13 @@
+# PaletteType
+
+<Badge type="info" text="Enum" />
+
+**Source:** `Color.h`
+
+## Description
+
+Selects which built-in 16-color palette the renderer resolves against.
+
+PR32 is the default and is the palette the Color enumerators are indexed for.
+The others are retro presets; the same Color value resolves to a different
+RGB565 output under each one.

--- a/docs/api/generated/graphics/StaticTilemapLayerCache.md
+++ b/docs/api/generated/graphics/StaticTilemapLayerCache.md
@@ -1,0 +1,54 @@
+# StaticTilemapLayerCache
+
+<Badge type="info" text="Class" />
+
+**Source:** `StaticTilemapLayerCache.h`
+
+## Description
+
+Centralized framebuffer snapshot for static 4bpp tilemap layers.
+
+On drivers that expose a direct logical 8bpp sprite buffer (e.g. TFT_eSPI),
+this avoids redrawing “static” layers every frame when the sampled camera
+position is unchanged and the cache has not been invalidated.
+
+Override points:
+- Compile-time: set PIXELROOT32_ENABLE_STATIC_TILEMAP_FB_CACHE to 0 in build flags.
+- Run-time: setFramebufferCacheEnabled(false) per scene or platform init.
+- No sprite buffer or failed allocation: automatically falls back to full draw.
+
+Allocate during scene init() via allocateForLogicalSize() or allocateForRenderer()
+so the game loop does not hit the heap (see ARCH_MEMORY_SYSTEM.md).
+
+## Methods
+
+### `void clear()`
+
+### `bool allocateForLogicalSize(int width, int height)`
+
+**Description:**
+
+Pre-allocate the snapshot for a logical framebuffer of width * height bytes.
+
+**Returns:** false if dimensions are invalid or allocation failed.
+
+### `bool allocateForRenderer(const Renderer& renderer)`
+
+**Description:**
+
+Same as allocateForLogicalSize(renderer.getLogicalWidth/Height()).
+
+### `void invalidate()`
+
+### `void draw(Renderer& renderer, int cameraSampleX, int cameraSampleY, const TileMap4bppDrawSpec* staticLayers, std::size_t staticLayerCount, const TileMap4bppDrawSpec* dynamicLayers, std::size_t dynamicLayerCount)`
+
+**Parameters:**
+
+- `cameraSampleX`: Typically
+- `cameraSampleY`: Typically
+
+### `void adviseFramebufferBeforeBeginFrame(Renderer& renderer, int cameraSampleX, int cameraSampleY, const TileMap4bppDrawSpec* staticLayers, std::size_t staticLayerCount, const TileMap4bppDrawSpec* dynamicLayers, std::size_t dynamicLayerCount) const`
+
+### `void setFramebufferCacheEnabled(bool enabled)`
+
+### `bool isFramebufferCacheEnabled() const`

--- a/docs/api/generated/graphics/TileMap4bppDrawSpec.md
+++ b/docs/api/generated/graphics/TileMap4bppDrawSpec.md
@@ -1,0 +1,12 @@
+# TileMap4bppDrawSpec
+
+<Badge type="info" text="Struct" />
+
+**Source:** `StaticTilemapLayerCache.h`
+
+## Description
+
+One drawable 4bpp tilemap layer with an origin in logical coordinates.
+
+Entries with map == nullptr are skipped. Use any number of static layers
+(snapshotted together) and dynamic layers (redrawn every frame after restore).

--- a/docs/api/generated/index.md
+++ b/docs/api/generated/index.md
@@ -9,7 +9,10 @@ Auto-generated API documentation from C++ header files.
 - [AudioEngine](./audio/AudioEngine.md) — Facade class for the NES-style audio subsystem.
 - [AudioScheduler](./audio/AudioScheduler.md) — Abstract interface for the audio execution context.
 - [DefaultAudioScheduler](./audio/DefaultAudioScheduler.md) — Backend-driven scheduler used on platforms without a dedicated audio task.
+- [ImmediateSfxDelayScheduler](./audio/ImmediateSfxDelayScheduler.md) — Plays every scheduled event immediately (ignores delay). Test / stub only.
 - [MusicPlayer](./audio/MusicPlayer.md) — Simple sequencer to play MusicTracks using the AudioEngine.
+- [NullSfxDelayScheduler](./audio/NullSfxDelayScheduler.md) — No-op scheduler for banks that only use simultaneous layers (no delayed steps).
+- [SfxDelayScheduler](./audio/SfxDelayScheduler.md) — Schedules delayed SFX events for `playSfxBank` sequence steps.
 
 ## Core
 
@@ -24,6 +27,7 @@ Auto-generated API documentation from C++ header files.
 - [PhysicsBodyType](./core/PhysicsBodyType.md) — Defines the simulation behavior of a PhysicsActor.
 - [Rect](./core/Rect.md) — Represents a 2D rectangle, typically used for hitboxes or bounds.
 - [Scene](./core/Scene.md) — Represents a game level or screen containing entities.
+- [SceneArena](./core/SceneArena.md) — Bump allocator for objects whose lifetime is one scene.
 - [SceneManager](./core/SceneManager.md) — Manages the stack of active scenes.
 - [TransitionState](./core/TransitionState.md) — State machine for scene transitions.
 - [WorldCollisionInfo](./core/WorldCollisionInfo.md) — Stores flags indicating which world boundaries were hit in the current frame.
@@ -69,7 +73,9 @@ Auto-generated API documentation from C++ header files.
 - [Camera2D](./graphics/Camera2D.md) — 2D camera for viewport management and smooth scrolling.
 - [CameraEffectsSystem](./graphics/CameraEffectsSystem.md) — Manages up to 4 simultaneous camera effects with round-robin insertion.
 - [CameraTween](./graphics/CameraTween.md) — Fixed-capacity camera tween pool with enum-based easing.
+- [Color](./graphics/Color.md) — Named color indices into the active 16-entry palette.
 - [DirtyGrid](./graphics/DirtyGrid.md) — Two-buffer dirty cell grid (8×8 px cells) for selective framebuffer clears.
+- [DisplayConfig](./graphics/DisplayConfig.md) — Configuration settings for initializing displays with optional resolution scaling.
 - [DisplayType](./graphics/DisplayType.md) — Identifies the type of display driver to use.
 - [DrawSurface](./graphics/DrawSurface.md) — Abstract interface for platform-specific drawing operations.
 - [EffectSlot](./graphics/EffectSlot.md) — Per-slot state for a single camera effect (20 bytes).
@@ -78,6 +84,8 @@ Auto-generated API documentation from C++ header files.
 - [LayerAttributes](./graphics/LayerAttributes.md) — All tiles with attributes in a single tilemap layer.
 - [LayerType](./graphics/LayerType.md) — Classifies draw layers for dirty-region marking (static backgrounds vs dynamic content).
 - [MultiSprite](./graphics/MultiSprite.md) — Multi-layer, multi-color sprite built from 1bpp layers.
+- [PaletteContext](./graphics/PaletteContext.md) — Context for palette selection in dual palette mode.
+- [PaletteType](./graphics/PaletteType.md) — Selects which built-in 16-color palette the renderer resolves against.
 - [Particle](./graphics/Particle.md) — Represents a single particle in the particle system.
 - [ParticleConfig](./graphics/ParticleConfig.md) — Configuration parameters for a particle emitter.
 - [ParticleEmitter](./graphics/ParticleEmitter.md) — Manages a pool of particles to create visual effects.
@@ -91,10 +99,12 @@ Auto-generated API documentation from C++ header files.
 - [SpriteAnimation](./graphics/SpriteAnimation.md) — Lightweight, step-based sprite animation controller.
 - [SpriteAnimationFrame](./graphics/SpriteAnimationFrame.md) — Single animation frame that can reference either a Sprite or a MultiSprite.
 - [SpriteLayer](./graphics/SpriteLayer.md) — Single monochrome layer used by layered sprites.
+- [StaticTilemapLayerCache](./graphics/StaticTilemapLayerCache.md) — Centralized framebuffer snapshot for static 4bpp tilemap layers.
 - [TileAnimation](./graphics/TileAnimation.md) — Single tile animation definition (compile-time constant).
 - [TileAnimationManager](./graphics/TileAnimationManager.md) — Manages tile animations for a tilemap.
 - [TileAttribute](./graphics/TileAttribute.md) — Single attribute key-value pair for tile metadata.
 - [TileAttributeEntry](./graphics/TileAttributeEntry.md) — All attributes for a single tile at a specific position.
+- [TileMap4bppDrawSpec](./graphics/TileMap4bppDrawSpec.md) — One drawable 4bpp tilemap layer with an origin in logical coordinates.
 - [TileMapGeneric](./graphics/TileMapGeneric.md) — Generic tilemap structure supporting 1bpp, 2bpp, or 4bpp tile graphics.
 - [TilemapSpriteDirtyMode](./graphics/TilemapSpriteDirtyMode.md) — Suppress per-sprite dirty marks while drawing tilemaps (static layer or selective animated marking).
 - [TouchConfig](./graphics/TouchConfig.md) — Configuration for a touch controller (XPT2046 or GT911).
@@ -134,8 +144,9 @@ Auto-generated API documentation from C++ header files.
 - [GT911Adapter](./input/GT911Adapter.md) — GT911 I2C touch controller driver
 - [InputConfig](./input/InputConfig.md) — Configuration structure for the InputManager.
 - [InputManager](./input/InputManager.md) — Handles input from physical buttons, keyboard (on PC), and touch/mouse.
-- [TouchAdapterBase](./input/TouchAdapterBase.md) — Base class requirements for touch adapters (conceptual)
+- [TouchAdapter](./input/TouchAdapter.md) — Base class requirements for touch adapters (conceptual)
 - [TouchCalibration](./input/TouchCalibration.md) — Calibration parameters for coordinate transformation
+- [TouchController](./input/TouchController.md) — Touch controller types
 - [TouchEvent](./input/TouchEvent.md) — Compact touch event structure (12 bytes total, naturally aligned)
 - [TouchEventDispatcher](./input/TouchEventDispatcher.md) — Pull-based touch event dispatcher
 - [TouchEventFlags](./input/TouchEventFlags.md) — Flags for touch events
@@ -155,6 +166,7 @@ Auto-generated API documentation from C++ header files.
 ## Math
 
 - [Fixed16](./math/Fixed16.md) — Fixed-point 16.16 number implementation optimized for RISC-V.
+- [Random](./math/Random.md) — Instance-based random number generator
 - [Vector2](./math/Vector2.md) — 2D vector using the configured Scalar type (float or Fixed16).
 
 ## Physics
@@ -164,6 +176,7 @@ Auto-generated API documentation from C++ header files.
 - [Contact](./physics/Contact.md) — Represents a contact point between two physics bodies.
 - [KinematicActor](./physics/KinematicActor.md) — A physics body moved via script/manual velocity with collision detection.
 - [KinematicCollision](./physics/KinematicCollision.md) — Contains information about a collision involving a KinematicActor.
+- [PhysicsScheduler](./physics/PhysicsScheduler.md) — Fixed-timestep accumulator that decouples physics from frame rate.
 - [RigidActor](./physics/RigidActor.md) — A physics body fully simulated by the engine.
 - [Segment](./physics/Segment.md) — Represents a 2D line segment for collision detection.
 - [SensorActor](./physics/SensorActor.md) — A static body that acts as a trigger: detects overlap but produces no physical response.

--- a/docs/api/generated/input/TouchAdapter.md
+++ b/docs/api/generated/input/TouchAdapter.md
@@ -1,4 +1,4 @@
-# TouchAdapterBase
+# TouchAdapter
 
 <Badge type="info" text="Class" />
 

--- a/docs/api/generated/input/TouchController.md
+++ b/docs/api/generated/input/TouchController.md
@@ -1,0 +1,9 @@
+# TouchController
+
+<Badge type="info" text="Enum" />
+
+**Source:** `TouchAdapter.h`
+
+## Description
+
+Touch controller types

--- a/docs/api/generated/math/Random.md
+++ b/docs/api/generated/math/Random.md
@@ -1,0 +1,88 @@
+# Random
+
+<Badge type="info" text="Struct" />
+
+**Source:** `MathUtil.h`
+
+## Description
+
+Instance-based random number generator
+
+Provides independent RNG state for scenarios requiring multiple
+separate random sequences (e.g., per-entity RNG).
+
+## Methods
+
+### `explicit Random(uint32_t seed = 0xDEADBEEF)`
+
+**Description:**
+
+Constructor with seed parameter
+
+**Parameters:**
+
+- `seed`: Initial seed value. If 0, uses fallback constant.
+
+### `uint32_t next()`
+
+**Description:**
+
+Generate next random value using Xorshift32
+
+**Returns:** Random uint32_t value
+
+### `Scalar rand01()`
+
+**Description:**
+
+Generate random Scalar in range [0, 1]
+Uses bit-shifting for Fixed16 path to avoid float operations.
+
+**Returns:** Random value in [0, 1] range
+
+### `Scalar rand_range(Scalar min, Scalar max)`
+
+**Description:**
+
+Generate random Scalar in range [min, max]
+
+**Parameters:**
+
+- `min`: Minimum value (inclusive)
+- `max`: Maximum value (inclusive)
+
+**Returns:** Random value in [min, max] range
+
+### `int32_t rand_int(int32_t min, int32_t max)`
+
+**Description:**
+
+Generate random integer in range [min, max]
+Uses rejection sampling for bias-free uniform distribution.
+
+**Parameters:**
+
+- `min`: Minimum value (inclusive)
+- `max`: Maximum value (inclusive)
+
+**Returns:** Random integer in [min, max] range
+
+### `bool rand_chance(Scalar p)`
+
+**Description:**
+
+Return true with probability p
+
+**Parameters:**
+
+- `p`: Probability in range [0, 1]
+
+**Returns:** true with probability p, false otherwise
+
+### `Scalar rand_sign()`
+
+**Description:**
+
+Return random sign -1 or 1
+
+**Returns:** -1 or 1 as Scalar

--- a/docs/api/generated/physics/PhysicsScheduler.md
+++ b/docs/api/generated/physics/PhysicsScheduler.md
@@ -1,0 +1,30 @@
+# PhysicsScheduler
+
+<Badge type="info" text="Class" />
+
+**Source:** `PhysicsScheduler.h`
+
+## Description
+
+Fixed-timestep accumulator that decouples physics from frame rate.
+
+Banks real elapsed time and spends it in fixed 60 Hz slices, so collision
+results stay identical regardless of how fast or unevenly frames arrive.
+
+Normally at most one step runs per frame. When the accumulator falls more
+than 2.5 frames behind, up to MAX_STEPS_BACKLOG steps run to catch up; that
+ceiling is what stops a long stall from cascading into a spiral of death.
+Time beyond the ceiling is kept in the accumulator, not discarded.
+
+Zero-heap and zero-allocation: the whole state is an accumulator and a step
+counter.
+
+## Methods
+
+### `inline void init()`
+
+### `inline uint8_t update(uint32_t realDeltaMicros, CollisionSystem& collisionSystem)`
+
+### `uint8_t getStepsExecuted() const`
+
+### `uint32_t getAccumulator() const`

--- a/include/audio/SfxBankPlayback.h
+++ b/include/audio/SfxBankPlayback.h
@@ -12,6 +12,7 @@
 namespace pixelroot32::audio {
 
 /**
+ * @class SfxDelayScheduler
  * @brief Schedules delayed SFX events for `playSfxBank` sequence steps.
  *
  * Games implement this with a scene timer / command queue. The helper does not
@@ -34,6 +35,7 @@ public:
 };
 
 /**
+ * @class NullSfxDelayScheduler
  * @brief No-op scheduler for banks that only use simultaneous layers (no delayed steps).
  */
 class NullSfxDelayScheduler final : public SfxDelayScheduler {
@@ -42,6 +44,7 @@ public:
 };
 
 /**
+ * @class ImmediateSfxDelayScheduler
  * @brief Plays every scheduled event immediately (ignores delay). Test / stub only.
  */
 class ImmediateSfxDelayScheduler final : public SfxDelayScheduler {

--- a/include/core/Scene.h
+++ b/include/core/Scene.h
@@ -28,6 +28,23 @@
 namespace pixelroot32::core {
 
 #include <new> // for placement new
+
+/**
+ * @struct SceneArena
+ * @brief Bump allocator for objects whose lifetime is one scene.
+ *
+ * Hands out aligned slices of a caller-supplied buffer by advancing an offset.
+ * There is no individual free: reset() rewinds the offset to zero and releases
+ * everything at once, which is why allocations must not outlive the scene.
+ * Destructors are never run, so only trivially destructible types are safe.
+ *
+ * allocate() returns nullptr when the request does not fit, and callers must
+ * check. Prefer arenaNew() over calling allocate() directly.
+ *
+ * @note Gated by platforms::config::EnableSceneArena. With the arena
+ *       disabled every allocate() returns nullptr and init()/reset() are
+ *       no-ops, so callers keep their fallback path.
+ */
 struct SceneArena {
     unsigned char* buffer;
     std::size_t capacity;

--- a/include/graphics/Color.h
+++ b/include/graphics/Color.h
@@ -9,6 +9,14 @@
 #include <cstdint>
 namespace pixelroot32::graphics {
 
+/**
+ * @enum PaletteType
+ * @brief Selects which built-in 16-color palette the renderer resolves against.
+ *
+ * PR32 is the default and is the palette the Color enumerators are indexed for.
+ * The others are retro presets; the same Color value resolves to a different
+ * RGB565 output under each one.
+ */
 enum class PaletteType {
     NES,
     GB,
@@ -18,7 +26,9 @@ enum class PaletteType {
 };
 
 /**
+ * @enum PaletteContext
  * @brief Context for palette selection in dual palette mode.
+ *
  * Determines which palette (background or sprite) is used for color resolution.
  */
 enum class PaletteContext {
@@ -28,9 +38,23 @@ enum class PaletteContext {
 
 static constexpr uint8_t PALETTE_SIZE = 16;
 
-// Default palette is PR32.
-// The Color enum is mapped to the PR32 palette indices (0-15).
-// Some legacy colors are aliased to the nearest available color in the 16-color palette.
+/**
+ * @enum Color
+ * @brief Named color indices into the active 16-entry palette.
+ *
+ * Enumerator values are the PR32 palette indices 0-15, so a Color is a palette
+ * slot, not an RGB value: the same enumerator resolves differently under each
+ * PaletteType.
+ *
+ * @note Legacy names are aliases, not extra colors. `LightBlue`, `Teal`,
+ *       `Olive`, `Gold` and `Brown` collapse onto the nearest of the 16 slots,
+ *       and every gray name (`MidGray`, `LightGray`, `DarkGray`, `Silver`)
+ *       resolves to the single `Gray` slot. Two aliased names compare equal.
+ *
+ * @warning `Transparent` (255) is a sentinel, not a color. The renderer and
+ *          blitter must intercept it; it must never be resolved against a
+ *          palette, and passing it to a drawing primitive is a no-op.
+ */
 enum class Color : uint8_t {
     // Standard Colors (PR32 indices)
     Black = 0,

--- a/include/graphics/DisplayConfig.h
+++ b/include/graphics/DisplayConfig.h
@@ -45,6 +45,7 @@ enum DisplayType {
 }; 
 
 /**
+ * @struct DisplayConfig
  * @brief Configuration settings for initializing displays with optional resolution scaling.
  * 
  * Supports both physical (hardware) and logical (rendering) resolutions.

--- a/include/graphics/StaticTilemapLayerCache.h
+++ b/include/graphics/StaticTilemapLayerCache.h
@@ -17,6 +17,7 @@
 namespace pixelroot32::graphics {
 
 /**
+ * @struct TileMap4bppDrawSpec
  * @brief One drawable 4bpp tilemap layer with an origin in logical coordinates.
  *
  * Entries with map == nullptr are skipped. Use any number of static layers
@@ -29,6 +30,7 @@ struct TileMap4bppDrawSpec {
 };
 
 /**
+ * @class StaticTilemapLayerCache
  * @brief Centralized framebuffer snapshot for static 4bpp tilemap layers.
  *
  * On drivers that expose a direct logical 8bpp sprite buffer (e.g. TFT_eSPI),

--- a/include/input/TouchAdapter.h
+++ b/include/input/TouchAdapter.h
@@ -14,6 +14,7 @@
 namespace pixelroot32::input {
 
 /**
+ * @enum TouchController
  * @brief Touch controller types
  */
 enum class TouchController {
@@ -138,7 +139,7 @@ private:
 using TouchCalibrationData = TouchCalibration;
 
 /**
- * @class TouchAdapterBase
+ * @class TouchAdapter
  * @brief Base class requirements for touch adapters (conceptual)
  *
  * This defines the interface that ALL touch adapters must implement.

--- a/include/math/MathUtil.h
+++ b/include/math/MathUtil.h
@@ -318,6 +318,7 @@ inline Scalar rand_sign() {
 }
 
 /**
+ * @struct Random
  * @brief Instance-based random number generator
  * 
  * Provides independent RNG state for scenarios requiring multiple

--- a/include/physics/PhysicsScheduler.h
+++ b/include/physics/PhysicsScheduler.h
@@ -14,6 +14,21 @@
 
 namespace pixelroot32::physics {
 
+/**
+ * @class PhysicsScheduler
+ * @brief Fixed-timestep accumulator that decouples physics from frame rate.
+ *
+ * Banks real elapsed time and spends it in fixed 60 Hz slices, so collision
+ * results stay identical regardless of how fast or unevenly frames arrive.
+ *
+ * Normally at most one step runs per frame. When the accumulator falls more
+ * than 2.5 frames behind, up to MAX_STEPS_BACKLOG steps run to catch up; that
+ * ceiling is what stops a long stall from cascading into a spiral of death.
+ * Time beyond the ceiling is kept in the accumulator, not discarded.
+ *
+ * Zero-heap and zero-allocation: the whole state is an accumulator and a step
+ * counter.
+ */
 class PhysicsScheduler {
 public:
     /// Fixed timestep in microseconds (60 Hz)


### PR DESCRIPTION
Chained on #192 — **merge that first**. This change is only safe because the generator
defects it fixes are already in.

Second half of the API-docs follow-up recorded in #190. `scripts/generate_api_docs.py`
emits a page only when a doc block carries `@class`/`@struct`/`@enum`; it never infers
the kind from the declaration. 14 public types had no tag and were simply absent from
the generated reference.

| | before | after |
|---|---|---|
| namespace-scope types under `include/` | 158 | 158 |
| visible to the generator | 142 | **156** |

The 2 remaining are `MockSDL2EventProvider` and `MockTimingProvider`, test doubles left
untagged on purpose.

An earlier informal figure of "30 types across 19 headers" circulated in #190. It was
wrong; the real count was 16 across 10 headers, measured with an audit that walks every
namespace-scope declaration and cross-checks it against the tags in its file.

## Changes

| File | Tagged |
|------|--------|
| `include/graphics/Color.h` | `PaletteType`, `PaletteContext`, `Color` |
| `include/audio/SfxBankPlayback.h` | `SfxDelayScheduler`, `NullSfxDelayScheduler`, `ImmediateSfxDelayScheduler` |
| `include/graphics/DisplayConfig.h` | `DisplayConfig` |
| `include/graphics/StaticTilemapLayerCache.h` | `TileMap4bppDrawSpec`, `StaticTilemapLayerCache` |
| `include/input/TouchAdapter.h` | `TouchController`, and `TouchAdapterBase` → `TouchAdapter` |
| `include/math/MathUtil.h` | `Random` |
| `include/core/Scene.h` | `SceneArena` — new doc block |
| `include/physics/PhysicsScheduler.h` | `PhysicsScheduler` — new doc block |

Comments only. No executable line changed.

## `TouchAdapterBase` never existed

The tag named a type found nowhere in the repository, yet the generator still published
`TouchAdapterBase.md` carrying the real `TouchAdapter`'s four methods — a documented
class nobody could use. Renaming the tag deletes the phantom and produces a correct
`TouchAdapter.md`.

## Why this is chained rather than standalone

Two earlier attempts at exactly this change were withdrawn, because tagging a type is
what makes the generator's defects fire:

- tagging `Color` published **20 namespace-scope palette helpers as methods of an enum**
- tagging `ImmediateSfxDelayScheduler` captured the free function `playSfxBank`
- tagging `DisplayConfig` published a fabricated heading built from its constructor's initializer list
- tagging `StaticTilemapLayerCache` silently dropped its three `[[nodiscard]]` methods

All four are fixed in #192. Each was verified absent here by tracing the generated page
back to its header, not by trusting the parent branch:

| Page | Now |
|------|-----|
| `Color.md` | 0 methods — correct, an enum has none |
| `ImmediateSfxDelayScheduler.md` | constructor + `schedule` only |
| `DisplayConfig.md` | its 9 members, no fabricated heading |
| `StaticTilemapLayerCache.md` | 8, including the 3 `[[nodiscard]]` that used to vanish |
| `Random.md` | 7, the 2 bogus headings gone |

Zero initializer-list or control-flow headings remain anywhere in the tree.

## Four doc blocks written from source

`SceneArena`, `PhysicsScheduler`, `PaletteType` and `Color` had no doc comment at all.
These were written against the implementation, not paraphrased from their names:

- **`SceneArena`** — bump allocator; `reset()` rewinds the offset and releases everything at once, so **destructors never run** and only trivially destructible types are safe; `allocate()` returns `nullptr` on overflow. Verified against `src/core/Scene.cpp`.
- **`PhysicsScheduler`** — 60 Hz slices; the `MAX_STEPS_BACKLOG` ceiling past 2.5 frames behind is what stops a stall becoming a spiral of death; leftover time stays in the accumulator. Verified against `update()`, which explicitly does not clamp.
- **`Color`** — enumerators are palette *slots*, not RGB. Legacy names are aliases that **compare equal** (`Teal`, `Olive`, `Silver`…), and `Transparent = 255` is a sentinel that must never be resolved. Verified against `resolveColor` and the `isDrawable` guard in `Renderer.cpp`.

## Test plan

- [x] `pio test -e native_test_gameplay` — 1725 cases, 1721 passed, 4 skipped, exit 0
- [x] Every one of the 14 tags checked against the declaration that follows, for name and kind
- [x] Every method on every new page traced to its header — no free function leaked, nothing fabricated
- [x] Tag audit: 156 of 158 visible
- [x] Generator output deterministic

`.github/workflows/tests.yml` triggers only on `main` and `develop`, so **no CI runs
against this PR**. The local run above is the only verification.

## Review status

| Lineage | Tier | Lenses | Outcome |
|---------|------|--------|---------|
| `review-e1ed585550f34a91` | high | 4R | approved, no correction |

One lens reported `DisplayConfig`'s missing constructors as newly caused here. That did
not survive checking and was reclassified: **no page in the entire generated tree renders
a constructor** — `Camera2D`, `Entity`, `Actor`, `AudioConfig`, `InputConfig` and
`TouchPoint` all document one and all show none. It is a uniform pre-existing limitation,
recorded as a follow-up.

## Follow-ups

- The generator cannot render constructors at all: the signature pattern needs a whitespace-separated return-type token, which a bare constructor name lacks, and the name group excludes `=` so `operator=` never matches either.
- `ImmediateSfxDelayScheduler`'s constructor heading carries its initializer list into the displayed signature, exposing the private member `engine_`. Its source declares constructor, initializer list and empty body on one line, which the initializer-list guard in #192 does not cover. Sole instance in the tree; belongs in #192's file.
- Documented private methods declared after an initial `public:` are still published as public API.
- `@note`/`@warning` bodies print twice, once in the description and once in the callout.
- A comment in `scripts/generate_api_docs.py` still cites `@class TouchAdapterBase` as a live example; this PR renames it away.