### PR TITLE
feat(graphics): add tileFootY per-tile foot anchor table

### DIFF
--- a/include/graphics/Renderer.h
+++ b/include/graphics/Renderer.h
@@ -136,6 +136,38 @@ struct TileMapGeneric {
     const uint8_t*  paletteIndices = nullptr;
 
     /**
+     * Optional per-tile foot row, parallel to `tiles[]`, `tileCount` entries.
+     * `nullptr` means anchor at top-left, i.e. current behaviour. Typically
+     * filled by editor/export tools. Encodes the shipped anchoring
+     * convention already used in game code: `examples/iso_dungeon/src/IsoDraw.h:28-29`
+     * draws a sprite at `(centreX - sprite.width / 2, centreY - footY)`.
+     */
+    const uint8_t*  tileFootY = nullptr;
+
+    /**
+     * @brief Resolve the foot-anchor row for a tile index.
+     *
+     * @param index Tile index into `tiles[]`.
+     * @return `tileFootY[index]` when a table is present and `index` is in
+     *         range; 0 otherwise (current top-left behaviour).
+     * @note `index >= tileCount` returns 0. `drawTileMap` already guards
+     *       `index >= map.tileCount` (src/graphics/Renderer.cpp:892), so this
+     *       is defence in depth against a caller that does not, not a
+     *       load-bearing branch.
+     * @note `footYFor(0)` reads the table with no special case, even though
+     *       index 0 is the empty-tile sentinel `drawTileMap` skips. The table
+     *       is parallel to `tiles[]`, so slot 0 exists; special-casing it
+     *       would bind the asset format's meaning to a renderer policy that
+     *       is free to change.
+     */
+    inline uint8_t footYFor(uint16_t index) const {
+        if (!tileFootY || index >= tileCount) {
+            return 0;
+        }
+        return tileFootY[index];
+    }
+
+    /**
      * @brief Initialize runtime mask buffer for tile activation control.
      * 
      * Allocates memory for tracking tile activation state. All tiles start as active.

--- a/include/math/Projection.h
+++ b/include/math/Projection.h
@@ -325,8 +325,9 @@ struct CellRange {
  * intersects the rectangle, not the window of cells whose *sprite* overlaps
  * it. Orthogonal tiles exactly fill their cell, so the shipped code needs no
  * padding; isometric tile art commonly overhangs its cell (a tall wall or
- * tree sprite drawn from a half-height diamond footprint), so a caller that
- * pads by sprite extent is a WU-5 concern, deliberately not addressed here.
+ * tree sprite drawn from a half-height diamond footprint). Padding the range
+ * by the sprite extent is therefore the caller's responsibility, deliberately
+ * not addressed here.
  *
  * @param spec Projection basis. The caller composes the effective origin
  *        (e.g. `spec.originX + viewOriginX`) before calling — this function

--- a/test/unit/test_tilemap_foot_anchor/test_tilemap_foot_anchor.cpp
+++ b/test/unit/test_tilemap_foot_anchor/test_tilemap_foot_anchor.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 PixelRoot32
+ * Licensed under the MIT License
+ */
+
+#include <unity.h>
+#include "../../test_config.h"
+#include "graphics/Renderer.h"
+
+using namespace pixelroot32::graphics;
+
+void setUp(void) {
+    test_setup();
+}
+
+void tearDown(void) {
+    test_teardown();
+}
+
+// Real measured anchors from examples/iso_dungeon/src/assets/DungeonTiles.h:
+// FLOOR_A, FLOOR_B, FLOOR_ACCENT, WALL, DOOR_NE, DOOR_NW, ALTAR, PILLAR.
+// Five distinct heights (8, 8, 8, 32, 32, 32, 22, 30) over the SAME 32x16
+// diamond footprint are the concrete evidence that the rejected alternative
+// `footY = tileHeight / 2` cannot work: WALL/DOOR_NE/DOOR_NW share the same
+// extruded footprint as FLOOR_A/B/ACCENT but need a completely different
+// anchor row, and ALTAR/PILLAR need two more values again. A per-tile table
+// is the only shape that reproduces IsoDraw::drawAtCell's per-sprite FOOT_Y.
+static const uint8_t kDungeonFootY[8] = {8, 8, 8, 32, 32, 32, 22, 30};
+
+void test_tilemap_foot_anchor_null_table_returns_zero() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = nullptr;
+
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(3));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(tileMap.tileCount - 1));
+}
+
+void test_tilemap_foot_anchor_null_table_returns_zero_4bpp() {
+    Sprite4bpp tiles[8] = {};
+    TileMap4bpp tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = nullptr;
+
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(3));
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(tileMap.tileCount - 1));
+}
+
+void test_tilemap_foot_anchor_returns_stored_value_per_index() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(0));   // FLOOR_A
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(1));   // FLOOR_B
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(2));   // FLOOR_ACCENT
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(3));  // WALL
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(4));  // DOOR_NE
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(5));  // DOOR_NW
+    TEST_ASSERT_EQUAL_UINT8(22, tileMap.footYFor(6));  // ALTAR
+    TEST_ASSERT_EQUAL_UINT8(30, tileMap.footYFor(7));  // PILLAR
+}
+
+void test_tilemap_foot_anchor_returns_stored_value_per_index_4bpp() {
+    Sprite4bpp tiles[8] = {};
+    TileMap4bpp tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(0));   // FLOOR_A
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(1));   // FLOOR_B
+    TEST_ASSERT_EQUAL_UINT8(8, tileMap.footYFor(2));   // FLOOR_ACCENT
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(3));  // WALL
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(4));  // DOOR_NE
+    TEST_ASSERT_EQUAL_UINT8(32, tileMap.footYFor(5));  // DOOR_NW
+    TEST_ASSERT_EQUAL_UINT8(22, tileMap.footYFor(6));  // ALTAR
+    TEST_ASSERT_EQUAL_UINT8(30, tileMap.footYFor(7));  // PILLAR
+}
+
+void test_tilemap_foot_anchor_out_of_range_returns_zero() {
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, tileMap.footYFor(tileMap.tileCount),
+        "index == tileCount must return 0 even with a non-null table");
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, tileMap.footYFor(tileMap.tileCount + 5),
+        "index > tileCount must return 0 even with a non-null table");
+}
+
+void test_tilemap_foot_anchor_zero_index_reads_table() {
+    // kDungeonFootY[0] == 8, a non-zero slot, so this assertion can actually
+    // distinguish "reads the table" from "hardcoded 0 for the sentinel
+    // index". footYFor(0) has no special case for the empty-tile sentinel
+    // that drawTileMap skips (src/graphics/Renderer.cpp:892): the table is
+    // parallel to tiles[], so slot 0 exists and is the tileset author's data.
+    // Special-casing it here would bind the asset format's meaning to a
+    // renderer branch that work unit 5 is about to rewrite.
+    Sprite tiles[8] = {};
+    TileMap tileMap;
+    tileMap.indices = nullptr;
+    tileMap.width = 0;
+    tileMap.height = 0;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 32;
+    tileMap.tileHeight = 16;
+    tileMap.tileCount = 8;
+    tileMap.runtimeMask = nullptr;
+    tileMap.tileFootY = kDungeonFootY;
+
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(8, tileMap.footYFor(0),
+        "footYFor(0) must read slot 0 of the table, not hardcode 0");
+}
+
+void test_tilemap_foot_anchor_default_constructed_tilemap_has_null_table() {
+    TileMap tileMap;
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+}
+
+void test_tilemap_foot_anchor_default_constructed_tilemap4bpp_has_null_table() {
+    TileMap4bpp tileMap;
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+}
+
+void test_tilemap_foot_anchor_existing_fixture_unchanged() {
+    // Existing-style field-assigned TileMap fixture that does NOT name
+    // tileFootY, matching the idiom in test/unit/test_tile_mask/. This is
+    // the layout-safety evidence: the new NSDMI'd member must not break
+    // callers that never set it.
+    uint8_t indices[256] = {0};
+    Sprite tiles[1] = {{nullptr, 8, 8}};
+
+    TileMap tileMap;
+    tileMap.indices = indices;
+    tileMap.width = 16;
+    tileMap.height = 16;
+    tileMap.tiles = tiles;
+    tileMap.tileWidth = 8;
+    tileMap.tileHeight = 8;
+    tileMap.tileCount = 1;
+    tileMap.runtimeMask = nullptr;
+
+    TEST_ASSERT_NULL(tileMap.tileFootY);
+    TEST_ASSERT_EQUAL_UINT8(0, tileMap.footYFor(0));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_tilemap_foot_anchor_null_table_returns_zero);
+    RUN_TEST(test_tilemap_foot_anchor_null_table_returns_zero_4bpp);
+    RUN_TEST(test_tilemap_foot_anchor_returns_stored_value_per_index);
+    RUN_TEST(test_tilemap_foot_anchor_returns_stored_value_per_index_4bpp);
+    RUN_TEST(test_tilemap_foot_anchor_out_of_range_returns_zero);
+    RUN_TEST(test_tilemap_foot_anchor_zero_index_reads_table);
+    RUN_TEST(test_tilemap_foot_anchor_default_constructed_tilemap_has_null_table);
+    RUN_TEST(test_tilemap_foot_anchor_default_constructed_tilemap4bpp_has_null_table);
+    RUN_TEST(test_tilemap_foot_anchor_existing_fixture_unchanged);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
Work unit 4 of the phase-1 isometric tilemap plan. Adds the per-tile vertical anchor table to `TileMapGeneric<T>` and nothing else.

Chained on #201 (`wu3/projection-cell-range`).

## What this adds

Two members on `TileMapGeneric<T>`, so all three aliases (`TileMap`, `TileMap2bpp`, `TileMap4bpp`) get them at once:

```cpp
const uint8_t* tileFootY = nullptr;
inline uint8_t footYFor(uint16_t index) const;
```

`tileFootY` is an optional array parallel to `tiles[]`, `tileCount` entries. `nullptr` means anchor at top-left — today's behaviour, unchanged for every existing tilemap.

## Where the semantics come from

This is characterization work, not new design. The anchoring rule already ships in game code at `examples/iso_dungeon/src/IsoDraw.h:28-29`:

```cpp
renderer.drawSprite(sprite, centreX - sprite.width / 2, centreY - footY, 0, flipX);
```

The tests use the real measured anchors from `examples/iso_dungeon/src/assets/DungeonTiles.h` rather than invented numbers: floors 8, altar 22, pillar 30, wall and doors 32.

Those five values are also the evidence for a rejected alternative. Deriving `footY = tileHeight / 2` would force one anchor per tile size, and here five different sprite heights sit over one identical cell footprint. Godot (`y_sort_origin`) and Tiled (`<tileoffset>`) both keep the anchor per-tile for the same reason.

The other rejected alternative was putting `footY` on `Sprite4bpp`. Every sprite descriptor in the repo is aggregate-initialised, so the blast radius exceeds the feature.

The shape follows the local precedent in the same struct: `paletteIndices`, an optional parallel array whose `nullptr` means old behaviour, documented as typically filled by editor/export tools.

## Two decisions a reviewer might reasonably want to change

**`footYFor(0)` reads the table — no special case for the empty-tile sentinel.** Index 0 is the tile `drawTileMap` skips at `src/graphics/Renderer.cpp:892`. Special-casing it here is tempting and wrong: the table is parallel to `tiles[]`, so slot 0 exists and is asset data owned by the tileset author. Binding the asset format's meaning to a renderer policy makes the format hostage to a draw-loop detail. One test pins this with a non-zero slot-0 fixture, so the assertion can actually distinguish "reads the table" from "hardcodes 0".

**`inline`, not `constexpr`.** `cellRangeForScreenRect` from #201 is `constexpr`; this deliberately is not. `footYFor` dereferences a runtime pointer that normally lives in flash/PROGMEM, so `constexpr` would be legal and inert — it could never fold. It matches `isTileActive`/`getRuntimeMask` in the same struct instead.

## Layout safety

Verified, not assumed: there is no `sizeof(TileMap...)` check and no `static_assert` on the struct anywhere in `include/`, `src/`, `test/` or `examples/`. The new member has a default initialiser and sits after `paletteIndices`, so every existing aggregate initialisation still compiles untouched. One test pins that directly — a fixture that never names `tileFootY` still compiles and behaves unchanged.

## Explicit non-goal

`src/graphics/Renderer.cpp` has a zero-line diff. `drawTileMap` still anchors at top-left and never reads `tileFootY`. Projected placement that consumes this table is the next work unit; this one only lands the data and its accessor.

## TDD

Two-stage red, both captured verbatim in the change record.

RED 1 — compile-red, the suite references the members before they exist:

```
test_tilemap_foot_anchor.cpp:41:13: error: ... has no member named 'tileFootY'
test_tilemap_foot_anchor.cpp:43:40: error: ... has no member named 'footYFor'
```

RED 2 — stub-red with a deliberately wrong body `return tileFootY ? 99 : 0;`, proving the oracle can fail rather than passing vacuously:

```
Expected 8 Was 99
Expected 0 Was 99. index == tileCount must return 0 even with a non-null table
Expected 8 Was 99. footYFor(0) must read slot 0 of the table, not hardcode 0
========== 10 test cases: 4 failed, 5 succeeded ==========
```

The 5 that pass under the wrong stub are the null-table cases, where the stub and the real implementation agree by construction. They are the other half of the contract, not dead assertions.

## Verification

| Suite | Before | After |
|---|---:|---:|
| `native_test` | 1726 (4 skipped, 1722 ok) | **1735 (4 skipped, 1731 ok)** |
| `native_test_gameplay` | 1920 | **1929 (4 skipped, 1925 ok)** |

Exactly +9 on each, matching the 9 new cases. Skipped stays 4 and the arithmetic closes on both. `native_test` was re-run independently after the implementation landed and reproduced 1735/4/1731.

Diff: 233 lines (32 header, 201 new test file), under the 400-line budget.

## Also in this PR

`1623734` removes a `WU-5` reference from `cellRangeForScreenRect`'s documented-limitation note in `include/math/Projection.h`, which landed in #201. Work-unit numbers are planning state, not API contract — once the plan is archived the comment points at nothing. The note now states the durable fact: padding the cell range by sprite extent is the caller's responsibility.
