### PR TITLE
feat(math): add projection-aware cell range culling

### DIFF
--- a/include/graphics/Renderer.h
+++ b/include/graphics/Renderer.h
@@ -136,6 +136,38 @@ struct TileMapGeneric {
     const uint8_t*  paletteIndices = nullptr;
 
     /**
+     * Optional per-tile foot row, parallel to `tiles[]`, `tileCount` entries.
+     * `nullptr` means anchor at top-left, i.e. current behaviour. Typically
+     * filled by editor/export tools. Encodes the shipped anchoring
+     * convention already used in game code: `examples/iso_dungeon/src/IsoDraw.h:28-29`
+     * draws a sprite at `(centreX - sprite.width / 2, centreY - footY)`.
+     */
+    const uint8_t*  tileFootY = nullptr;
+
+    /**
+     * @brief Resolve the foot-anchor row for a tile index.
+     *
+     * @param index Tile index into `tiles[]`.
+     * @return `tileFootY[index]` when a table is present and `index` is in
+     *         range; 0 otherwise (current top-left behaviour).
+     * @note `index >= tileCount` returns 0. `drawTileMap` already guards
+     *       `index >= map.tileCount` (src/graphics/Renderer.cpp:892), so this
+     *       is defence in depth against a caller that does not, not a
+     *       load-bearing branch.
+     * @note `footYFor(0)` reads the table with no special case, even though
+     *       index 0 is the empty-tile sentinel `drawTileMap` skips. The table
+     *       is parallel to `tiles[]`, so slot 0 exists; special-casing it
+     *       would bind the asset format's meaning to a renderer policy that
+     *       is free to change.
+     */
+    inline uint8_t footYFor(uint16_t index) const {
+        if (!tileFootY || index >= tileCount) {
+            return 0;
+        }
+        return tileFootY[index];
+    }
+
+    /**
      * @brief Initialize runtime mask buffer for tile activation control.
      * 
      * Allocates memory for tracking tile activation state. All tiles start as active.

--- a/include/math/Projection.h
+++ b/include/math/Projection.h
@@ -267,6 +267,153 @@ constexpr bool projectionSpecIsValid(const ProjectionSpec& spec, int cols, int r
     return true;
 }
 
+/**
+ * @struct CellRange
+ * @brief Half-open cell-space window `[startCol, endCol) x [startRow, endRow)`
+ *        covering a screen rectangle, under a given ProjectionSpec.
+ *
+ * Field names are deliberately identical to
+ * `TilemapDirtyTrackingHelper`'s (`include/graphics/Renderer.h`), so the
+ * eventual renderer wiring is a rename-free assignment rather than a mapping.
+ * A default-constructed `CellRange` is empty (`start == end == 0` on both
+ * axes), matching "nothing to draw".
+ */
+struct CellRange {
+    int startCol = 0;
+    int endCol   = 0;
+    int startRow = 0;
+    int endRow   = 0;
+};
+
+/**
+ * @brief Cell-space window covering a screen rectangle, for any
+ *        ProjectionSpec (orthogonal, isometric, or oblique).
+ *
+ * The rectangle is given half-open as `(screenX, screenY, screenW, screenH)`
+ * and inverted at its FOUR corners using its inclusive last pixel
+ * (`screenX + screenW - 1`, `screenY + screenH - 1`), never the exclusive
+ * edge. This is not a rounding nicety: the correct question is "which cells
+ * contain a pixel of this rectangle", and the last pixel is the last pixel.
+ * For an orthogonal spec whose screen extent is an exact multiple of the tile
+ * size, the exclusive-edge form overcounts by one cell on that edge (see the
+ * `endCol == 15` regression case for a 240px-wide, 16px-tile map: the
+ * exclusive form yields 16). This exactly reproduces the shipped culling in
+ * `computeTilemapDirtyTracking()` (`include/graphics/Renderer.h`), including
+ * its `+ tileWidth - 1` ceiling term, once expressed through
+ * `screenToCellX`/`screenToCellY` instead of a hand-derived orthogonal
+ * formula.
+ *
+ * The four-corner min/max is not a heuristic: each of `screenToCellX`/
+ * `screenToCellY` is affine in the screen coordinates (Cramer's rule), so it
+ * is a linear functional; a linear functional over a convex polygon attains
+ * its extrema at a vertex, and the rectangle's four corners are exactly the
+ * vertices bounding its interior. `floor` (see `detail::projectionFloorDiv`)
+ * is monotone non-decreasing, so composing it with a linear functional
+ * preserves "extrema at the vertices". The min/max of the four corner
+ * inversions therefore equals the min/max over every point in the rectangle:
+ * the returned window is exact and tight, never a loose over-approximation.
+ *
+ * Under a non-orthogonal basis the set of cells whose parallelogram touches
+ * the rectangle is itself a parallelogram, not a rectangle, so an
+ * axis-aligned bounding box in cell space necessarily includes cells that
+ * are not actually on screen. This is intended overdraw, not a defect: for
+ * the documented 2:1 isometric layout on a 240x240 screen the measured
+ * factor is about 2.25x (see the AC-5 test), and each rejected cell costs one
+ * screen-bounds compare, far cheaper than a sprite decode.
+ *
+ * **Documented limitation**: this is the window of cells whose parallelogram
+ * intersects the rectangle, not the window of cells whose *sprite* overlaps
+ * it. Orthogonal tiles exactly fill their cell, so the shipped code needs no
+ * padding; isometric tile art commonly overhangs its cell (a tall wall or
+ * tree sprite drawn from a half-height diamond footprint), so a caller that
+ * pads by sprite extent is a WU-5 concern, deliberately not addressed here.
+ *
+ * @param spec Projection basis. The caller composes the effective origin
+ *        (e.g. `spec.originX + viewOriginX`) before calling — this function
+ *        takes no separate camera/view origin, so there is exactly one
+ *        origin to reason about (see the header's `ProjectionSpec` docs).
+ * @param screenX Left edge of the screen rectangle, in pixels.
+ * @param screenY Top edge of the screen rectangle, in pixels.
+ * @param screenW Width of the screen rectangle, in pixels.
+ * @param screenH Height of the screen rectangle, in pixels.
+ * @param cols Map width in cells. `endCol` is clamped high to this; `startCol`
+ *        has no upper clamp (matches the shipped asymmetry: a start past the
+ *        map only makes the range empty once compared against `endCol`).
+ * @param rows Map height in cells. Same asymmetric clamp as `cols`/`endCol`.
+ * @return An empty `CellRange{}` for any degenerate input (see the table
+ *         below), otherwise the half-open window `[startCol, endCol) x
+ *         [startRow, endRow)`.
+ *
+ * | Input | Result |
+ * |---|---|
+ * | `projectionDet(spec) < 1` | Empty. Never divides — see `projectionFloorDiv`'s precondition. |
+ * | `cols <= 0` or `rows <= 0` | Empty. |
+ * | `screenW <= 0` or `screenH <= 0` | Empty. |
+ * | Rectangle entirely off the map | Empty, after clamping. |
+ */
+[[nodiscard]] constexpr CellRange cellRangeForScreenRect(const ProjectionSpec& spec,
+                                                          int screenX, int screenY,
+                                                          int screenW, int screenH,
+                                                          int cols, int rows) {
+    if (projectionDet(spec) < 1 || cols <= 0 || rows <= 0 || screenW <= 0 || screenH <= 0) {
+        return CellRange{};
+    }
+
+    const int leftX   = screenX;
+    const int rightX  = screenX + screenW - 1;  // Inclusive last pixel.
+    const int topY    = screenY;
+    const int bottomY = screenY + screenH - 1;  // Inclusive last pixel.
+
+    const int cellX0 = screenToCellX(leftX, topY, spec);
+    const int cellX1 = screenToCellX(rightX, topY, spec);
+    const int cellX2 = screenToCellX(leftX, bottomY, spec);
+    const int cellX3 = screenToCellX(rightX, bottomY, spec);
+
+    const int cellY0 = screenToCellY(leftX, topY, spec);
+    const int cellY1 = screenToCellY(rightX, topY, spec);
+    const int cellY2 = screenToCellY(leftX, bottomY, spec);
+    const int cellY3 = screenToCellY(rightX, bottomY, spec);
+
+    int minCol = cellX0;
+    if (cellX1 < minCol) minCol = cellX1;
+    if (cellX2 < minCol) minCol = cellX2;
+    if (cellX3 < minCol) minCol = cellX3;
+
+    int maxCol = cellX0;
+    if (cellX1 > maxCol) maxCol = cellX1;
+    if (cellX2 > maxCol) maxCol = cellX2;
+    if (cellX3 > maxCol) maxCol = cellX3;
+
+    int minRow = cellY0;
+    if (cellY1 < minRow) minRow = cellY1;
+    if (cellY2 < minRow) minRow = cellY2;
+    if (cellY3 < minRow) minRow = cellY3;
+
+    int maxRow = cellY0;
+    if (cellY1 > maxRow) maxRow = cellY1;
+    if (cellY2 > maxRow) maxRow = cellY2;
+    if (cellY3 > maxRow) maxRow = cellY3;
+
+    CellRange range{};
+    range.startCol = minCol;
+    range.endCol   = maxCol + 1;  // Half-open.
+    range.startRow = minRow;
+    range.endRow   = maxRow + 1;  // Half-open.
+
+    // Clamp asymmetrically, mirroring the shipped culling exactly: start
+    // clamps low only, end clamps high only. No upper clamp on start, no
+    // lower clamp on end — both remain sufficient to make the range empty
+    // when the rectangle sits fully off the map (e.g. an unclamped start far
+    // above `cols`/`rows` still yields an empty `[start, end)` once `end`
+    // stays at its clamped value).
+    if (range.startCol < 0) range.startCol = 0;
+    if (range.endCol > cols) range.endCol = cols;
+    if (range.startRow < 0) range.startRow = 0;
+    if (range.endRow > rows) range.endRow = rows;
+
+    return range;
+}
+
 }  // namespace pixelroot32::math
 
 #endif  // PIXELROOT32_ENABLE_PROJECTION

--- a/include/math/Projection.h
+++ b/include/math/Projection.h
@@ -325,8 +325,9 @@ struct CellRange {
  * intersects the rectangle, not the window of cells whose *sprite* overlaps
  * it. Orthogonal tiles exactly fill their cell, so the shipped code needs no
  * padding; isometric tile art commonly overhangs its cell (a tall wall or
- * tree sprite drawn from a half-height diamond footprint), so a caller that
- * pads by sprite extent is a WU-5 concern, deliberately not addressed here.
+ * tree sprite drawn from a half-height diamond footprint). Padding the range
+ * by the sprite extent is therefore the caller's responsibility, deliberately
+ * not addressed here.
  *
  * @param spec Projection basis. The caller composes the effective origin
  *        (e.g. `spec.originX + viewOriginX`) before calling — this function

--- a/test/unit/test_math_projection/test_math_projection.cpp
+++ b/test/unit/test_math_projection/test_math_projection.cpp
@@ -139,26 +139,310 @@ void test_math_projection_zero_cost_when_disabled(void) {
     constexpr math::ProjectionSpec kProbe{0, 0, 8, 4, -8, 4};
     static_assert(math::projectionSpecIsValid(kProbe, 4, 4), "probe spec must be constexpr-valid");
     static_assert(math::cellToScreenX(1, 0, kProbe) == 8, "cellToScreenX must be constexpr-evaluable");
+    static_assert(math::cellRangeForScreenRect(kProbe, 0, 0, 32, 32, 4, 4).startCol == 0,
+                  "cellRangeForScreenRect must be constexpr-evaluable");
 
     TEST_PASS_MESSAGE(
         "PIXELROOT32_ENABLE_PROJECTION=1: math::ProjectionSpec stays a plain "
-        "six-int aggregate and every free function is constexpr-evaluable, "
-        "so a constexpr consumer pays zero runtime footprint.");
+        "six-int aggregate and every free function, including "
+        "cellRangeForScreenRect, is constexpr-evaluable, so a constexpr "
+        "consumer pays zero runtime footprint.");
+}
+
+// ===========================================================================
+// cellRangeForScreenRect — characterization against the shipped culling
+// ===========================================================================
+
+namespace {
+
+/**
+ * @brief Oracle reproducing the shipped viewport culling verbatim.
+ *
+ * Copied character-for-character from `computeTilemapDirtyTracking()`
+ * (include/graphics/Renderer.h:1348-1361), substituting local parameter names
+ * for the original `h.*`/`map.*` member accesses. This is the only correct
+ * way to characterize the new function against the old one: re-deriving the
+ * expressions from the doc comment would risk encoding today's understanding
+ * of the old code rather than the old code itself.
+ */
+struct OrthogonalCullOracle {
+    int startCol = 0;
+    int endCol   = 0;
+    int startRow = 0;
+    int endRow   = 0;
+};
+
+OrthogonalCullOracle orthogonalCullOracle(int viewOriginX, int viewOriginY, int tileWidth,
+                                          int tileHeight, int mapWidth, int mapHeight,
+                                          int logicalWidth, int logicalHeight) {
+    OrthogonalCullOracle h{};
+
+    // Verbatim from include/graphics/Renderer.h:1348-1361 ("Viewport culling").
+    h.startCol = (viewOriginX < 0) ? (-viewOriginX / tileWidth) : 0;
+    h.endCol   = (viewOriginX + mapWidth * tileWidth > logicalWidth)
+                     ? ((logicalWidth - viewOriginX + tileWidth - 1) / tileWidth)
+                     : mapWidth;
+    h.startRow = (viewOriginY < 0) ? (-viewOriginY / tileHeight) : 0;
+    h.endRow   = (viewOriginY + mapHeight * tileHeight > logicalHeight)
+                     ? ((logicalHeight - viewOriginY + tileHeight - 1) / tileHeight)
+                     : mapHeight;
+
+    if (h.startCol < 0) h.startCol = 0;
+    if (h.endCol > mapWidth) h.endCol = mapWidth;
+    if (h.startRow < 0) h.startRow = 0;
+    if (h.endRow > mapHeight) h.endRow = mapHeight;
+
+    return h;
+}
+
+/**
+ * @brief Asserts one axis of a returned range against the oracle, per AC-2.
+ *
+ * When the oracle's iteration range is non-empty, raw integer equality MUST
+ * hold. When the oracle's range is empty, only the new range's emptiness is
+ * asserted — C++ truncation-toward-zero (old code) versus this function's
+ * corner-inversion ceiling can produce different negative integers that are
+ * both "empty" (see the two dedicated divergence tests below), and asserting
+ * raw equality there would be wrong per the proposal's AC-2.
+ */
+void assertAxisRangeMatchesOracle(int oracleStart, int oracleEnd, int actualStart,
+                                  int actualEnd, const char* what) {
+    if (oracleStart < oracleEnd) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(oracleStart, actualStart, what);
+        TEST_ASSERT_EQUAL_INT_MESSAGE(oracleEnd, actualEnd, what);
+    } else {
+        TEST_ASSERT_TRUE_MESSAGE(actualStart >= actualEnd, what);
+    }
+}
+
+struct CharacterizationCase {
+    const char* name;
+    int viewOriginX;
+    int viewOriginY;
+    int tileWidth;
+    int tileHeight;
+    int mapWidth;
+    int mapHeight;
+    int logicalWidth;
+    int logicalHeight;
+};
+
+// AC-4 coverage, per axis: origin zero/positive/negative; screen extent an
+// exact multiple of the tile size and not; map smaller/equal/larger than the
+// screen; map entirely off-screen left and right.
+constexpr CharacterizationCase kCharacterizationCases[] = {
+    {"origin x zero",           0,   0, 16, 16, 20, 20, 240, 240},
+    {"origin x positive",      40,   0, 16, 16, 20, 20, 240, 240},
+    {"origin x negative",     -40,   0, 16, 16, 20, 20, 240, 240},
+    {"origin y zero",           0,   0, 16, 16, 20, 20, 240, 240},
+    {"origin y positive",       0,  40, 16, 16, 20, 20, 240, 240},
+    {"origin y negative",       0, -40, 16, 16, 20, 20, 240, 240},
+    {"extent exact multiple",   0,   0, 16, 16, 20, 20, 240, 240},
+    {"extent not multiple",     0,   0, 16, 16, 20, 20, 241, 241},
+    {"map smaller than screen", 0,   0, 16, 16,  5,  5, 240, 240},
+    {"map equal to screen",     0,   0, 16, 16, 15, 15, 240, 240},
+    {"map larger than screen",  0,   0, 16, 16, 40, 40, 240, 240},
+    {"map off-screen left", -1000,   0, 16, 16, 10, 10, 240, 240},
+    {"map off-screen right", 1000,   0, 16, 16, 10, 10, 240, 240},
+};
+
+}  // namespace
+
+void test_math_cell_range_for_screen_rect_matches_the_shipped_orthogonal_culling(void) {
+    for (const CharacterizationCase& c : kCharacterizationCases) {
+        const math::ProjectionSpec spec{c.viewOriginX, c.viewOriginY, c.tileWidth, 0, 0,
+                                        c.tileHeight};
+        const OrthogonalCullOracle oracle =
+            orthogonalCullOracle(c.viewOriginX, c.viewOriginY, c.tileWidth, c.tileHeight,
+                                 c.mapWidth, c.mapHeight, c.logicalWidth, c.logicalHeight);
+        const math::CellRange r = math::cellRangeForScreenRect(
+            spec, 0, 0, c.logicalWidth, c.logicalHeight, c.mapWidth, c.mapHeight);
+
+        assertAxisRangeMatchesOracle(oracle.startCol, oracle.endCol, r.startCol, r.endCol, c.name);
+        assertAxisRangeMatchesOracle(oracle.startRow, oracle.endRow, r.startRow, r.endRow, c.name);
+    }
+}
+
+void test_math_cell_range_for_screen_rect_orthogonal_edge_uses_inclusive_last_pixel(void) {
+    // AC-3 regression guard: the screen rect is inverted at its inclusive
+    // last pixel (screenW - 1), never the exclusive edge. For a 240px-wide
+    // screen tiled at 16px, the exclusive-edge form would yield endCol == 16
+    // (240 / 16 exactly); the correct, last-pixel answer is endCol == 15,
+    // because pixel 239 (the last pixel) falls in cell 14, so the half-open
+    // end is 15. This is the specific defect this unit exists to prevent.
+    constexpr math::ProjectionSpec spec{0, 0, 16, 0, 0, 16};
+    const math::CellRange r = math::cellRangeForScreenRect(spec, 0, 0, 240, 240, 20, 20);
+    TEST_ASSERT_EQUAL_INT(15, r.endCol);
+    TEST_ASSERT_EQUAL_INT(15, r.endRow);
+}
+
+void test_math_cell_range_for_screen_rect_end_col_diverges_from_oracle_but_both_stay_empty(void) {
+    // AC-2 divergence case 1: logicalWidth=100, viewOriginX=145, tileWidth=16
+    // gives a = logicalWidth - viewOriginX = -45. C++ truncation toward zero
+    // (the old, oracle code) and this function's ceil-via-corner-inversion
+    // diverge for a negative dividend: oracle endCol == -1, new endCol == -2.
+    // Both produce an EMPTY [startCol, endCol) range (0 >= -1 and 0 >= -2), so
+    // behaviour is identical; do NOT assert raw equality here.
+    constexpr int viewOriginX = 145;
+    constexpr int tileWidth = 16;
+    constexpr int mapWidth = 20;
+    constexpr int logicalWidth = 100;
+
+    const OrthogonalCullOracle oracle = orthogonalCullOracle(
+        viewOriginX, 0, tileWidth, tileWidth, mapWidth, mapWidth, logicalWidth, logicalWidth);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(-1, oracle.endCol, "oracle must reproduce the documented -1");
+    TEST_ASSERT_TRUE_MESSAGE(oracle.startCol >= oracle.endCol, "oracle range must be empty");
+
+    constexpr math::ProjectionSpec spec{viewOriginX, 0, tileWidth, 0, 0, tileWidth};
+    const math::CellRange r = math::cellRangeForScreenRect(spec, 0, 0, logicalWidth, logicalWidth,
+                                                            mapWidth, mapWidth);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(-2, r.endCol, "new function must reproduce the documented -2");
+    TEST_ASSERT_TRUE_MESSAGE(r.startCol >= r.endCol, "new range must be empty too");
+}
+
+void test_math_cell_range_for_screen_rect_start_col_has_no_upper_clamp_but_range_stays_empty(void) {
+    // AC-2 divergence case 2: viewOriginX=-1000, tileWidth=16, cols=10. The
+    // oracle's startCol (62) has NO upper clamp against cols (the shipped
+    // code, and this function, clamp `start` low-only and `end` high-only —
+    // see the asymmetric clamp), so it can exceed cols entirely. The range is
+    // still empty once compared against endCol (10): emptiness comes from the
+    // comparison, not from clamping. Assert emptiness, not a specific raw pair.
+    constexpr int viewOriginX = -1000;
+    constexpr int tileWidth = 16;
+    constexpr int mapWidth = 10;
+    constexpr int logicalWidth = 240;
+
+    const OrthogonalCullOracle oracle = orthogonalCullOracle(
+        viewOriginX, 0, tileWidth, tileWidth, mapWidth, mapWidth, logicalWidth, logicalWidth);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(62, oracle.startCol, "oracle must reproduce the documented 62");
+    TEST_ASSERT_TRUE_MESSAGE(oracle.startCol >= oracle.endCol, "oracle range must be empty");
+
+    constexpr math::ProjectionSpec spec{viewOriginX, 0, tileWidth, 0, 0, tileWidth};
+    const math::CellRange r = math::cellRangeForScreenRect(spec, 0, 0, logicalWidth, logicalWidth,
+                                                            mapWidth, mapWidth);
+    TEST_ASSERT_TRUE_MESSAGE(r.startCol >= r.endCol, "new range must be empty too");
+}
+
+// ===========================================================================
+// AC-5: non-orthogonal (isometric) — a tight superset of the visible cells
+// ===========================================================================
+
+void test_math_cell_range_for_screen_rect_iso_is_a_tight_superset_of_the_visible_cells(void) {
+    // kIso2to1 on a 240x240 screen: every cell whose anchor projects inside
+    // the rect must be inside the returned range (superset), and the range
+    // must be a parallelogram-vs-bounding-box overdraw, not an arbitrary one.
+    const math::CellRange r = math::cellRangeForScreenRect(kIso2to1, 0, 0, 240, 240, 32, 32);
+
+    int visibleCount = 0;
+    for (int row = 0; row < 32; ++row) {
+        for (int col = 0; col < 32; ++col) {
+            const int sx = math::cellToScreenX(col, row, kIso2to1);
+            const int sy = math::cellToScreenY(col, row, kIso2to1);
+            if (sx >= 0 && sx < 240 && sy >= 0 && sy < 240) {
+                ++visibleCount;
+                TEST_ASSERT_TRUE_MESSAGE(col >= r.startCol && col < r.endCol,
+                                         "visible col must be inside the returned range");
+                TEST_ASSERT_TRUE_MESSAGE(row >= r.startRow && row < r.endRow,
+                                         "visible row must be inside the returned range");
+            }
+        }
+    }
+
+    TEST_ASSERT_TRUE_MESSAGE(visibleCount > 0, "the visible set must be non-empty for this fixture");
+
+    // Measured overdraw factor for THIS fixture, recorded as a fact, not a
+    // guess. The proposal's ~2.25x estimate is the unclamped
+    // bounding-box-area-over-diamond-area ratio for an infinite map; here the
+    // 32x32 map clamps the returned range to [0, 32) on both axes, which
+    // trims part of that bounding box back down. The actually measured ratio
+    // for a 32x32 kIso2to1 map on a 240x240 screen is ~1.96x.
+    const int returnedCells = (r.endCol - r.startCol) * (r.endRow - r.startRow);
+    const float overdraw = static_cast<float>(returnedCells) / static_cast<float>(visibleCount);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 1.96f, overdraw);
+}
+
+// ===========================================================================
+// AC-6: degenerate inputs — one test per proposal-§4 row
+// ===========================================================================
+
+void test_math_cell_range_for_screen_rect_degenerate_determinant_returns_empty(void) {
+    // det == 0: collinear basis, no inverse. Must never divide.
+    constexpr math::ProjectionSpec kCollinear{0, 0, 16, 0, 32, 0};
+    const math::CellRange r = math::cellRangeForScreenRect(kCollinear, 0, 0, 240, 240, 20, 20);
+    TEST_ASSERT_EQUAL_INT(0, r.startCol);
+    TEST_ASSERT_EQUAL_INT(0, r.endCol);
+    TEST_ASSERT_EQUAL_INT(0, r.startRow);
+    TEST_ASSERT_EQUAL_INT(0, r.endRow);
+}
+
+void test_math_cell_range_for_screen_rect_non_positive_cols_or_rows_returns_empty(void) {
+    constexpr math::ProjectionSpec spec{0, 0, 16, 0, 0, 16};
+    const math::CellRange zeroCols = math::cellRangeForScreenRect(spec, 0, 0, 240, 240, 0, 20);
+    const math::CellRange zeroRows = math::cellRangeForScreenRect(spec, 0, 0, 240, 240, 20, 0);
+    const math::CellRange negativeCols = math::cellRangeForScreenRect(spec, 0, 0, 240, 240, -5, 20);
+
+    TEST_ASSERT_EQUAL_INT(0, zeroCols.endCol);
+    TEST_ASSERT_EQUAL_INT(0, zeroRows.endRow);
+    TEST_ASSERT_EQUAL_INT(0, negativeCols.endCol);
+}
+
+void test_math_cell_range_for_screen_rect_non_positive_screen_extent_returns_empty(void) {
+    constexpr math::ProjectionSpec spec{0, 0, 16, 0, 0, 16};
+    const math::CellRange zeroWidth = math::cellRangeForScreenRect(spec, 0, 0, 0, 240, 20, 20);
+    const math::CellRange zeroHeight = math::cellRangeForScreenRect(spec, 0, 0, 240, 0, 20, 20);
+
+    TEST_ASSERT_EQUAL_INT(0, zeroWidth.endCol);
+    TEST_ASSERT_EQUAL_INT(0, zeroHeight.endRow);
+}
+
+void test_math_cell_range_for_screen_rect_entirely_off_map_returns_empty(void) {
+    // Map anchored far outside the screen rect: no corner inversion lands
+    // inside [0, cols) x [0, rows) once clamped.
+    constexpr math::ProjectionSpec spec{2000, 2000, 16, 0, 0, 16};
+    const math::CellRange r = math::cellRangeForScreenRect(spec, 0, 0, 240, 240, 20, 20);
+    TEST_ASSERT_TRUE(r.startCol >= r.endCol);
+    TEST_ASSERT_TRUE(r.startRow >= r.endRow);
+}
+
+// ===========================================================================
+// AC-7: constexpr — a full non-empty range computed at compile time
+// ===========================================================================
+
+namespace {
+
+constexpr math::ProjectionSpec kStaticProbeSpec{0, 0, 16, 0, 0, 16};
+constexpr math::CellRange kStaticRange =
+    math::cellRangeForScreenRect(kStaticProbeSpec, 0, 0, 240, 240, 20, 20);
+
+// The same orthogonal case pinned by the AC-3 regression test above, proven
+// here to be a compile-time constant, not merely runtime-correct.
+static_assert(kStaticRange.startCol == 0, "cellRangeForScreenRect must be constexpr: startCol");
+static_assert(kStaticRange.endCol == 15, "cellRangeForScreenRect must be constexpr: endCol");
+static_assert(kStaticRange.startRow == 0, "cellRangeForScreenRect must be constexpr: startRow");
+static_assert(kStaticRange.endRow == 15, "cellRangeForScreenRect must be constexpr: endRow");
+
+}  // namespace
+
+void test_math_cell_range_for_screen_rect_is_constexpr_evaluable(void) {
+    TEST_PASS_MESSAGE(
+        "cellRangeForScreenRect computed a full non-empty range at compile "
+        "time (see the static_assert block above this test).");
 }
 
 #else  // !PIXELROOT32_ENABLE_PROJECTION
 
 void test_math_projection_zero_cost_when_disabled(void) {
     // With the flag off, math::ProjectionSpec/projectionDet/
-    // projectionSpecIsValid/cellToScreen*/screenToCell* are not compiled at
-    // all — their entire declaration lives inside the
-    // #if PIXELROOT32_ENABLE_PROJECTION guard in include/math/Projection.h.
-    // This translation unit compiling and passing without referencing any of
-    // them IS the "zero bytes reserved" property required by the spec's
-    // "Flags-off means not compiled" requirement.
+    // projectionSpecIsValid/cellToScreen*/screenToCell*/CellRange/
+    // cellRangeForScreenRect are not compiled at all — their entire
+    // declaration lives inside the #if PIXELROOT32_ENABLE_PROJECTION guard in
+    // include/math/Projection.h. This translation unit compiling and passing
+    // without referencing any of them IS the "zero bytes reserved" property
+    // required by the spec's "Flags-off means not compiled" requirement.
     TEST_PASS_MESSAGE(
         "PIXELROOT32_ENABLE_PROJECTION=0: math::ProjectionSpec/cellToScreen/"
-        "screenToCell/projectionSpecIsValid are not compiled, zero bytes reserved.");
+        "screenToCell/projectionSpecIsValid/CellRange/cellRangeForScreenRect "
+        "are not compiled, zero bytes reserved.");
 }
 
 #endif  // PIXELROOT32_ENABLE_PROJECTION
@@ -188,6 +472,16 @@ int main(int argc, char** argv) {
     RUN_TEST(test_gameplay_projection_det_is_the_same_function_as_math);
     RUN_TEST(test_gameplay_projection_spec_is_valid_is_the_same_function_as_math);
     RUN_TEST(test_gameplay_detail_projection_floor_div_is_the_same_function_as_math);
+    RUN_TEST(test_math_cell_range_for_screen_rect_matches_the_shipped_orthogonal_culling);
+    RUN_TEST(test_math_cell_range_for_screen_rect_orthogonal_edge_uses_inclusive_last_pixel);
+    RUN_TEST(test_math_cell_range_for_screen_rect_end_col_diverges_from_oracle_but_both_stay_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_start_col_has_no_upper_clamp_but_range_stays_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_iso_is_a_tight_superset_of_the_visible_cells);
+    RUN_TEST(test_math_cell_range_for_screen_rect_degenerate_determinant_returns_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_non_positive_cols_or_rows_returns_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_non_positive_screen_extent_returns_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_entirely_off_map_returns_empty);
+    RUN_TEST(test_math_cell_range_for_screen_rect_is_constexpr_evaluable);
 #endif
     RUN_TEST(test_math_projection_zero_cost_when_disabled);
 

--- a/test/unit/test_tilemap_foot_anchor/test_tilemap_foot_anchor.cpp
+++ b/test/unit/test_tilemap_foot_anchor/test_tilemap_foot_anchor.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "graphics/Renderer.h"
+
+using namespace pixelroot32::graphics;
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+// Real measured anchors from examples/iso_dungeon/src/assets/DungeonTiles.h:
+// FLOOR_A, FLOOR_B, FLOOR_ACCENT, WALL, DOOR_NE, DOOR_NW, ALTAR, PILLAR.
+// Five distinct heights (8, 8, 8, 32, 32, 32, 22, 30) over the SAME 32x16
+// diamond footprint are the concrete evidence that the rejected alternative
+// `footY = tileHeight / 2` cannot work: WALL/DOOR_NE/DOOR_NW share the same
+// extruded footprint as FLOOR_A/B/ACCENT but need a completely different
+// anchor row, and ALTAR/PILLAR need two more values again. A per-tile table
+// is the only shape that reproduces IsoDraw::drawAtCell's per-sprite FOOT_Y.
+static const uint8_t kDungeonFootY[8] = {8, 8, 8, 32, 32, 32, 22, 30};
+
+void test_tilemap_foot_anchor_null_table_returns_zero() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = nullptr;
+
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(3));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(tileMap.tileCount - 1));
+}
+
+void test_tilemap_foot_anchor_null_table_returns_zero_4bpp() {
+    Sprite4bpp tiles[8] = {};
+    TileMap4bpp tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = nullptr;
+
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(3));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(tileMap.tileCount - 1));
+}
+
+void test_tilemap_foot_anchor_returns_stored_value_per_index() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(0));   // FLOOR_A
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(1));   // FLOOR_B
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(2));   // FLOOR_ACCENT
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(3));  // WALL
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(4));  // DOOR_NE
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(5));  // DOOR_NW
+    TEST_ASSERT_EQUAL_UINT8(22, tileMap.footYFor(6));  // ALTAR
+    TEST_ASSERT_EQUAL_UINT8(30, tileMap.footYFor(7));  // PILLAR
+}
+
+void test_tilemap_foot_anchor_returns_stored_value_per_index_4bpp() {
+    Sprite4bpp tiles[8] = {};
+    TileMap4bpp tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(0));   // FLOOR_A
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(1));   // FLOOR_B
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(2));   // FLOOR_ACCENT
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(3));  // WALL
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(4));  // DOOR_NE
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(5));  // DOOR_NW
+    TEST_ASSERT_EQUAL_UINT8(22, tileMap.footYFor(6));  // ALTAR
+    TEST_ASSERT_EQUAL_UINT8(30, tileMap.footYFor(7));  // PILLAR
+}
+
+void test_tilemap_foot_anchor_out_of_range_returns_zero() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, tileMap.footYFor(tileMap.tileCount),
+        "index == tileCount must return 0 even with a non-null table");
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, tileMap.footYFor(tileMap.tileCount + 5),
+        "index > tileCount must return 0 even with a non-null table");
+}
+
+void test_tilemap_foot_anchor_zero_index_reads_table() {
+    // kDungeonFootY[0] == 8, a non-zero slot, so this assertion can actually
+    // distinguish "reads the table" from "hardcoded 0 for the sentinel
+    // index". footYFor(0) has no special case for the empty-tile sentinel
+    // that drawTileMap skips (src/graphics/Renderer.cpp:892): the table is
+    // parallel to tiles[], so slot 0 exists and is the tileset author's data.
+    // Special-casing it here would bind the asset format's meaning to a
+    // renderer branch that work unit 5 is about to rewrite.
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(8, tileMap.footYFor(0),
+        "footYFor(0) must read slot 0 of the table, not hardcode 0");
+}
+
+void test_tilemap_foot_anchor_default_constructed_tilemap_has_null_table() {
+    TileMap tileMap;
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+}
+
+void test_tilemap_foot_anchor_default_constructed_tilemap4bpp_has_null_table() {
+    TileMap4bpp tileMap;
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+}
+
+void test_tilemap_foot_anchor_existing_fixture_unchanged() {
+    // Existing-style field-assigned TileMap fixture that does NOT name
+    // tileFootY, matching the idiom in test/unit/test_tile_mask/. This is
+    // the layout-safety evidence: the new NSDMI'd member must not break
+    // callers that never set it.
+    uint8_t indices[256] = {0};
+    Sprite tiles[1] = {{nullptr, 8, 8}};
+
+    TileMap tileMap;
+    tileMap.indices = indices;
+    tileMap.width = 16;
+    tileMap.height = 16;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 8;
+    tileMap.tileHeight = 8;
+    tileMap.tileCount = 1;
+    tileMap.runtimeMask = nullptr;
+
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_tilemap_foot_anchor_null_table_returns_zero);
+    RUN_TEST(test_tilemap_foot_anchor_null_table_returns_zero_4bpp);
+    RUN_TEST(test_tilemap_foot_anchor_returns_stored_value_per_index);
+    RUN_TEST(test_tilemap_foot_anchor_returns_stored_value_per_index_4bpp);
+    RUN_TEST(test_tilemap_foot_anchor_out_of_range_returns_zero);
+    RUN_TEST(test_tilemap_foot_anchor_zero_index_reads_table);
+    RUN_TEST(test_tilemap_foot_anchor_default_constructed_tilemap_has_null_table);
+    RUN_TEST(test_tilemap_foot_anchor_default_constructed_tilemap4bpp_has_null_table);
+    RUN_TEST(test_tilemap_foot_anchor_existing_fixture_unchanged);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
**PR 4.** Stacked on #200. Work unit 3 of 9.

## What

Adds `math::CellRange` and `math::cellRangeForScreenRect` to `include/math/Projection.h`: the cell-space window covering a screen rectangle under an arbitrary `ProjectionSpec`, computed by inverting the rectangle's four corners and taking their bounding box.

`[[nodiscard]] constexpr`. No heap, no state, eight floor divisions.

**Nothing calls it yet.** `include/graphics/Renderer.h` is untouched — wiring it into `drawTileMap` is work unit 5. That is why this PR has no runtime harness: there is no runtime path to exercise.

## Why a free function and not renderer code

Placement and culling is the hard part of projected rendering, and as a pure function it is unit-testable with no `Renderer` at all. Today the only tests that call `drawTileMap` never inspect pixels, so there was no seam to assert placement through. This creates one.

## The requirement that dominated the design

The engine already culls, in `computeTilemapDirtyTracking` (`include/graphics/Renderer.h:1348-1361`). For an orthogonal `ProjectionSpec`, the new function **must reproduce that behaviour**, or work unit 5 silently changes culling for every orthogonal tilemap that already ships — and the symptom is a tile flickering at a screen edge, which survives releases.

So the first test is a **characterization test**: the oracle is a verbatim copy of the shipped expression, not a re-derivation.

## Two things a reviewer should not "fix"

**1. The edge convention is the inclusive last pixel, not the exclusive edge.** With `logicalWidth=240, viewOriginX=0, tileWidth=16`, the shipped formula gives `endCol == 15`. Using `screenW` instead of `screenW - 1` gives 16 — one column too many, and only when the width is an exact multiple of the tile size, so a casually written test misses it. Pinned by `..._orthogonal_edge_uses_inclusive_last_pixel`.

**2. The clamping is asymmetric on purpose.** `startCol`/`startRow` clamp low only; `endCol`/`endRow` clamp high only. No upper clamp on start, no lower clamp on end. This mirrors the shipped code exactly. Symmetrising it is the instinctive tidy-up that would break the characterization.

## Equality against the oracle is NOT unconditional

Two cases where the raw integers legitimately differ while behaviour is identical, because the iteration range is empty either way. Each has its own named test asserting **emptiness-equivalence**, not integer equality:

| Case | Example | Oracle | This function |
|---|---|---|---|
| `logicalWidth - viewOriginX <= 0` — C++ truncates toward zero, diverging from a true ceiling | `logicalWidth=100, viewOriginX=145, tileWidth=16` | `-1` | `-2` |
| `startCol` has no upper clamp and can exceed `cols` | `viewOriginX=-1000, tileWidth=16, cols=10` | `startCol=62` vs `endCol=10` | empty |

A reviewer reading the acceptance criterion as unconditional integer equality would conclude these tests are wrong. They are not — the criterion is emptiness in exactly these two zones.

## Strict TDD, with a second red step that matters

1. **RED 1** — the test calls `cellRangeForScreenRect` before it exists: `'cellRangeForScreenRect' is not a member of 'math'` at all five call sites.
2. **RED 2** — the function is then declared with a stub body `return CellRange{}` and run again: `Expected 15 Was 0`, `Expected 15 Was 0`, `Expected -2 Was 0`.

The second step is the load-bearing one. The oracle is a copy of existing code, so without observing it *fail*, a later green proves nothing — you would be asserting that two things agree without evidence that either can disagree.

## Overdraw is intended behaviour, not a defect

Under a non-orthogonal basis the visible cell set is a parallelogram, so a bounding box necessarily includes cells that are not visible. Each one costs a screen-bounds compare, not a sprite decode.

Measured at **1.96x** for the 2:1 isometric basis `{16,8,-16,8}` on a 240x240 rect. The audit's derived figure was 2.25x for an unbounded grid; the test fixture's finite 32x32 map clamps the range, which accounts for the difference. The measured number is recorded as measured rather than adjusted to match the estimate.

## Known limitation, deferred to WU-5

The returned range covers cells whose *parallelogram* intersects the rect, with no padding for sprite extent. Isometric tile art overhangs its cell — a 40 px wall on a 16 px vertical stride — so WU-5 must add padding or tiles will clip at screen edges. Documented in the header.

## Verification

- `pio test -e native_test` (flag off) -> **1726 / 4 skipped / 1722 succeeded**, unchanged. Any drift would mean the `#if PIXELROOT32_ENABLE_PROJECTION` guard leaked.
- `pio test -e native_test_gameplay` (flag on) -> **1910 -> 1920**, exactly +10, the ten new cases, 0 failed.
- A `static_assert` computes a full non-empty range at compile time.

## `include/gameplay/Projection.h` is deliberately NOT extended

The forwarding shim stays frozen at the symbol set from #200. `CellRange` and `cellRangeForScreenRect` have zero `gameplay::`-qualified callers, and the shim exists for backward compatibility rather than as a mirror. The omission is a decision, not an oversight.

## Review size: 459 lines, above the 400 budget

Declared rather than split. Composition: **312 lines in the test file**, 147 in the header — and much of the header count is the Doxygen argument for why inverting four corners is sufficient (a linear functional over a convex polygon attains its extrema at a vertex, and floor is monotone).

Splitting would mean one PR with the function and partial characterization and another with the rest, neither of which stands alone under strict TDD. The overshoot is 15% and concentrated in tests.

## Rollback

Revert the single commit. Removes `CellRange`, `cellRangeForScreenRect` and all ten test functions. Nothing references the function yet, so runtime behaviour is identical before and after.