### PR TITLE
docs(architecture): record why isometric props cannot be a tile layer

### DIFF
--- a/docs/architecture/projected-tilemap-producer-obligations.md
+++ b/docs/architecture/projected-tilemap-producer-obligations.md
@@ -51,6 +51,18 @@ orthogonal generator already satisfies and must keep satisfying:
   isometric convention, for the reason obligation 2 gives: a full-size empty
   tile would still render correctly if the index-0 skip regressed.
 
+## Free-standing props are not tiles, and layers do not change that
+
+A producer converting an isometric scene will reach for a second tile layer to hold props -- the way an orthogonal map layers background, platforms and stairs. It does not work, and the reason is worth stating because the failure is intermittent rather than obvious.
+
+**Every tile layer is drawn before every entity.** `examples/metroidvania` draws its three layers and only then calls `Scene::draw`. That is sufficient for an orthogonal game, where a mover is in front of a whole plane or behind a whole plane.
+
+Under a projection, depth is per **cell**, not per layer. In `examples/iso_dungeon`'s room 1, screen depth is `8 * (x + y)`, and the shipped pillars at `(2, 2)` and `(4, 4)` have depths 32 and 64 with the hero at `(3, 3)` sitting at 48 -- strictly between them. The hero must paint after one pillar and before the other, and both would be in the same layer. A `drawTileMap` call is atomic, so no layer arrangement expresses it.
+
+**Obligation: art a mover can pass behind must be drawn as a depth-sorted entity, not as a tile.** The test is not size. `iso_dungeon`'s 40 px `WALL` is legitimately a tile because both walls hug the back edges and nothing reachable is ever behind them; its 30 px altar is not, because the hero walks past both sides of it.
+
+This constrains *rendering* only. Whether such props should nonetheless be authored and exported as map data is a separate question with a different answer, and one this page does not settle.
+
 ## Open: the behaviour layer is not covered
 
 The editor also emits per-tile behaviour flags — `TILE_BEHAVIOR_LAYER_<NAME>[]`,


### PR DESCRIPTION
Chained on #213. Twelve lines, one file, no code.

## Why this is worth a page

A producer converting an isometric scene will reach for a second tile layer to hold free-standing props — exactly the way `examples/metroidvania` layers background, platforms and stairs. It does not work, and the failure mode is what makes it worth writing down: the occlusion looks correct until a mover walks *between* two props.

The reason is structural, not a limitation of the projected path:

```cpp
// MetroidvaniaScene::draw
tilemapLayerCache.draw(renderer, camX, camY, ...);  // every tile layer
pixelroot32::core::Scene::draw(renderer);           // then every entity
```

**Every tile layer draws before every entity.** Sufficient for an orthogonal game, where a mover is in front of a whole plane or behind a whole plane. Under a projection, depth is per **cell**.

With the pillars `iso_dungeon`'s room 1 actually ships:

| What | Cell | Depth (`8 * (x + y)`) |
|---|---|---:|
| Pillar | (2, 2) | 32 |
| **Hero** | **(3, 3)** | **48** |
| Pillar | (4, 4) | 64 |

The hero must paint after one pillar and before the other, and both would sit in the same layer. `drawTileMap` is atomic, so no layer arrangement expresses it.

## The test the page states, because size is the wrong instinct

> Can a mover ever pass *behind* this?

- `WALL`, 40 px tall — **is** a tile. Both walls hug the back edges; nothing reachable is ever behind them.
- `ALTAR`, 30 px tall — **is not**. The hero walks past both sides of it.

Taller art is a tile; shorter art is an entity. The rule is reachability, not extent.

## Scope

Deliberately about **rendering only**. Whether such props should nonetheless be authored and exported as map data is a separate question with a different answer, and the page says so without settling it. That design work is tracked outside the repository, at the maintainer's request.

## Verification

Docs-only, one file.

| Gate | Result |
|---|---|
| `native_test` | 1737 cases, 4 skipped, **1733 succeeded** |
| `native_test_gameplay` | 1969 cases, 4 skipped, **1965 succeeded** |

Both ran on this branch; the only edit after them was removing two markdown links. Every figure quoted in the page was checked against the source it names — `RoomCatalog.h:180-183` for the pillar cells, `MetroidvaniaScene.cpp:251,256` for the draw order, `RoomRenderer.cpp` for the depth formula.